### PR TITLE
Fix #937

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -24,6 +24,7 @@ Change log
 
 ## v0.5.2-dev (upcoming changes)
 
+- fix widgets not animating when animate: true is used. on every move, styles were recreated-fix should slightly improve gridstack.js speed ([#937](https://github.com/gridstack/gridstack.js/issues/937)).
 - fix moving widgets when having multiple grids. jquery-ui workaround ([#1043](https://github.com/gridstack/gridstack.js/issues/1043)).
 - switch to eslint ([#763](https://github.com/gridstack/gridstack.js/issues/763)).
 - null values to addWidget() exception fix ([#1042](https://github.com/gridstack/gridstack.js/issues/1042)).

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1094,12 +1094,13 @@
     if (typeof maxHeight == 'undefined') {
       maxHeight = this._styles._max;
     }
+
+    if (this._styles._max !== 0 && maxHeight <= this._styles._max) { // Keep this._styles._max increasing
+      return ;
+    }
     this._initStyles();
     this._updateContainerHeight();
     if (!this.opts.cellHeight) { // The rest will be handled by CSS
-      return ;
-    }
-    if (this._styles._max !== 0 && maxHeight <= this._styles._max) { // Keep this._styles._max increasing
       return ;
     }
 


### PR DESCRIPTION
### Description
Fixes #937. Styles were being removed and recreated on every widget drag. This could have had other unexpected impacts as well. Should make moving widgets faster.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
