### PR TITLE
removed 1.0 release doc info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Join gridstack.js on Slack: https://gridstackjs.troolee.com
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-<!--- [gridstack.js News](#gridstackjs-news) -->
 - [Demo and examples](#demo-and-examples)
 - [Usage](#usage)
   - [Requirements](#requirements)
@@ -32,19 +31,11 @@ Join gridstack.js on Slack: https://gridstackjs.troolee.com
     - [Different grid widths](#different-grid-widths)
   - [Override resizable/draggable options](#override-resizabledraggable-options)
   - [IE8 support](#ie8-support)
-  - [Use with require.js](#use-with-requirejs)
 - [Changes](#changes)
 - [The Team](#the-team)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update 
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
-gridstack.js News
-=====
-
-Version 1.0 is coming! Check out the blog post here for more information:
-[https://dylandreams.com/2017/04/26/gridstack-10-coming-soon/](https://dylandreams.com/2017/04/26/gridstack-10-coming-soon/) and [subscribe to the blog](https://dylandreams.com) for more gridstack news and tutorials.
--->
 
 Demo and examples
 ====

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,6 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [v1.0.0 (development)](#v100-development)
 - [v0.5.0 (2019-03-29)](#v050-2019-03-29)
 - [v0.4.0 (2018-05-11)](#v040-2018-05-11)
 - [v0.3.0 (2017-04-21)](#v030-2017-04-21)
@@ -19,10 +18,6 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-## v1.0.0 (development)
-
-TBD
 
 ## v0.5.0 (2019-03-29)
 


### PR DESCRIPTION
### Description
removed 1.0 release doc info as it was causing generated doc to be modified on each builds (git mod).
We can add it back if/when it makes sense.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
