### PR TITLE
Fix verticalMargin setter.

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1553,7 +1553,7 @@
 
         var heightData = Utils.parseHeight(val);
 
-        if (this.opts.verticalMarginUnit === heightData.unit && this.opts.height === heightData.height) {
+        if (this.opts.verticalMarginUnit === heightData.unit && this.opts.verticalMargin === heightData.height) {
             return ;
         }
         this.opts.verticalMarginUnit = heightData.unit;


### PR DESCRIPTION
Fixes bug where verticalMargin is string (eg: 12px) and has same numeric value as opt.height.