### PR TITLE
Widgets initiated with undefined data-gs-x and data-gs-y glitch #1017

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1388,8 +1388,8 @@
 
         el.addClass(this.opts.itemClass);
         var node = self.grid.addNode({
-            x: parseInt(el.attr('data-gs-x'), 10),
-            y: parseInt(el.attr('data-gs-y'), 10),
+            x: parseInt(el.attr('data-gs-x'), 10) || 0,
+            y: parseInt(el.attr('data-gs-y'), 10) || 0,
             width: el.attr('data-gs-width'),
             height: el.attr('data-gs-height'),
             maxWidth: el.attr('data-gs-max-width'),


### PR DESCRIPTION
### Description
This fixes the https://github.com/gridstack/gridstack.js/issues/1017 

The modified line originally ended up with `NaN` as a result. That caused the widget to not be initialized later on [this line](https://github.com/SomMeri/gridstack.js/blob/1b95810c4fefc319c3c5faf0b117f5d507ea42a9/src/gridstack.js#L396). This later caused the styles not to be initialized [in this loop](https://github.com/SomMeri/gridstack.js/blob/1b95810c4fefc319c3c5faf0b117f5d507ea42a9/src/gridstack.js#L1109)

Here is how compiled version that works: https://jsfiddle.net/30qfrzcd/


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary <- not necessary
