### PR TITLE
Fixed typo

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -243,7 +243,7 @@ grid.addWidget(el, 0, 0, 3, 2, true);
 
 ### batchUpdate()
 
-Initailizes batch updates. You will see no changes until `commit` method is called.
+Initializes batch updates. You will see no changes until `commit` method is called.
 
 ### cellHeight()
 


### PR DESCRIPTION
On `batchUpdate()` documentation, `Initializes` was incorrectly typed as `Initailizes`.

### Description
Just fixed a typo on `batchUpdate()` documentation.
