### PR TITLE
undefined x,y position messed up grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Usage
 * Using CDN:
 
 ```html
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.css" />
-<script type="text/javascript" src='//cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.js'></script>
-<script type="text/javascript" src='//cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.jQueryUI.min.js'></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.css" />
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.jQueryUI.min.js"></script>
 ```
 
 * Using bower:

--- a/README.md
+++ b/README.md
@@ -317,4 +317,4 @@ View our change log [here](https://github.com/gridstack/gridstack.js/tree/develo
 The Team
 ========
 
-gridstack.js is currently maintained by [Pavel Reznikov](https://github.com/troolee) and [Dylan Weiss](https://github.com/radiolips). We appreciate [all contributors](https://github.com/gridstack/gridstack.js/graphs/contributors) for help.
+gridstack.js is currently maintained by [Pavel Reznikov](https://github.com/troolee),  [Dylan Weiss](https://github.com/radiolips) and [Alain Dumesny](https://github.com/adumesny). We appreciate [all contributors](https://github.com/gridstack/gridstack.js/graphs/contributors) for help.

--- a/doc/README.md
+++ b/doc/README.md
@@ -103,14 +103,13 @@ gridstack.js API
 
 ## Item attributes
 
-- `data-gs-x`, `data-gs-y` - element position
+- `data-gs-x`, `data-gs-y` - element position. Note: if one is missing this will `autoPosition` the item
 - `data-gs-width`, `data-gs-height` - element size
 - `data-gs-id`- good for quick identification (for example in change event)
 - `data-gs-max-width`, `data-gs-min-width`, `data-gs-max-height`, `data-gs-min-height` - element constraints
 - `data-gs-no-resize` - disable element resizing
 - `data-gs-no-move` - disable element moving
-- `data-gs-auto-position` - tells to ignore `data-gs-x` and `data-gs-y` attributes and to place element to the first
-    available position
+- `data-gs-auto-position` - tells to ignore `data-gs-x` and `data-gs-y` attributes and to place element to the first available position. Having either one missing will also do that.
 - `data-gs-locked` - the widget will be locked. It means another widget wouldn't be able to move it during dragging or resizing.
 The widget can still be dragged or resized. You need to add `data-gs-no-resize` and `data-gs-no-move` attributes
 to completely lock the widget.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,8 @@ module.exports = function(config) {
           'node_modules/core-js/client/shim.min.js',
           'src/gridstack.js',
           'src/gridstack.jQueryUI.js',
-          'spec/*-spec.js'
+          'spec/*-spec.js',
+          // 'spec/e2e/*-spec.js' issues with ReferenceError: `browser` & `element` is not defined
         ],
 
 

--- a/spec/e2e/gridstack-html-spec.js
+++ b/spec/e2e/gridstack-html-spec.js
@@ -7,7 +7,7 @@ describe('gridstack.js with height', function() {
         browser.get('http://localhost:8080/spec/e2e/html/gridstack-with-height.html');
     });
 
-    it('shouldn\'t throw exeption when dragging widget outside the grid', function() {
+    it('shouldn\'t throw exception when dragging widget outside the grid', function() {
         var widget = element(by.id('item-1'));
         var gridContainer = element(by.id('grid'));
 
@@ -20,5 +20,20 @@ describe('gridstack.js with height', function() {
         browser.manage().logs().get('browser').then(function(browserLog) {
             expect(browserLog.length).toEqual(0);
         });
+    });
+});
+
+describe('grid elements with no x,y positions', function() {
+    beforeAll(function() {
+        browser.ignoreSynchronization = true;
+    });
+
+    beforeEach(function() {
+        browser.get('http://localhost:8080/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html');
+    });
+
+    it('should match positions in order 5,1,2,4,3', function() {
+        // TBD
+        // expect(null).not.toBeNull();
     });
 });

--- a/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
+++ b/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
@@ -1,0 +1,76 @@
+<!-- 
+    grid items have no x,y position, just size. Used to come up with wrong size and overlap. https://github.com/gridstack/gridstack.js/issues/1017
+    Now, will have element 5 (autoPosition but small x,y), 1,2,4, then 3 (too big to fit)
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!--[if lt IE 9]>
+    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../dist/gridstack.css" />
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.9/shim.min.js"></script>
+    <script src="../../../src/gridstack.js"></script>
+    <script src="../../../src/gridstack.jQueryUI.js"></script>
+
+    <style type="text/css">
+        .grid-stack {
+            margin-top: 10px;
+            background: lightgoldenrodyellow;
+        }
+
+        .grid-stack-item-content {
+            color: #2c3e50;
+            text-align: center;
+            background-color: #18bc9c;
+        }
+
+        .upper .grid-stack-item-content {
+            background: blue;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="grid-stack">
+        <div class="grid-stack-item upper" data-gs-width="2" data-gs-height="2" data-gs-id="1">
+            <div class="grid-stack-item-content">item 1</div>
+        </div>
+        <div class="grid-stack-item" data-gs-width="3" data-gs-height="2" data-gs-id="2">
+            <div class="grid-stack-item-content">item 2</div>
+        </div>
+        <div class="grid-stack-item" data-gs-width="9" data-gs-height="1" data-gs-id="3">
+            <div class="grid-stack-item-content">item 3 too big to fit, so next row</div>
+        </div>
+        <div class="grid-stack-item" data-gs-width="3" data-gs-height="1" data-gs-id="4">
+            <div class="grid-stack-item-content">item 4</div>
+        </div>
+        <div class="grid-stack-item" data-gs-x="1" data-gs-y="1" data-gs-width="1" data-gs-height="1" data-gs-id="5" data-gs-auto-position="false">
+            <div class="grid-stack-item-content">item 5 first</div>
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        $(function () {
+            var options = {
+                cellHeight: 80,
+                verticalMargin: 10,
+                float: true
+            };
+            $('.grid-stack').gridstack(options);
+        });
+    </script>
+</body>
+
+</html>

--- a/spec/e2e/html/gridstack-with-height.html
+++ b/spec/e2e/html/gridstack-with-height.html
@@ -10,13 +10,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>gridstack.js tests</title>
 
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="../../../dist/gridstack.css"/>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.6.9/shim.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.9/shim.min.js"></script>
     <script src="../../../dist/gridstack.js"></script>
     <script src="../../../dist/gridstack.jQueryUI.js"></script>
 

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -106,4 +106,17 @@ describe('gridstack utils', function() {
             expect(function() { utils.parseHeight('-12.5 df'); }).toThrowError('Invalid height');
         });
     });
+
+    describe('test defaults', function() {
+        it('should assign missing field or undefined', function() {
+            var src = {};
+            expect(src).toEqual({});
+            expect(utils.defaults(src, {x: 1, y: 2})).toEqual({x: 1, y: 2});
+            expect(utils.defaults(src, {x: 10})).toEqual({x: 1, y: 2});
+            src.width = undefined;
+            expect(src).toEqual({x: 1, y: 2, width: undefined});
+            expect(utils.defaults(src, {x: 10, width: 3})).toEqual({x: 1, y: 2, width: 3});
+            expect(utils.defaults(src, {height: undefined})).toEqual({x: 1, y: 2, width: 3, height: undefined});
+        });
+    });
 });


### PR DESCRIPTION
### Description
fix for #1017 (missing x,y breaks grid), but also a long time issue with
autoPlacement=true not respecting DOM order to place items (missing x,y or zero values)
(bugged me for a while, so glad to tackle it)

* no longer force x,y to be integer up front (get Nan when missing),
instead we detect missing and set autoPosition=true. They get fixed soon after.
* fixed Utils.defaults() field assignment to check for x=undefined not just missing
* fixed code that sorted elements to be created to put autoPosition items last
while keeping DOM order.
* added karma test cases and UI HTML sample showing complex case - to make
sure it doesn't break going forward.
* fixed README & others CDN locations to use https:// so we can test them locally.

TODO: karma test on HTML file wasn't working, so mine isn't tested either.
I would like this go in now, while I research karma test case...

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X All tests passing (`yarn test`)
