### PR TITLE
Treat grid coordinates as integers when sorting

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -41,9 +41,10 @@
         },
 
         sort: function(nodes, dir, width) {
-            width = width || _.chain(nodes).map(function(node) { return node.x + node.width; }).max().value();
+            width = width || _.chain(nodes).map(function(node) {
+                return parseInt(node.x) + parseInt(node.width);}).max().value();
             dir = dir != -1 ? 1 : -1;
-            return _.sortBy(nodes, function(n) { return dir * (n.x + n.y * width); });
+            return _.sortBy(nodes, function(n) { return dir * (parseInt(n.x) + parseInt(n.y) * width); });
         },
 
         createStylesheet: function(id) {


### PR DESCRIPTION
 Today I experienced a very frustrating bug. I was reading a grid layout using jQuery `.attr()` on the `data-gs-` attributes and saving the result as a JSON blob. Later I was loading the JSON string and redrawing the grid on the page. The grid was loading but the layout was broken. Some items were displaying correctly, but many were in incorrect positions. 

Eventually I figured out that .attr() was returning the coordinates as strings instead of integers. Gridstack.js was then using the string values to sort the grid items. This resulted in an order like  `x = ['0', '13', '5']` instead of `x = [0, 5, 13]`. 

I think GridStackUI.Utils.sort()  should coerce the x, y and width values to integers before sorting. It does not make sense to ever sort those coordinates as strings.