### PR TITLE
Fix #882, set version at 1.0.0-dev, update demos to use lodash 4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Usage
 
 ## Requirements
 
-* [lodash.js](https://lodash.com) (>= 3.5.0, full build)
+* [lodash.js](https://lodash.com) (>= 4.17.10, full build)
 * [jQuery](http://jquery.com) (>= 3.1.0)
 
 Note: You can still use [underscore.js](http://underscorejs.org) (>= 1.7.0) instead of lodash.js

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "0.4.0",
+  "version": "1.0.0-dev",
   "homepage": "https://github.com/gridstack/gridstack.js",
   "authors": [
     "Pavel Reznikov <pashka.reznikov@gmail.com>",

--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -18,7 +18,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 

--- a/demo/float.html
+++ b/demo/float.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.2.0/knockout-min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>

--- a/demo/knockout2.html
+++ b/demo/knockout2.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.2.0/knockout-min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -17,7 +17,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 
@@ -109,7 +109,7 @@
                     _.each(items, function (node, i) {
                         this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'),
                             node.x, node.y, node.width, node.height);
-                    }, this);
+                    }.bind(this));
                     return false;
                 }.bind(this);
 

--- a/demo/rtl.html
+++ b/demo/rtl.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.2.0/knockout-min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -16,7 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 
@@ -77,9 +77,9 @@
                     this.grid.removeAll();
                     var items = GridStackUI.Utils.sort(this.serializedData);
                     _.each(items, function (node) {
-                        this.grid.addWidget($('<div><div class="grid-stack-item-content" /><div/>'),
-                            node.x, node.y, node.width, node.height);
-                    }, this);
+                        this.grid.addWidget($('<div><div class="grid-stack-item-content" /></div>'),
+                        node.x, node.y, node.width, node.height);
+                    }.bind(this));
                     return false;
                 }.bind(this);
 
@@ -93,7 +93,7 @@
                             width: node.width,
                             height: node.height
                         };
-                    }, this);
+                    });
                     $('#saved-data').val(JSON.stringify(this.serializedData, null, '    '));
                     return false;
                 }.bind(this);

--- a/demo/two.html
+++ b/demo/two.html
@@ -17,7 +17,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.0/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.5.0/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.0/lodash.min.js"></script>
     <script src="../dist/gridstack.js"></script>
     <script src="../dist/gridstack.jQueryUI.js"></script>
 
@@ -131,7 +131,7 @@
                 _.each(items, function (node) {
                     grid.addWidget($('<div><div class="grid-stack-item-content" /><div/>'),
                         node.x, node.y, node.width, node.height);
-                }, this);
+                });
             });
 
             $('.sidebar .grid-stack-item').draggable({

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,8 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [v0.4.0 (development)](#v040-development)
+- [v0.1.0 (development)](#v010-development)
+- [v0.4.0](#v040)
 - [v0.3.0 (2017-04-21)](#v030-2017-04-21)
 - [v0.2.6 (2016-08-17)](#v026-2016-08-17)
 - [v0.2.5 (2016-03-02)](#v025-2016-03-02)
@@ -18,7 +19,11 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## v0.4.0 (development)
+## v0.1.0 (development)
+
+- don't push locked widgets even if they are at the top of the grid ([#882](https://github.com/troolee/gridstack.js/issues/882)).
+
+## v0.4.0
 
 - widgets can have their own resize handles. Use `data-gs-resize-handles` element attribute to use. For example, `data-gs-resize-handles="e,w"` will make the particular widget only resize west and east. ([#494](https://github.com/troolee/gridstack.js/issues/494)).
 - enable sidebar items to be duplicated properly. Pass `helper: 'clone'` in `draggable` options. ([#661](https://github.com/troolee/gridstack.js/issues/661), ([#396](https://github.com/troolee/gridstack.js/issues/396), ([#499](https://github.com/troolee/gridstack.js/issues/499)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "0.4.0",
+  "version": "1.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "0.4.0",
+  "version": "1.0.0-dev",
   "description": "gridstack.js is a jQuery plugin for widget layout",
   "main": "dist/gridstack.js",
   "repository": {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1,5 +1,5 @@
 /**
- * gridstack.js 0.4.0
+ * gridstack.js 1.0.0-dev
  * http://troolee.github.io/gridstack.js/
  * (c) 2014-2018 Pavel Reznikov, Dylan Weiss
  * gridstack.js may be freely distributed under the MIT license.
@@ -1171,6 +1171,8 @@
                         self._updateContainerHeight();
 
                         node._temporaryRemoved = true;
+                    } else {
+                        return;
                     }
                 } else {
                     self._clearRemovingTimeout(el);


### PR DESCRIPTION
### Description
Fix #882 by preventing widget from checking if it can move when it has been excised from the grid.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [x] Extended the README / documentation, if necessary
