### PR TITLE
added "gsresize" trigger

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1214,7 +1214,7 @@
 =======
 
             if (event.type == 'resize')  {
-                $(event.target).trigger('gsresize',node);
+                $(event.target).trigger('gsresize', node);
             }
 >>>>>>> 8a587b6... event.target instead of this reference
         };

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1210,6 +1210,13 @@
             node.lastTriedHeight = height;
             self.grid.moveNode(node, x, y, width, height);
             self._updateContainerHeight();
+<<<<<<< HEAD
+=======
+
+            if (event.type == 'resize')  {
+                $(event.target).trigger('gsresize',node);
+            }
+>>>>>>> 8a587b6... event.target instead of this reference
         };
 
         var onStartMoving = function(event, ui) {


### PR DESCRIPTION
I added event "gsresize" for each "grid-stack-item" fired immediately once widget is resized. I will use it to choose specific knockout template for content according item height.

it discussed in pull request https://github.com/gridstack/gridstack.js/pull/835
this is request to add it in develop branch