### PR TITLE
Don't overwrite globals when in a modular environment.

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -9,10 +9,13 @@
     if (typeof define === 'function' && define.amd) {
         define(['jquery', 'exports'], factory);
     } else if (typeof exports !== 'undefined') {
-        try { jQuery = require('jquery'); } catch (e) {}
-        factory(jQuery, exports);
+        var jQueryModule;
+
+        try { jQueryModule = require('jquery'); } catch (e) {}
+
+        factory(jQueryModule || window.jQuery, exports);
     } else {
-        factory(jQuery, window);
+        factory(window.jQuery, window);
     }
 })(function($, scope) {
     var obsolete = function(f, oldName, newName) {


### PR DESCRIPTION
### Description
Requiring `jQuery` and `_` without a `var` declaration were overwriting the global implementations of those libraries if they exist.

Because `jQuery` and `_` can be customized and configured, it would be best to keep internal dependencies isolated.

I have a 2018 MBP and `npm test` does not run for me -- Karma simply times out. Since this falls back to the global versions, I don't foresee any tests failing. But please let me know if I'm missing a step to get tests running locally.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`npm test`)
- [x] Extended the README / documentation, if necessary
