### PR TITLE
onStartMoving() fix to minHeight

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1278,8 +1278,9 @@
             self.grid.cleanNodes();
             self.grid.beginUpdate(node);
             cellWidth = self.cellWidth();
-            var strictCellHeight = Math.ceil(o.outerHeight() / o.attr('data-gs-height'));
-            cellHeight = self.container.height() / parseInt(self.container.attr('data-gs-current-height'));
+            height = o.attr('data-gs-height');
+            verticalMargin = self.opts.verticalMargin;
+            cellHeight = Math.ceil((o.outerHeight() - (height - 1) * verticalMargin) / height);
             self.placeholder
                 .attr('data-gs-x', o.attr('data-gs-x'))
                 .attr('data-gs-y', o.attr('data-gs-y'))
@@ -1290,9 +1291,9 @@
             node._beforeDragX = node.x;
             node._beforeDragY = node.y;
             node._prevYPix = ui.position.top;
-
+            minHeight = (node.minHeight || 1);
             self.dd.resizable(el, 'option', 'minWidth', cellWidth * (node.minWidth || 1));
-            self.dd.resizable(el, 'option', 'minHeight', strictCellHeight * (node.minHeight || 1));
+            self.dd.resizable(el, 'option', 'minHeight', cellHeight * minHeight + (minHeight - 1) * verticalMargin);
 
             if (event.type == 'resizestart') {
                 o.find('.grid-stack-item').trigger('resizestart');


### PR DESCRIPTION
### Description
*method was not correctly counting margin when figuring out minHeight during a drag
(see #999)

Note: many other places don't handle margin, both height and width of cells.
Should probably be fix globally. WidthMargin is not
in opts though but CSS, making it harder.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

I ran two.html sample app to make sure things scaled up/down correctly