### PR TITLE
Animates grid-stack container itself.

### DIFF
--- a/src/gridstack.css
+++ b/src/gridstack.css
@@ -102,7 +102,7 @@
     }
 }
 
-.grid-stack.grid-stack-animate .grid-stack-item {
+.grid-stack.grid-stack-animate, .grid-stack.grid-stack-animate .grid-stack-item {
     -webkit-transition: left .3s, top .3s, height .3s, width .3s;
     -moz-transition: left .3s, top .3s, height .3s, width .3s;
     -o-transition: left .3s, top .3s, height .3s, width .3s;


### PR DESCRIPTION
@troolee Slight adjustment to css.  When widgets were moved or resized such that the grid-stack container was resized, the container would snap into a higher height.  This allows the container to also animate making it a lot smoother (assuming animation is turned on).
