### PR TITLE
Fix for grids with many columns

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1623,7 +1623,7 @@
     };
 
     GridStack.prototype.cellWidth = function() {
-        return Math.round(this.container.outerWidth() / this.opts.width);
+        return this.container.outerWidth() / this.opts.width;
     };
 
     GridStack.prototype.getCellFromPixel = function(position, useOffset) {


### PR DESCRIPTION
There was a problem with positioning dragged widgets if there were larger number of columns and cumulated diff between real value and rounded one. (e.g. cellWidth is calculated to be 19.5px and there are 30 columns. Further we go, larger the mistake with positioning widgets)

### Description
Updated cellWidth method to not round cellWidth value. It was causing problem for grids with larger number of columns and uneven cell width calculated.