### PR TITLE
Add extra row when accepting widgets

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -175,10 +175,11 @@
 
     var idSeq = 0;
 
-    var GridStackEngine = function(width, onchange, floatMode, height, items) {
+    var GridStackEngine = function(width, onchange, floatMode, height, items, extraRow) {
         this.width = width;
         this.float = floatMode || false;
         this.height = height || 0;
+        this.extraRow = extraRow || false;
 
         this.nodes = items || [];
         this.onchange = onchange || function() {};
@@ -422,7 +423,8 @@
                     return clonedNode;
                 }
                 return $.extend({}, n);
-            }));
+            }),
+            this.extraRow);
 
         if (typeof clonedNode === 'undefined') {
             return true;
@@ -454,7 +456,8 @@
             null,
             this.float,
             0,
-            _.map(this.nodes, function(n) { return $.extend({}, n); }));
+            _.map(this.nodes, function(n) { return $.extend({}, n); }),
+            this.extraRow);
         clone.addNode(node);
         return clone.getGridHeight() <= this.height;
     };
@@ -518,7 +521,8 @@
     };
 
     GridStackEngine.prototype.getGridHeight = function() {
-        return _.reduce(this.nodes, function(memo, n) { return Math.max(memo, n.y + n.height); }, 0);
+        return (this.extraRow ? 1 : 0) +
+            _.reduce(this.nodes, function(memo, n) { return Math.max(memo, n.y + n.height); }, 0);
     };
 
     GridStackEngine.prototype.beginUpdate = function(node) {
@@ -690,7 +694,7 @@
                 }
             });
             self._updateStyles(maxHeight + 10);
-        }, this.opts.float, this.opts.height);
+        }, this.opts.float, this.opts.height, null, !!this.opts.acceptWidgets);
 
         if (this.opts.auto) {
             var elements = [];


### PR DESCRIPTION
### Description
Addresses issue #219.
When accepting widgets dragged from outside, the grid will allocate one more row to allow drops at the bottom.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [x] Extended the README / documentation, if necessary
