### PR TITLE
fixed gsresizestop doc

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -206,6 +206,8 @@ $('.grid-stack').on('resizestart', function(event, ui) {
 ```
 
 ### gsresizestop(event, ui)
+**Note**: this is a custom event name that is guaranteed to be called
+**after** the jqueryui resizestop event where we update `data-gs-width` and `data-gs-height`.
 
 ```javascript
 $('.grid-stack').on('gsresizestop', function(event, elem) {


### PR DESCRIPTION
documentation fix for https://github.com/gridstack/gridstack.js/pull/978 which should be closed (incorrect)