### PR TITLE
Bug wrong maxHeight for updateStyles function

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -675,7 +675,7 @@
             var maxHeight = 0;
             _.each(this.nodes, function(n) {
                 maxHeight = Math.max(maxHeight, n.y + n.height);
-            }
+            });
             _.each(nodes, function(n) {
                 if (detachNode && n._id === null) {
                     if (n.el) {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -673,6 +673,9 @@
         this.grid = new GridStackEngine(this.opts.width, function(nodes, detachNode) {
             detachNode = typeof detachNode === 'undefined' ? true : detachNode;
             var maxHeight = 0;
+            _.each(this.nodes, function(n) {
+                maxHeight = Math.max(maxHeight, n.y + n.height);
+            }
             _.each(nodes, function(n) {
                 if (detachNode && n._id === null) {
                     if (n.el) {
@@ -684,7 +687,6 @@
                         .attr('data-gs-y', n.y)
                         .attr('data-gs-width', n.width)
                         .attr('data-gs-height', n.height);
-                    maxHeight = Math.max(maxHeight, n.y + n.height);
                 }
             });
             self._updateStyles(maxHeight + 10);


### PR DESCRIPTION
When there are 4 row of grid items and more. There are bug of updates styles. 
The function does not take into account all nodes, but only those that have been changed (_dirty).
In this regard, the styles for the lower layers do not sink, and they rise upward.
The solution is to calculate the maxHeight for all nodes.

Bug example - https://youtu.be/1bZQIaZqVLQ