### PR TITLE
trigger only one event when calling removeAll()

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1288,8 +1288,9 @@
         return this.grid.canBePlacedWithRespectToHeight(node);
     };
 
-    GridStack.prototype.removeWidget = function(el, detachNode) {
+    GridStack.prototype.removeWidget = function(el, detachNode, triggerEvents) {
         detachNode = typeof detachNode === 'undefined' ? true : detachNode;
+        triggerEvents = typeof detachNode === 'undefined' ? true : triggerEvents;
         el = $(el);
         var node = el.data('_gridstack_node');
 
@@ -1304,16 +1305,21 @@
         if (detachNode) {
             el.remove();
         }
-        this._triggerChangeEvent(true);
-        this._triggerRemoveEvent();
+        if (triggerEvents) {
+            this._triggerChangeEvent(true);
+            this._triggerRemoveEvent();
+        }
     };
 
     GridStack.prototype.removeAll = function(detachNode) {
         _.each(this.grid.nodes, _.bind(function(node) {
-            this.removeWidget(node.el, detachNode);
+            this.removeWidget(node.el, detachNode, false);
         }, this));
         this.grid.nodes = [];
         this._updateContainerHeight();
+        
+        this._triggerChangeEvent(true);
+        this._triggerRemoveEvent();
     };
 
     GridStack.prototype.destroy = function(detachGrid) {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1317,7 +1317,7 @@
         }, this));
         this.grid.nodes = [];
         this._updateContainerHeight();
-        
+
         this._triggerChangeEvent(true);
         this._triggerRemoveEvent();
     };


### PR DESCRIPTION
Hi guys,

Currently when calling removeAll(), the 'removed' event get triggered for every item on the grid, and it passes only one item to the event handler. I think a more logical behavior is triggering the event only once. Otherwise, there isn't really a point for '_removedNodes' on GridStackEngine. Hope you'll find this change needed. 