### PR TITLE
make tests rely upon dependencies in node_modules

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,9 +15,9 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-          'bower_components/jquery/dist/jquery.min.js',
-          'bower_components/jquery-ui/jquery-ui.min.js',
-          'bower_components/lodash/dist/lodash.min.js',
+          'node_modules/jquery/dist/jquery.min.js',
+          'node_modules/components-jqueryui/jquery-ui.min.js',
+          'node_modules/lodash/lodash.min.js',
           'src/gridstack.js',
           'src/gridstack.jQueryUI.js',
           'spec/*-spec.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -728,6 +728,12 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "components-jqueryui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/components-jqueryui/-/components-jqueryui-1.12.1.tgz",
+      "integrity": "sha1-YXB28SjzvkwmXz4ttQRx75bNnO4=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "grunt && doctoc ./README.md && doctoc ./doc/README.md && doctoc ./doc/CHANGES.md",
     "test": "grunt lint && karma start karma.conf.js",
     "lint": "grunt lint",
-    "reset": "rm -rf node_modules dist"
+    "reset": "rm -rf dist node_modules"
   },
   "keywords": [
     "gridstack",
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "connect": "^3.4.1",
+    "components-jqueryui": "1.12.1",
     "coveralls": "^2.11.8",
     "doctoc": "^1.3.0",
     "grunt": "^1.0.1",


### PR DESCRIPTION
### Description
Addresses #781. The karma test script previously relied upon jquery-ui, jquery, and lodash being in `bower_components`. Since each is declared as a dependencies, it makes more sense to import them from `node_modules`. I added a dev dependency for jquery-ui because the official `jquery-ui` package does not provide a bundle of the internal scripts.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [x] Extended the README / documentation, if necessary
