### PR TITLE
fix for #451

### DIFF
--- a/dist/gridstack.js
+++ b/dist/gridstack.js
@@ -728,11 +728,13 @@
                         n.el.remove();
                     }
                 } else {
-                    n.el
-                        .attr('data-gs-x', n.x)
-                        .attr('data-gs-y', n.y)
-                        .attr('data-gs-width', n.width)
-                        .attr('data-gs-height', n.height);
+                    if (n.el) {
+                        n.el
+                            .attr('data-gs-x', n.x)
+                            .attr('data-gs-y', n.y)
+                            .attr('data-gs-width', n.width)
+                            .attr('data-gs-height', n.height);
+                    }
                 }
             });
             self._updateStyles(maxHeight + 10);
@@ -1282,6 +1284,7 @@
             self._triggerChangeEvent(forceNotify);
 
             self.grid.endUpdate();
+            self.grid.cleanNodes();
 
             var nestedGrids = o.find('.grid-stack');
             if (nestedGrids.length && event.type == 'resizestop') {


### PR DESCRIPTION
### Description
It seems to fix #451 but, since I'm new to Gridstack, I'd like someone with more intimate knowledge looking over proposed changes and figure out if it doesn't have any unwanted implications. 

I'm calling `cleanNodes()` inside `onEndMoving()` so when `onStartMoving()` is triggered on another gridstack container, current gridstack item doesn't get deleted. 
This change seems to trigger errors when trying to drag an item in between two different grid containers so I had to add a condition on `gridstack.js:731`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [ ] Extended the README / documentation, if necessary

### Note
For my tests, I have upped `two.html` dependencies to:
- Bootstrap (all) `3.2.0` > `3.3.7`
- jQuery `1.11.1` > `3.3.1`
- jQueryUI `1.11.0` > `1.12.1`
- lodash `4.17.0` > `4.17.10`
- Gridstack (all) `1.0.0-dev`

I haven't committed changes made to `two.html` into this pull request but I'm ready to, if deemed worthy.