### PR TITLE
fix url to gridster.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
                         grid. It allows you to build draggable responsive bootstrap v3 friendly layouts.
                         It also works great with <a href="http://knockoutjs.com">knockout.js</a> and touch devices.</p>
 
-                        <p>Inspired by <a href="http://gridster.net">gridster.js</a>. Built with love.</p>
+                        <p>Inspired by <a href="https://github.com/ducksboard/gridster.js">gridster.js</a>. Built with love.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Description
fix url to gridster.js using https://github.com/ducksboard/gridster.js instead of gridster.net which is malware now - see #917

### Checklist
manual editing, no easy way to test change,