### PR TITLE
Update documentation and force x/y coords to be stores as ints.

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -23,9 +23,12 @@ Change log
 - widgets can have their own resize handles. Use `data-gs-resize-handles` element attribute to use. For example, `data-gs-resize-handles="e,w"` will make the particular widget only resize west and east. ([#494](https://github.com/troolee/gridstack.js/issues/494)).
 - enable sidebar items to be duplicated properly. Pass `helper: 'clone'` in `draggable` options. ([#661](https://github.com/troolee/gridstack.js/issues/661), ([#396](https://github.com/troolee/gridstack.js/issues/396), ([#499](https://github.com/troolee/gridstack.js/issues/499)).
 - fix `staticGrid` grid option ([#743](https://github.com/troolee/gridstack.js/issues/743))
-- preserve inline styles when moving/cloning items (thanks silverwind)
+- preserve inline styles when moving/cloning items (thanks [@silverwind](https://github.com/silverwind))
 - fix bug causing heights not to get set ([#744](https://github.com/troolee/gridstack.js/issues/744))
-- allow grid to have min-height, fixes ([#628](https://github.com/troolee/gridstack.js/issues/628))
+- allow grid to have min-height, fixes ([#628](https://github.com/troolee/gridstack.js/issues/628)) (thanks [@adumesny](https://github.com/adumesny))
+- widget x and y are now ints (thanks [@DonnchaC](https://github.com/donnchac))
+- allow all droppable options (thanks [@vigor-vlad](https://github.com/vigor-vlad))
+- properly track mouse position in `getCellFromPixel` (thanks [@aletorrado](https://github.com/aletorrado))
 
 ## v0.3.0 (2017-04-21)
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1272,8 +1272,8 @@
 
         el.addClass(this.opts.itemClass);
         var node = self.grid.addNode({
-            x: el.attr('data-gs-x'),
-            y: el.attr('data-gs-y'),
+            x: parseInt(el.attr('data-gs-x'), 10),
+            y: parseInt(el.attr('data-gs-y'), 10),
             width: el.attr('data-gs-width'),
             height: el.attr('data-gs-height'),
             maxWidth: el.attr('data-gs-max-width'),


### PR DESCRIPTION
### Description
Piggyback on idea from https://github.com/gridstack/gridstack.js/pull/648 - when x and y coordinates for widgets are stored, run `parseInt(num, 10)` to ensure that they're treated as integers when sorting.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [x] Extended the README / documentation, if necessary
