### PR TITLE
onStartMoving() fix to minHeight (#999)

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -18,8 +18,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.9/shim.min.js"></script>
-    <script src="../dist/gridstack.js"></script>
-    <script src="../dist/gridstack.jQueryUI.js"></script>
+    <script src="../src/gridstack.js"></script>
+    <script src="../src/gridstack.jQueryUI.js"></script>
 
     <style type="text/css">
         #grid1 {

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -23,8 +23,9 @@ Change log
 
 ## v0.5.1-dev (work in progress)
 
-- undefined x,y position messes up grid ([#1017](https://github.com/gridstack/gridstack.js/issues/1017)).
+- undefined x,y position messes up grid ([#1017](https://github.com/gridstack/gridstack.js/issues/1017))
 - changed code to 2 spaces
+- fix minHeight during `onStartMoving()` ([#999](https://github.com/gridstack/gridstack.js/issues/999))
 
 ## v0.5.1 (2019-11-07)
 


### PR DESCRIPTION
### Description
*method was not correctly counting margin when figuring out minHeight during a drag
(see gridstack#999)
* fixed cellHeight() getter to correctly returns the value and checked all places that use to adjust for margins

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary

I tested two.html as well as my app that doesn't a lot of drag&drop and made sure things resized correctly and no new issue, but min size is now correct (see #999 screen shots)