### PR TITLE
v0.5.1-dev label, CDN url fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Usage
 * Using CDN:
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.css" />
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.5.0/gridstack.jQueryUI.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.5.1/dist/gridstack.min.css" />
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.1/dist/gridstack.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.1/dist/gridstack.jQueryUI.min.js"></script>
 ```
 
 * Using bower:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "0.5.1",
+  "version": "0.5.1-dev",
   "homepage": "https://github.com/gridstack/gridstack.js",
   "authors": [
     "Pavel Reznikov <pashka.reznikov@gmail.com>",

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [v0.5.1-dev (work in progress)](#v051-dev-work-in-progress)
 - [v0.5.1 (2019-11-07)](#v051-2019-11-07)
 - [v0.5.0 (2019-11-06)](#v050-2019-11-06)
 - [v0.4.0 (2018-05-11)](#v040-2018-05-11)
@@ -19,6 +20,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## v0.5.1-dev (work in progress)
+
+- undefined x,y position messes up grid ([#1017](https://github.com/gridstack/gridstack.js/issues/1017)).
 
 ## v0.5.1 (2019-11-07)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "0.5.1",
+  "version": "0.5.1-dev",
   "description": "gridstack.js is a jQuery plugin for widget layout",
   "main": "dist/gridstack.js",
   "repository": {

--- a/src/gridstack.jQueryUI.js
+++ b/src/gridstack.jQueryUI.js
@@ -1,5 +1,5 @@
 /**
- * gridstack.js 0.5.0
+ * gridstack.js 0.5.1-dev
  * http://troolee.github.io/gridstack.js/
  * (c) 2014-2017 Pavel Reznikov, Dylan Weiss
  * gridstack.js may be freely distributed under the MIT license.

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1,5 +1,5 @@
 /**
- * gridstack.js 0.5.0
+ * gridstack.js 0.5.1-dev
  * http://troolee.github.io/gridstack.js/
  * (c) 2014-2018 Pavel Reznikov, Dylan Weiss
  * gridstack.js may be freely distributed under the MIT license.


### PR DESCRIPTION
### Description
* for CDN switched to cdn.jsdelivr.net which has the latest 0.5.1 images (cdnjs.cloudflare.com does not)

### Checklist
- [X] Extended the README / documentation, if necessary
