### PR TITLE
changed jquery to "^1.8 || 2 || 3"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Join gridstack.js on Slack: https://gridstackjs.troolee.com
 - [Demo and examples](#demo-and-examples)
 - [Usage](#usage)
   - [Requirements](#requirements)
-      - [Using gridstack.js with jQuery UI](#using-gridstackjs-with-jquery-ui)
   - [Install](#install)
   - [Basic usage](#basic-usage)
   - [Migrating to v0.3.0](#migrating-to-v030)
@@ -46,13 +45,13 @@ Usage
 
 ## Requirements
 
-* [jQuery](http://jquery.com) (>= 3.1.0)
+* [jQuery](http://jquery.com) (>= 1.8)
 * `Array.prototype.find`, and `Number.isNaN()` for IE and older browsers.
   * Note: as of v0.5.4 We supply a separate `gridstack.poly.js` for that 
 (part of `gridstack.all.js`) or you can look at other pollyfills 
 ([core.js](https://github.com/zloirock/core-js#ecmascript-6-array) and [mozilla.org](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)).
 
-#### Using gridstack.js with jQuery UI
+Using gridstack.js with jQuery UI
 
 * [jQuery UI](http://jqueryui.com) (>= 1.12.0). Minimum required components: Draggable, Droppable, Resizable (Widget, Mouse, core).
   * Note: as of v0.5.4 we include this subset as `jquery-ui.js` (and min.js) which is part of `gridstack.all.js`. If you wish to bring your own lib, include the individual gridstack parts instead of all.js
@@ -188,14 +187,14 @@ GridStack makes it very easy if you need [1-12] columns out of the box (default 
 $('.grid-stack').gridstack( {column: N} );
 ```
 
-2) and change your HTML accordingly if **N < 12** (else custom CSS section next). Without this, things will not render/work correctly.
+2) include `gridstack-extra.css` if **N < 12** (else custom CSS - see next). Without these, things will not render/work correctly.
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@latest/dist/gridstack-extra.css"/>
 
 <div class="grid-stack grid-stack-N">...</div>
 ```
 
-Note `grid-stack-N` class was added.
+Note `grid-stack-N` class was added, and extra CSS.
 
 `gridstack-extra.css` (and `gridstack-extra.min.css`) defines CSS for grids with custom [1-12] columns. Anything more and you'll need to generate the SASS/CSS yourself (see next).
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -26,7 +26,9 @@ Change log
 ## v0.5.3-dev (upcoming changes)
 
 - add `gridstack.poly.js` for IE and older browsers, removed `core-js` lib from samples (<1k vs 85k), and all IE8 mentions ([#1061](https://github.com/gridstack/gridstack.js/pull/1061)).
-- add `jquery-ui.js` (and min.js) as minimal subset we need (55k vs 248k), which is now part of `gridstack.all.js` - so just 1 include needed now.
+- add `jquery-ui.js` (and min.js) as minimal subset we need (55k vs 248k), which is now part of `gridstack.all.js`. Include individual parts if you need your own lib instead of all.js
+([#1064](https://github.com/gridstack/gridstack.js/pull/1064)).
+- changed jquery dep to lowest we can use (>=1.8) ([#629](https://github.com/gridstack/gridstack.js/issues/629)).
 
 ## v0.5.3 (2019-11-20)
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "gridstack",
     "grid",
     "gridster",
-    "layout",
-    "jquery"
+    "layout"
   ],
   "author": "Pavel Reznikov <pashka.reznikov@gmail.com>",
   "contributors": [
@@ -32,10 +31,9 @@
   },
   "homepage": "http://gridstack.github.io/gridstack.js/",
   "dependencies": {
-    "jquery": "^3.1.0"
+    "jquery": "^1.8 || 2 || 3"
   },
   "devDependencies": {
-    "components-jqueryui": "1.12.1",
     "connect": "^3.6.6",
     "core-js": "^3.0.0",
     "coveralls": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,11 +772,6 @@ component-inherit@0.0.3:
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
-components-jqueryui@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/components-jqueryui/-/components-jqueryui-1.12.1.tgz#617076f128f3be4c265f3e2db50471ef96cd9cee"
-  integrity sha1-YXB28SjzvkwmXz4ttQRx75bNnO4=
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2749,7 +2744,7 @@ jasminewd2@^2.1.0:
   resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.2.0.tgz#e37cf0b17f199cce23bea71b2039395246b4ec4e"
   integrity sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=
 
-jquery@^3.1.0:
+"jquery@^1.8 || 2 || 3":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==


### PR DESCRIPTION
### Description
fixes #629
* tested samples and lowest we can use is 1.8 (1.7 gives us .addBack() missing for jqUI 1.12)
* I don't see any harm is listing a wider range. Still using latest locally (smaller)

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
