### PR TITLE
Disallow grid overgrow

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -425,7 +425,7 @@
             }));
 
         if (typeof clonedNode === 'undefined') {
-            return true;
+            return false;
         }
 
         clone.moveNode(clonedNode, x, y, width, height);


### PR DESCRIPTION
This patch disallows the grid to grow beyond the 'height' specified in the gridstack options.

Without this patch, it is trivial to grow the grid vertically where it may be undesirable to do so, assuming the height option is to be treated as a maximum size.

With this patch, the grid no longer grows beyond the maximum height specified in the gridstack options.

Video demonstration before/after patch:
https://youtu.be/ypX7Wf2G1pQ