### PR TITLE
removed item-content z-index

### DIFF
--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -50,7 +50,6 @@ $animation_speed: .3s !default;
             right: $horizontal_padding / 2;
             bottom: 0;
             width: auto;
-            z-index: 0;
             overflow-x: hidden;
             overflow-y: auto;
         }


### PR DESCRIPTION
* there is no need for the regular grid content to have a topmost z-index
(dragging and placeholder still render on top unchanged)
this was causing modal dialogs to grid content to be clipped and not render correctly

### Checklist
- [x] Created tests which fail without the change (if possible)
I test two.html and another testc ase and see no differences in z-ordering.

- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

![image](https://user-images.githubusercontent.com/3496166/55207243-95b32280-5196-11e9-883b-f486db0a9891.png)

instead of the correct modal (OK button from grid item).
![image](https://user-images.githubusercontent.com/3496166/55207256-a4013e80-5196-11e9-9614-bcb9c59e99e7.png)
