### PR TITLE
grid options renamed to `columns` & `maxRows`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ Join gridstack.js on Slack: https://gridstackjs.troolee.com
   - [API Documentation](#api-documentation)
   - [Touch devices support](#touch-devices-support)
   - [gridstack.js for specific frameworks](#gridstackjs-for-specific-frameworks)
-  - [Change grid width](#change-grid-width)
-  - [Extra CSS](#extra-css)
-    - [Different grid widths](#different-grid-widths)
+  - [Change grid columns](#change-grid-columns)
+  - [Custom columns CSS](#custom-columns-css)
   - [Override resizable/draggable options](#override-resizabledraggable-options)
   - [IE8 support](#ie8-support)
 - [Changes](#changes)
@@ -174,10 +173,31 @@ If you're still experiencing issues on touch devices please check [#444](https:/
 - ember: [gridstack-ember](https://github.com/yahoo/ember-gridstack)
 
 
-## Change grid width
+## Change grid columns
 
-To change grid width (columns count), in addition to setting the `width` grid option CSS rules
-for `.grid-stack-item[data-gs-width="X"]` and  `.grid-stack-item[data-gs-x="X"]` have to be changed accordingly.
+GridStack makes it very easy if you need [1-12] columns out of the box (default is 12), but you always need **2 things** if you need to customize this:
+
+1) Change the `columns` grid option when creating a grid to your number N
+```js
+$('.grid-stack').gridstack( {columns: N} );
+```
+
+2) and change your HTML accordingly if **N < 12** (else custom CSS section next). Without this, things will not render/work correctly.
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.5.2/dist/gridstack-extra.css"/>
+
+<div class="grid-stack grid-stack-N">...</div>
+```
+
+Note `grid-stack-N` class was added.
+
+`gridstack-extra.css` (and `gridstack-extra.min.css`) defines CSS for grids with custom [1-12] columns. Anything more and you'll need to generate the SASS/CSS yourself (see next).
+
+See example: [2 grids demo](http://gridstack.github.io/gridstack.js/demo/two.html) with 6 columns
+
+## Custom columns CSS
+
+If you need > 12 columns or want to generate the CSS manually (else see above) you will need to generate CSS rules for `.grid-stack-item[data-gs-width="X"]` and `.grid-stack-item[data-gs-x="X"]`.
 
 For instance for 3-column grid you need to rewrite CSS to be:
 
@@ -205,7 +225,7 @@ For 4-column grid it should be:
 
 and so on.
 
-Here is a SASS code snippet which can make life easier (Thanks to @ascendantofrain, [#81](https://github.com/gridstack/gridstack.js/issues/81) and @StefanM98, [#868](https://github.com/gridstack/gridstack.js/issues/868)) and use a site like [sassmeister.com](https://www.sassmeister.com/) to generate CSS if you need to:
+Better yet, here is a SASS code snippet which can make life much easier (Thanks to @ascendantofrain, [#81](https://github.com/gridstack/gridstack.js/issues/81) and @StefanM98, [#868](https://github.com/gridstack/gridstack.js/issues/868)) and you can use sites like [sassmeister.com](https://www.sassmeister.com/) to generate the CSS for you instead:
 
 ```sass
 .grid-stack > .grid-stack-item {
@@ -222,25 +242,6 @@ Here is a SASS code snippet which can make life easier (Thanks to @ascendantofra
   }
 }
 ```
-
-Or you can include `gridstack-extra.css` which include [1-12] column sizes. See below for more details.
-
-## Extra CSS
-
-There are few extra CSS batteries in `gridstack-extra.css` (`gridstack-extra.min.css`) that defines CSS for grids with [1-12] columns. Anything more and you'll need to generate the above SASS/CSS yourself.
-
-### Different grid widths
-
-You can use other than 12 grid width:
-
-```html
-<div class="grid-stack grid-stack-N">...</div>
-```
-```javascript
-$('.grid-stack').gridstack({width: N});
-```
-
-See example: [2 grids demo](http://gridstack.github.io/gridstack.js/demo/two.html)
 
 ## Override resizable/draggable options
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you're still experiencing issues on touch devices please check [#444](https:/
 
 ## Change grid width
 
-To change grid width (columns count), to addition to `width` option, CSS rules
+To change grid width (columns count), in addition to setting the `width` grid option CSS rules
 for `.grid-stack-item[data-gs-width="X"]` and  `.grid-stack-item[data-gs-x="X"]` have to be changed accordingly.
 
 For instance for 3-column grid you need to rewrite CSS to be:
@@ -205,12 +205,14 @@ For 4-column grid it should be:
 
 and so on.
 
-Here is a SASS code snippet which can make life easier (Thanks to @ascendantofrain, [#81](https://github.com/gridstack/gridstack.js/issues/81) and @StefanM98, [#868](https://github.com/gridstack/gridstack.js/issues/868)):
+Here is a SASS code snippet which can make life easier (Thanks to @ascendantofrain, [#81](https://github.com/gridstack/gridstack.js/issues/81) and @StefanM98, [#868](https://github.com/gridstack/gridstack.js/issues/868)) and use a site like [sassmeister.com](https://www.sassmeister.com/) to generate CSS if you need to:
 
 ```sass
 .grid-stack > .grid-stack-item {
 
   $gridstack-columns: 12;
+
+  min-width: (100% / $gridstack-columns);
 
   @for $i from 1 through $gridstack-columns {
     &[data-gs-width='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
@@ -221,11 +223,11 @@ Here is a SASS code snippet which can make life easier (Thanks to @ascendantofra
 }
 ```
 
-Or you can include `gridstack-extra.css`. See below for more details.
+Or you can include `gridstack-extra.css` which include [1-12] column sizes. See below for more details.
 
 ## Extra CSS
 
-There are few extra CSS batteries in `gridstack-extra.css` (`gridstack-extra.min.css`).
+There are few extra CSS batteries in `gridstack-extra.css` (`gridstack-extra.min.css`) that defines CSS for grids with [1-12] columns. Anything more and you'll need to generate the above SASS/CSS yourself.
 
 ### Different grid widths
 

--- a/demo/two.html
+++ b/demo/two.html
@@ -106,7 +106,7 @@
   <script type="text/javascript">
     $(function () {
       var options = {
-        width: 6,
+        columns: 6,
         float: false,
         removable: '.trash',
         removeTimeout: 100,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,6 +28,7 @@ Change log
 - fix moving widgets when having multiple grids. jquery-ui workaround ([#1043](https://github.com/gridstack/gridstack.js/issues/1043)).
 - switch to eslint ([#763](https://github.com/gridstack/gridstack.js/issues/763)).
 - null values to addWidget() exception fix ([#1042](https://github.com/gridstack/gridstack.js/issues/1042)).
+- various fixes for custom # of columns (readme, safer code) ([#1053](https://github.com/gridstack/gridstack.js/issues/1053)).
 
 ## v0.5.2 (2019-11-13)
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -24,11 +24,11 @@ Change log
 
 ## v0.5.2-dev (upcoming changes)
 
+- grid options `width` is now `columns`, and `height` is now `maxRows` which match what they are. Old names are still supported for now (with console warnings). Also various fixes for custom # of columns and re-wrote entire doc section ([#1053](https://github.com/gridstack/gridstack.js/issues/1053)).
 - fix widgets not animating when animate: true is used. on every move, styles were recreated-fix should slightly improve gridstack.js speed ([#937](https://github.com/gridstack/gridstack.js/issues/937)).
 - fix moving widgets when having multiple grids. jquery-ui workaround ([#1043](https://github.com/gridstack/gridstack.js/issues/1043)).
 - switch to eslint ([#763](https://github.com/gridstack/gridstack.js/issues/763)).
 - null values to addWidget() exception fix ([#1042](https://github.com/gridstack/gridstack.js/issues/1042)).
-- various fixes for custom # of columns (readme, safer code) ([#1053](https://github.com/gridstack/gridstack.js/issues/1053)).
 
 ## v0.5.2 (2019-11-13)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -104,10 +104,10 @@ gridstack.js API
 
 ## Item attributes
 
-- `data-gs-x`, `data-gs-y` - element position. Note: if one is missing this will `autoPosition` the item
-- `data-gs-width`, `data-gs-height` - element size
-- `data-gs-id`- good for quick identification (for example in change event)
-- `data-gs-max-width`, `data-gs-min-width`, `data-gs-max-height`, `data-gs-min-height` - element constraints
+- `data-gs-x`, `data-gs-y` - (number) element position in row/column. Note: if one is missing this will `autoPosition` the item
+- `data-gs-width`, `data-gs-height` - (number) element size in row/column
+- `data-gs-id`- (number | string) good for quick identification (for example in change event)
+- `data-gs-max-width`, `data-gs-min-width`, `data-gs-max-height`, `data-gs-min-height` - element constraints in row/column
 - `data-gs-no-resize` - disable element resizing
 - `data-gs-no-move` - disable element moving
 - `data-gs-auto-position` - tells to ignore `data-gs-x` and `data-gs-y` attributes and to place element to the first available position. Having either one missing will also do that.

--- a/doc/README.md
+++ b/doc/README.md
@@ -77,7 +77,8 @@ gridstack.js API
 - `draggable` - allows to override jQuery UI draggable options. (default: `{handle: '.grid-stack-item-content', scroll: false, appendTo: 'body'}`)
 - `handle` - draggable handle selector (default: `'.grid-stack-item-content'`)
 - `handleClass` - draggable handle class (e.g. `'grid-stack-item-content'`). If set `handle` is ignored (default: `null`)
-- `height` - maximum rows amount. Default is `0` which means no maximum rows
+- `columns` - amount of columns (default: `12`)
+- `maxRows` - maximum rows amount. Default is `0` which means no maximum rows
 - `float` - enable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
 - `itemClass` - widget class (default: `'grid-stack-item'`)
 - `minWidth` - minimal width. If window width is less than or equal to, grid will be shown in one-column mode (default: `768`)
@@ -93,13 +94,12 @@ gridstack.js API
 - `verticalMargin` - vertical gap size (default: `20`). Can be:
   * an integer (px)
   * a string (ex: '2em', '20px', '2rem')
-- `width` - amount of columns (default: `12`)
 
 ## Grid attributes
 
 - `data-gs-animate` - turns animation on
-- `data-gs-width` - amount of columns. Setting non-default value must be supported by equivalent change in CSS, [see docs here](https://github.com/gridstack/gridstack.js#change-grid-width).
-- `data-gs-height` - maximum rows amount. Default is `0` which means no maximum rows.
+- `data-gs-columns` - amount of columns. Setting non-default value must be supported by equivalent change in CSS, [see docs here](https://github.com/gridstack/gridstack.js#change-grid-columns).
+- `data-gs-maxRows` - maximum rows amount. Default is `0` which means no maximum rows.
 - `data-gs-current-height` - current rows amount. Set by the library only. Can be used by the CSS rules.
 
 ## Item attributes

--- a/spec/e2e/html/810-many-columns.css
+++ b/spec/e2e/html/810-many-columns.css
@@ -1,0 +1,381 @@
+/* SASS code using https://www.sassmeister.com/
+.grid-stack > .grid-stack-item {
+
+    $gridstack-columns: 30;
+  
+    min-width: (100% / $gridstack-columns);
+    
+    @for $i from 1 through $gridstack-columns {
+      &[data-gs-width='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
+      &[data-gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
+      &[data-gs-min-width='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
+      &[data-gs-max-width='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
+    }
+  }
+  */
+
+  /* override gridstack,css */
+  .grid-stack > .grid-stack-item {
+    min-width: 3.3333333333%;
+  }
+
+  .grid-stack > .grid-stack-item[data-gs-width="1"] {
+    width: 3.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="1"] {
+    left: 3.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="1"] {
+    min-width: 3.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="1"] {
+    max-width: 3.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="2"] {
+    width: 6.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="2"] {
+    left: 6.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="2"] {
+    min-width: 6.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="2"] {
+    max-width: 6.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="3"] {
+    width: 10%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="3"] {
+    left: 10%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="3"] {
+    min-width: 10%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="3"] {
+    max-width: 10%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="4"] {
+    width: 13.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="4"] {
+    left: 13.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="4"] {
+    min-width: 13.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="4"] {
+    max-width: 13.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="5"] {
+    width: 16.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="5"] {
+    left: 16.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="5"] {
+    min-width: 16.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="5"] {
+    max-width: 16.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="6"] {
+    width: 20%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="6"] {
+    left: 20%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="6"] {
+    min-width: 20%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="6"] {
+    max-width: 20%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="7"] {
+    width: 23.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="7"] {
+    left: 23.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="7"] {
+    min-width: 23.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="7"] {
+    max-width: 23.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="8"] {
+    width: 26.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="8"] {
+    left: 26.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="8"] {
+    min-width: 26.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="8"] {
+    max-width: 26.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="9"] {
+    width: 30%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="9"] {
+    left: 30%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="9"] {
+    min-width: 30%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="9"] {
+    max-width: 30%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="10"] {
+    width: 33.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="10"] {
+    left: 33.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="10"] {
+    min-width: 33.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="10"] {
+    max-width: 33.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="11"] {
+    width: 36.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="11"] {
+    left: 36.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="11"] {
+    min-width: 36.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="11"] {
+    max-width: 36.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="12"] {
+    width: 40%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="12"] {
+    left: 40%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="12"] {
+    min-width: 40%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="12"] {
+    max-width: 40%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="13"] {
+    width: 43.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="13"] {
+    left: 43.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="13"] {
+    min-width: 43.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="13"] {
+    max-width: 43.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="14"] {
+    width: 46.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="14"] {
+    left: 46.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="14"] {
+    min-width: 46.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="14"] {
+    max-width: 46.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="15"] {
+    width: 50%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="15"] {
+    left: 50%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="15"] {
+    min-width: 50%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="15"] {
+    max-width: 50%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="16"] {
+    width: 53.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="16"] {
+    left: 53.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="16"] {
+    min-width: 53.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="16"] {
+    max-width: 53.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="17"] {
+    width: 56.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="17"] {
+    left: 56.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="17"] {
+    min-width: 56.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="17"] {
+    max-width: 56.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="18"] {
+    width: 60%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="18"] {
+    left: 60%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="18"] {
+    min-width: 60%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="18"] {
+    max-width: 60%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="19"] {
+    width: 63.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="19"] {
+    left: 63.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="19"] {
+    min-width: 63.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="19"] {
+    max-width: 63.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="20"] {
+    width: 66.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="20"] {
+    left: 66.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="20"] {
+    min-width: 66.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="20"] {
+    max-width: 66.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="21"] {
+    width: 70%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="21"] {
+    left: 70%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="21"] {
+    min-width: 70%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="21"] {
+    max-width: 70%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="22"] {
+    width: 73.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="22"] {
+    left: 73.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="22"] {
+    min-width: 73.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="22"] {
+    max-width: 73.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="23"] {
+    width: 76.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="23"] {
+    left: 76.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="23"] {
+    min-width: 76.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="23"] {
+    max-width: 76.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="24"] {
+    width: 80%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="24"] {
+    left: 80%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="24"] {
+    min-width: 80%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="24"] {
+    max-width: 80%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="25"] {
+    width: 83.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="25"] {
+    left: 83.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="25"] {
+    min-width: 83.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="25"] {
+    max-width: 83.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="26"] {
+    width: 86.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="26"] {
+    left: 86.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="26"] {
+    min-width: 86.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="26"] {
+    max-width: 86.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="27"] {
+    width: 90%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="27"] {
+    left: 90%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="27"] {
+    min-width: 90%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="27"] {
+    max-width: 90%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="28"] {
+    width: 93.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="28"] {
+    left: 93.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="28"] {
+    min-width: 93.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="28"] {
+    max-width: 93.3333333333%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="29"] {
+    width: 96.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="29"] {
+    left: 96.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="29"] {
+    min-width: 96.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="29"] {
+    max-width: 96.6666666667%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-width="30"] {
+    width: 100%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-x="30"] {
+    left: 100%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-min-width="30"] {
+    min-width: 100%;
+  }
+  .grid-stack > .grid-stack-item[data-gs-max-width="30"] {
+    max-width: 100%;
+  }

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--[if lt IE 9]>
+  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Many columns demo</title>
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+  <link rel="stylesheet" href="../../../dist/gridstack.css"/>
+  <link rel="stylesheet" href="810-many-columns.css"/>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.9/shim.min.js"></script>
+  <script src="../../../src/gridstack.js"></script>
+  <script src="../../../src/gridstack.jQueryUI.js"></script>
+
+  <style type="text/css">
+    .grid-stack {
+      background: lightgoldenrodyellow;
+    }
+
+    .grid-stack-item-content {
+      color: #2c3e50;
+      text-align: center;
+      background-color: #18bc9c;
+    }
+  </style>
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Many Columns demo</h1>
+    <div>
+      <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
+    </div>
+    <br><br>
+    <div class="grid-stack"></div>
+  </div>
+
+
+  <script type="text/javascript">
+    $(function () {
+      const COLUMNS = 30; // # of columns, also need to update CSS
+      var count = 0;
+      var options = {
+        width: COLUMNS,
+        cellHeight: 'auto',
+        float: false
+      };
+      $('.grid-stack').gridstack(options);
+
+      new function () {
+        this.grid = $('.grid-stack').data('gridstack');
+
+        this.addNewWidget = function(i) {
+          this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), {id: i});
+          return false;
+        }.bind(this);
+
+        for (; count < COLUMNS; count++) {
+          this.addNewWidget(count); 
+        }
+
+        $('#add-widget').click(this.addNewWidget(count++));
+      };
+    });
+  </script>
+</body>
+</html>

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -49,7 +49,7 @@
       const COLUMNS = 30; // # of columns, also need to update CSS
       var count = 0;
       var options = {
-        width: COLUMNS,
+        columns: COLUMNS,
         cellHeight: 'auto',
         float: false
       };

--- a/spec/gridstack-engine-spec.js
+++ b/spec/gridstack-engine-spec.js
@@ -17,9 +17,9 @@ describe('gridstack engine', function() {
     });
 
     it('should be setup properly', function() {
-      expect(engine.width).toEqual(12);
+      expect(engine.columns).toEqual(12);
       expect(engine.float).toEqual(false);
-      expect(engine.height).toEqual(0);
+      expect(engine.maxRows).toEqual(0);
       expect(engine.nodes).toEqual([]);
     });
   });

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -7,14 +7,10 @@ describe('gridstack', function() {
   var gridstackHTML =
     '<div style="width: 992px; height: 800px" id="gs-cont">' +
     '  <div class="grid-stack">' +
-    '    <div class="grid-stack-item"' +
-    '      data-gs-x="0" data-gs-y="0"' +
-    '      data-gs-width="4" data-gs-height="2">' +
+    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
-    '    <div class="grid-stack-item"' +
-    '      data-gs-x="4" data-gs-y="0"' +
-    '      data-gs-width="4" data-gs-height="4">' +
+    '    <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
     '  </div>' +
@@ -35,9 +31,9 @@ describe('gridstack', function() {
 
     it('should set default params correctly.', function() {
       e.call(w);
-      expect(w.width).toBeUndefined();
+      expect(w.columns).toBeUndefined();
       expect(w.float).toBe(false);
-      expect(w.height).toEqual(0);
+      expect(w.maxRows).toEqual(0);
       expect(w.nodes).toEqual([]);
       expect(typeof w.onchange).toBe('function');
       expect(w._updateCounter).toEqual(0);
@@ -49,9 +45,9 @@ describe('gridstack', function() {
       var arr = [1,2,3];
 
       e.call(w, 1, fkt, true, 2, arr);
-      expect(w.width).toEqual(1);
+      expect(w.columns).toEqual(1);
       expect(w.float).toBe(true);
-      expect(w.height).toEqual(2);
+      expect(w.maxRows).toEqual(2);
       expect(w.nodes).toEqual(arr);
       expect(w.onchange).toEqual(fkt);
       expect(w._updateCounter).toEqual(0);
@@ -75,27 +71,27 @@ describe('gridstack', function() {
 
   describe('sorting of nodes', function() {
 
-    it('should sort ascending with width.', function() {
+    it('should sort ascending with columns.', function() {
       w.nodes = [{x: 7, y: 0}, {x: 4, y: 4}, {x: 9, y: 0}, {x: 0, y: 1}];
       e.prototype._sortNodes.call(w, 1);
       expect(w.nodes).toEqual([{x: 0, y: 1}, {x: 7, y: 0}, {x: 4, y: 4}, {x: 9, y: 0}]);
     });
 
-    it('should sort descending with width.', function() {
+    it('should sort descending with columns.', function() {
       w.nodes = [{x: 7, y: 0}, {x: 4, y: 4}, {x: 9, y: 0}, {x: 0, y: 1}];
       e.prototype._sortNodes.call(w, -1);
       expect(w.nodes).toEqual([{x: 9, y: 0}, {x: 4, y: 4}, {x: 7, y: 0}, {x: 0, y: 1}]);
     });
 
-    it('should sort ascending without width.', function() {
-      w.width = false;
+    it('should sort ascending without columns.', function() {
+      w.columns = undefined;
       w.nodes = [{x: 7, y: 0, width: 1}, {x: 4, y: 4, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}];
       e.prototype._sortNodes.call(w, 1);
       expect(w.nodes).toEqual([{x: 7, y: 0, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}, {x: 4, y: 4, width: 1}]);
     });
 
-    it('should sort descending without width.', function() {
-      w.width = false;
+    it('should sort descending without columns.', function() {
+      w.columns = undefined;
       w.nodes = [{x: 7, y: 0, width: 1}, {x: 4, y: 4, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}];
       e.prototype._sortNodes.call(w, -1);
       expect(w.nodes).toEqual([{x: 4, y: 4, width: 1}, {x: 0, y: 1, width: 1}, {x: 9, y: 0, width: 1}, {x: 7, y: 0, width: 1}]);
@@ -224,7 +220,7 @@ describe('gridstack', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10,
-        width: 12
+        columns: 12
       };
       $('.grid-stack').gridstack(options);
       var grid = $('.grid-stack').data('gridstack');
@@ -235,7 +231,7 @@ describe('gridstack', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10,
-        width: 10
+        columns: 10
       };
       $('.grid-stack').gridstack(options);
       var grid = $('.grid-stack').data('gridstack');
@@ -255,7 +251,7 @@ describe('gridstack', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10,
-        width: 12
+        columns: 12
       };
       $('.grid-stack').gridstack(options);
       var grid = $('.grid-stack').data('gridstack');
@@ -266,7 +262,7 @@ describe('gridstack', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10,
-        width: 10
+        columns: 10
       };
       $('.grid-stack').gridstack(options);
       var grid = $('.grid-stack').data('gridstack');

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -913,6 +913,26 @@ describe('gridstack', function() {
     });
   });
 
+  describe('addWidget() with bad string value widget options', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should use default', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      var widgetHTML = '<div class="grid-stack-item"><div class="grid-stack-item-content"></div></div>';
+      var widget = grid.addWidget(widgetHTML, {x: 'foo', height: null, width: 'bar', height: ''});
+      var $widget = $(widget);
+      expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
+      expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
+      expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
+      expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(1);
+    });
+  });
+
   describe('addWidget with null options, ', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -437,9 +437,14 @@ interface GridstackOptions {
     handleClass?: string;
 
     /**
+    * number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns
+    */
+    columns?: number;
+
+    /**
     * maximum rows amount. Default? is 0 which means no maximum rows
     */
-    height?: number;
+    maxRows?: number;
 
     /**
     * enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html)
@@ -513,10 +518,5 @@ interface GridstackOptions {
     * (internal?) unit for verticalMargin (default? 'px')
     */
     verticalMarginUnit?: string;
-
-    /**
-    * number of columns (default?: 12)
-    */
-    width?: number;
 }
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -18,6 +18,8 @@
     factory(window.jQuery, window);
   }
 })(function($, scope) {
+
+  // checks for obsolete method names
   var obsolete = function(f, oldName, newName) {
     var wrapper = function() {
       console.warn('gridstack.js: Function `' + oldName + '` is deprecated as of v0.2.5 and has been replaced ' +
@@ -29,10 +31,21 @@
     return wrapper;
   };
 
-  var obsoleteOpts = function(opts, oldName, newName) {
+   // checks for obsolete grid options 9can be used for any fields, but msg is about options)
+   var obsoleteOpts = function(opts, oldName, newName) {
     if (opts[oldName] !== undefined) {
       opts[newName] = opts[oldName];
       console.warn('gridstack.js: Option `' + oldName + '` is deprecated as of v0.2.5 and has been replaced with `' +
+        newName + '`. It will be **completely** removed in v1.0.');
+    }
+  };
+
+  // checks for obsolete Jquery element attributes
+  var obsoleteAttr = function(el, oldName, newName) {
+    var oldAttr = el.attr(oldName);
+    if (oldAttr !== undefined) {
+      el.attr(newName, oldAttr);
+      console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object as of v0.5.2 and has been replaced with `' +
         newName + '`. It will be **completely** removed in v1.0.');
     }
   };
@@ -675,6 +688,10 @@
     obsoleteOpts(opts, 'always_show_resize_handle', 'alwaysShowResizeHandle');
     obsoleteOpts(opts, 'width', 'columns');
     obsoleteOpts(opts, 'height', 'maxRows');
+
+    // container attributes
+    obsoleteAttr(this.container, 'data-gs-width', 'data-gs-columns');
+    obsoleteAttr(this.container, 'data-gs-height', 'data-gs-max-rows');
     /*eslint-enable camelcase */
 
     opts.itemClass = opts.itemClass || 'grid-stack-item';

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -279,10 +279,10 @@
 
   var idSeq = 0;
 
-  var GridStackEngine = function(width, onchange, floatMode, height, items) {
-    this.width = width;
+  var GridStackEngine = function(columns, onchange, floatMode, maxRows, items) {
+    this.columns = columns;
     this.float = floatMode || false;
-    this.height = height || 0;
+    this.maxRows = maxRows || 0;
 
     this.nodes = items || [];
     this.onchange = onchange || function() {};
@@ -320,7 +320,7 @@
     var nn = node;
     var hasLocked = Boolean(this.nodes.find(function(n) { return n.locked; }));
     if (!this.float && !hasLocked) {
-      nn = {x: 0, y: node.y, width: this.width, height: node.height};
+      nn = {x: 0, y: node.y, width: this.columns, height: node.height};
     }
     while (true) {
       var collisionNode = this.nodes.find(Utils._collisionNodeCheck, {node: node, nn: nn});
@@ -339,7 +339,7 @@
   };
 
   GridStackEngine.prototype._sortNodes = function(dir) {
-    this.nodes = Utils.sort(this.nodes, dir, this.width);
+    this.nodes = Utils.sort(this.nodes, dir, this.columns);
   };
 
   GridStackEngine.prototype._packNodes = function() {
@@ -416,8 +416,8 @@
     if (Number.isNaN(node.width))  { node.width = defaults.width; }
     if (Number.isNaN(node.height)) { node.height = defaults.height; }
 
-    if (node.width > this.width) {
-      node.width = this.width;
+    if (node.width > this.columns) {
+      node.width = this.columns;
     } else if (node.width < 1) {
       node.width = 1;
     }
@@ -430,11 +430,11 @@
       node.x = 0;
     }
 
-    if (node.x + node.width > this.width) {
+    if (node.x + node.width > this.columns) {
       if (resizing) {
-        node.width = this.width - node.x;
+        node.width = this.columns - node.x;
       } else {
-        node.x = this.width - node.width;
+        node.x = this.columns - node.width;
       }
     }
 
@@ -482,9 +482,9 @@
       this._sortNodes();
 
       for (var i = 0;; ++i) {
-        var x = i % this.width;
-        var y = Math.floor(i / this.width);
-        if (x + node.width > this.width) {
+        var x = i % this.columns;
+        var y = Math.floor(i / this.columns);
+        if (x + node.width > this.columns) {
           continue;
         }
         if (!this.nodes.find(Utils._isAddNodeIntercepted, {x: x, y: y, node: node})) {
@@ -521,13 +521,13 @@
     }
     var hasLocked = Boolean(this.nodes.find(function(n) { return n.locked; }));
 
-    if (!this.height && !hasLocked) {
+    if (!this.maxRows && !hasLocked) {
       return true;
     }
 
     var clonedNode;
     var clone = new GridStackEngine(
-      this.width,
+      this.columns,
       null,
       this.float,
       0,
@@ -550,26 +550,26 @@
         return n !== clonedNode && Boolean(n.locked) && Boolean(n._dirty);
       }));
     }
-    if (this.height) {
-      res &= clone.getGridHeight() <= this.height;
+    if (this.maxRows) {
+      res &= clone.getGridHeight() <= this.maxRows;
     }
 
     return res;
   };
 
   GridStackEngine.prototype.canBePlacedWithRespectToHeight = function(node) {
-    if (!this.height) {
+    if (!this.maxRows) {
       return true;
     }
 
     var clone = new GridStackEngine(
-      this.width,
+      this.columns,
       null,
       this.float,
       0,
       this.nodes.map(function(n) { return $.extend({}, n); }));
     clone.addNode(node);
-    return clone.getGridHeight() <= this.height;
+    return clone.getGridHeight() <= this.maxRows;
   };
 
   GridStackEngine.prototype.isNodeChangedPosition = function(node, x, y, width, height) {
@@ -700,14 +700,22 @@
       opts.alwaysShowResizeHandle = opts.always_show_resize_handle;
       obsoleteOpts('always_show_resize_handle', 'alwaysShowResizeHandle');
     }
+    if (opts.width !== undefined) {
+      opts.columns = opts.width;
+      obsoleteOpts('width', 'columns');
+    }
+    if (opts.height !== undefined) {
+      opts.maxRows = opts.height;
+      obsoleteOpts('height', 'maxRows');
+    }
     /*eslint-enable camelcase */
 
     opts.itemClass = opts.itemClass || 'grid-stack-item';
     var isNested = this.container.closest('.' + opts.itemClass).length > 0;
 
     this.opts = Utils.defaults(opts || {}, {
-      width: parseInt(this.container.attr('data-gs-width')) || 12,
-      height: parseInt(this.container.attr('data-gs-height')) || 0,
+      columns: parseInt(this.container.attr('data-gs-columns')) || 12,
+      maxRows: parseInt(this.container.attr('data-gs-max-rows')) || 0,
       itemClass: 'grid-stack-item',
       placeholderClass: 'grid-stack-placeholder',
       placeholderText: '',
@@ -784,7 +792,7 @@
 
     this._initStyles();
 
-    this.grid = new GridStackEngine(this.opts.width, function(nodes, detachNode) {
+    this.grid = new GridStackEngine(this.opts.columns, function(nodes, detachNode) {
       detachNode = detachNode === undefined ? true : detachNode;
       var maxHeight = 0;
       this.nodes.forEach(function(n) {
@@ -804,7 +812,7 @@
         }
       });
       self._updateStyles(maxHeight + 10);
-    }, this.opts.float, this.opts.height);
+    }, this.opts.float, this.opts.maxRows);
 
     if (this.opts.auto) {
       var elements = [];
@@ -816,7 +824,7 @@
             el: el,
             // if x,y are missing (autoPosition) add them to end of list - keep their respective DOM order
             i: (parseInt(el.attr('data-gs-x')) || 100) +
-              (parseInt(el.attr('data-gs-y')) || 100) * _this.opts.width
+              (parseInt(el.attr('data-gs-y')) || 100) * _this.opts.columns
           });
         });
       Utils.sortBy(elements, function(x) { return x.i; }).forEach(function(item) {
@@ -1718,7 +1726,7 @@
 
     var heightData = Utils.parseHeight(val);
 
-    if (this.opts.verticalMarginUnit === heightData.unit && this.opts.height === heightData.height) {
+    if (this.opts.verticalMarginUnit === heightData.unit && this.opts.maxRows === heightData.height) {
       return ;
     }
     this.opts.verticalMarginUnit = heightData.unit;
@@ -1758,7 +1766,7 @@
 
   GridStack.prototype.cellWidth = function() {
     // TODO: take margin into account ($horizontal_padding in .scss) to make cellHeight='auto' square ? (see 810-many-columns.html)
-    return Math.round(this.container.outerWidth() / this.opts.width);
+    return Math.round(this.container.outerWidth() / this.opts.columns);
   };
 
   GridStack.prototype.getCellFromPixel = function(position, useOffset) {
@@ -1767,7 +1775,7 @@
     var relativeLeft = position.left - containerPos.left;
     var relativeTop = position.top - containerPos.top;
 
-    var columnWidth = Math.floor(this.container.width() / this.opts.width);
+    var columnWidth = Math.floor(this.container.width() / this.opts.columns);
     var rowHeight = Math.floor(this.container.height() / parseInt(this.container.attr('data-gs-current-height')));
 
     return {x: Math.floor(relativeLeft / columnWidth), y: Math.floor(relativeTop / rowHeight)};
@@ -1816,11 +1824,11 @@
   };
 
   GridStack.prototype.setGridWidth = function(gridWidth,doNotPropagate) {
-    this.container.removeClass('grid-stack-' + this.opts.width);
+    this.container.removeClass('grid-stack-' + this.opts.columns);
     if (doNotPropagate !== true) {
-      this._updateNodeWidths(this.opts.width, gridWidth);
+      this._updateNodeWidths(this.opts.columns, gridWidth);
     }
-    this.opts.width = gridWidth;
+    this.opts.columns = gridWidth;
     this.grid.width = gridWidth;
     this.container.addClass('grid-stack-' + gridWidth);
   };

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -29,9 +29,12 @@
     return wrapper;
   };
 
-  var obsoleteOpts = function(oldName, newName) {
-    console.warn('gridstack.js: Option `' + oldName + '` is deprecated as of v0.2.5 and has been replaced with `' +
-      newName + '`. It will be **completely** removed in v1.0.');
+  var obsoleteOpts = function(opts, oldName, newName) {
+    if (opts[oldName] !== undefined) {
+      opts[newName] = opts[oldName];
+      console.warn('gridstack.js: Option `' + oldName + '` is deprecated as of v0.2.5 and has been replaced with `' +
+        newName + '`. It will be **completely** removed in v1.0.');
+    }
   };
 
   var Utils = {
@@ -660,54 +663,18 @@
     this.container = $(el);
 
     /*eslint-disable camelcase */
-    if (opts.handle_class !== undefined) {
-      opts.handleClass = opts.handle_class;
-      obsoleteOpts('handle_class', 'handleClass');
-    }
-    if (opts.item_class !== undefined) {
-      opts.itemClass = opts.item_class;
-      obsoleteOpts('item_class', 'itemClass');
-    }
-    if (opts.placeholder_class !== undefined) {
-      opts.placeholderClass = opts.placeholder_class;
-      obsoleteOpts('placeholder_class', 'placeholderClass');
-    }
-    if (opts.placeholder_text !== undefined) {
-      opts.placeholderText = opts.placeholder_text;
-      obsoleteOpts('placeholder_text', 'placeholderText');
-    }
-    if (opts.cell_height !== undefined) {
-      opts.cellHeight = opts.cell_height;
-      obsoleteOpts('cell_height', 'cellHeight');
-    }
-    if (opts.vertical_margin !== undefined) {
-      opts.verticalMargin = opts.vertical_margin;
-      obsoleteOpts('vertical_margin', 'verticalMargin');
-    }
-    if (opts.min_width !== undefined) {
-      opts.minWidth = opts.min_width;
-      obsoleteOpts('min_width', 'minWidth');
-    }
-    if (opts.static_grid !== undefined) {
-      opts.staticGrid = opts.static_grid;
-      obsoleteOpts('static_grid', 'staticGrid');
-    }
-    if (opts.is_nested !== undefined) {
-      opts.isNested = opts.is_nested;
-      obsoleteOpts('is_nested', 'isNested');
-    }
-    if (opts.always_show_resize_handle !== undefined) {
-      opts.alwaysShowResizeHandle = opts.always_show_resize_handle;
-      obsoleteOpts('always_show_resize_handle', 'alwaysShowResizeHandle');
-    }
-    if (opts.width !== undefined) {
-      opts.columns = opts.width;
-      obsoleteOpts('width', 'columns');
-    }
-    if (opts.height !== undefined) {
-      opts.maxRows = opts.height;
-      obsoleteOpts('height', 'maxRows');
-    }
+    obsoleteOpts(opts, 'handle_class', 'handleClass');
+    obsoleteOpts(opts, 'item_class', 'itemClass');
+    obsoleteOpts(opts, 'placeholder_class', 'placeholderClass');
+    obsoleteOpts(opts, 'placeholder_text', 'placeholderText');
+    obsoleteOpts(opts, 'cell_height', 'cellHeight');
+    obsoleteOpts(opts, 'vertical_margin', 'verticalMargin');
+    obsoleteOpts(opts, 'min_width', 'minWidth');
+    obsoleteOpts(opts, 'static_grid', 'staticGrid');
+    obsoleteOpts(opts, 'is_nested', 'isNested');
+    obsoleteOpts(opts, 'always_show_resize_handle', 'alwaysShowResizeHandle');
+    obsoleteOpts(opts, 'width', 'columns');
+    obsoleteOpts(opts, 'height', 'maxRows');
     /*eslint-enable camelcase */
 
     opts.itemClass = opts.itemClass || 'grid-stack-item';

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -31,8 +31,8 @@
     return wrapper;
   };
 
-   // checks for obsolete grid options 9can be used for any fields, but msg is about options)
-   var obsoleteOpts = function(opts, oldName, newName) {
+  // checks for obsolete grid options 9can be used for any fields, but msg is about options)
+  var obsoleteOpts = function(opts, oldName, newName) {
     if (opts[oldName] !== undefined) {
       opts[newName] = opts[oldName];
       console.warn('gridstack.js: Option `' + oldName + '` is deprecated as of v0.2.5 and has been replaced with `' +

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -393,18 +393,28 @@
   GridStackEngine.prototype._prepareNode = function(node, resizing) {
     node = node || {};
     // if we're missing position, have the grid position us automatically (before we set them to 0,0)
-    if (node.x === undefined || node.y === undefined) {
+    if (node.x === undefined || node.y === undefined || node.x === null || node.y === null) {
       node.autoPosition = true;
     }
-    node = Utils.defaults(node, {width: 1, height: 1, x: 0, y: 0});
 
-    node.x = parseInt('' + node.x);
-    node.y = parseInt('' + node.y);
-    node.width = parseInt('' + node.width);
-    node.height = parseInt('' + node.height);
+    // assign defaults for missing required fields
+    var defaults = {width: 1, height: 1, x: 0, y: 0};
+    node = Utils.defaults(node, defaults);
+
+    // convert any strings over
+    node.x = parseInt(node.x);
+    node.y = parseInt(node.y);
+    node.width = parseInt(node.width);
+    node.height = parseInt(node.height);
     node.autoPosition = node.autoPosition || false;
     node.noResize = node.noResize || false;
     node.noMove = node.noMove || false;
+
+    // check for NaN (in case messed up strings were passed. can't do parseInt() || defaults.x above as 0 is valid #)
+    if (Number.isNaN(node.x))      { node.x = defaults.x; node.autoPosition = true; }
+    if (Number.isNaN(node.y))      { node.y = defaults.y; node.autoPosition = true; }
+    if (Number.isNaN(node.width))  { node.width = defaults.width; }
+    if (Number.isNaN(node.height)) { node.height = defaults.height; }
 
     if (node.width > this.width) {
       node.width = this.width;
@@ -1747,6 +1757,7 @@
   };
 
   GridStack.prototype.cellWidth = function() {
+    // TODO: take margin into account ($horizontal_padding in .scss) to make cellHeight='auto' square ? (see 810-many-columns.html)
     return Math.round(this.container.outerWidth() / this.opts.width);
   };
 


### PR DESCRIPTION
### Description
* grid options `width` is now `columns`, and `height` is now `maxRows` which match what they are.
* Old names are still supported for now (with console warnings)
* updated test (required), samples (optional), readme
* re-wrote entire custom column section. Hopefully much easier to find/use now.

Created a sample for #810 with 30 columns, but not seeing issues in that PR (issue rounding cellWidth() with large # of columns). I was able to move and resize and things lined up as expected even when total width / 30 was close to .5 off 
@nulen please update with info.

In the meantime I found those issues:
* fix README talking about custom columns #
* fix SASS code to handle >12 columns as you need to override stack-item min-width (we have 8.3333% otherwise which is 12 column!)
* while testing I incorrectly passed 'auto' for gridItem width (it's a cellHeight on grid options instead)
so fixed code to handle wrong strings/garbage passed for x,y,w,h as I was getting inf loop instead.
* updated test cases

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
also ran every demo samples, and the new 30 columns sample as well.
