### PR TITLE
issue-805 - fix node being added to grid more than once after being dragged out of bounds

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1221,6 +1221,7 @@
                         .attr('data-gs-height', node.height);
                     node.x = node._beforeDragX;
                     node.y = node._beforeDragY;
+                    node._temporaryRemoved = false;
                     self.grid.addNode(node);
                 }
             }


### PR DESCRIPTION
Frequent Transient Bug when moving or resizing
issue-805 - fix node being added to grid more than once after being dragged out of bounds

Description of issue

After a grid item was dragged out of bounds there were extra node being added to the grid.  This caused the node to get stuck. 
See video:  https://youtu.be/QJj6hi7lnDU.

Solution:
Node only gets re-added once, after being dragged out of bounds.  Set "node._temporaryRemoved" to false when adding node back into grid the first time.  This prevents multiple calls to addNode().

