### PR TITLE
removed bootstrap from demos

### DIFF
--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -6,27 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AniJS demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://anijs.github.io/lib/anicollection/anicollection.css" />
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,0 +1,32 @@
+@import "../dist/gridstack.css";
+
+.btn-primary {
+  color: #fff;
+  background-color: #007bff;
+}
+
+.btn {
+  display: inline-block;
+  padding: .375rem .75rem;
+  line-height: 1.5;
+  border-radius: .25rem;
+}
+
+a {
+  text-decoration: none;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: .5rem;
+}
+
+.grid-stack {
+  background: lightgoldenrodyellow;
+}
+
+.grid-stack-item-content {
+  color: #2c3e50;
+  text-align: center;
+  background-color: #18bc9c;
+}

--- a/demo/float.html
+++ b/demo/float.html
@@ -6,25 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Float grid demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
   </style>
 </head>
 <body>

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -6,41 +6,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Knockout.js demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">
     <h1>knockout.js Demo</h1>
-
     <div>
-      <button data-bind="click: addNewWidget">Add new widget</button>
+      <a class="btn btn-primary" data-bind="click: addNewWidget">Add Widget</a>
     </div>
-
     <br>
-
     <div data-bind="component: {name: 'dashboard-grid', params: $data}"></div>
   </div>
-
 
   <script type="text/javascript">
     ko.components.register('dashboard-grid', {

--- a/demo/knockout2.html
+++ b/demo/knockout2.html
@@ -6,41 +6,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Knockout.js demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">
     <h1>knockout.js Demo</h1>
-
     <div>
-      <button data-bind="click: addNewWidget">Add new widget</button>
+      <a class="btn btn-primary" data-bind="click: addNewWidget">Add Widget</a>
     </div>
-
     <br>
-
     <div data-bind="component: {name: 'dashboard-grid', params: $data}"></div>
   </div>
-
 
   <script type="text/javascript">
     ko.components.register('dashboard-grid', {

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -6,31 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Nested grids demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 
   <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-
     .grid-stack .grid-stack {
       /*margin: 0 -10px;*/
       background: rgba(255, 255, 255, 0.3);
     }
-
     .grid-stack .grid-stack .grid-stack-item-content {
       background: lightpink;
     }

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -6,27 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Responsive grid demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="device-xs visible-xs"></div>

--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -6,38 +6,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Right-To-Left (RTL) demo</title>
 
-  <!-- TODO Note: bootstrap 4.3.1 seem to prevent our h1 tag and button from right aligning, so use older for now... -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
+  <style type="text/css">
+    .grid-stack-item-content {
+      text-align: right; /* override demo.css */
+    }
+  </style>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">
     <h1>RTL Demo</h1>
-
     <div>
-      <button data-bind="click: addNewWidget">Add new widget</button>
+      <a class="btn btn-primary" data-bind="click: addNewWidget">Add Widget</a>
     </div>
-
     <br>
-
     <div data-bind="component: {name: 'dashboard-grid', params: $data}"></div>
   </div>
 

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -6,26 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Serialization demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../dist/gridstack.css"/>
+  <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">

--- a/demo/two.html
+++ b/demo/two.html
@@ -11,7 +11,6 @@
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../src/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>

--- a/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
+++ b/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
@@ -10,27 +10,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../../../dist/gridstack.css" />
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../../../src/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
 
   <style type="text/css">
-    .grid-stack {
-      margin-top: 10px;
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-
     .upper .grid-stack-item-content {
       background: blue;
     }
@@ -38,6 +25,7 @@
 </head>
 
 <body>
+  <br>
   <div class="grid-stack">
     <div class="grid-stack-item upper" data-gs-width="2" data-gs-height="2" data-gs-id="1">
       <div class="grid-stack-item-content">item 1</div>

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -6,27 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Many columns demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../../../dist/gridstack.css"/>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
   <link rel="stylesheet" href="810-many-columns.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../../../src/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">

--- a/spec/e2e/html/column.html
+++ b/spec/e2e/html/column.html
@@ -6,27 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Column grid demo</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../../../dist/gridstack.css"/>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
   <link rel="stylesheet" href="../../../dist/gridstack-extra.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../../../src/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">

--- a/spec/e2e/html/gridstack-with-height.html
+++ b/spec/e2e/html/gridstack-with-height.html
@@ -6,37 +6,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>gridstack.js tests</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../../../dist/gridstack.css"/>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
   <script src="../../../src/jquery-ui.min.js"></script>
   <script src="../../../dist/gridstack.js"></script>
   <script src="../../../dist/gridstack.jQueryUI.js"></script>
-
-  <style type="text/css">
-    .grid-stack {
-      background: lightgoldenrodyellow;
-    }
-
-    .grid-stack-item-content {
-      color: #2c3e50;
-      text-align: center;
-      background-color: #18bc9c;
-    }
-  </style>
 </head>
 <body>
   <div class="container-fluid">
     <h1>gridstack.js tests</h1>
-
     <br/>
-
     <div class="grid-stack" id="grid">
     </div>
   </div>
-
 
   <script type="text/javascript">
     $(function() {


### PR DESCRIPTION
### Description
* bootstrap .css and .js removed, other than two.html which uses column class
* added simple demo.css for shared button/grid styles (one place)

simplifies the includes a lot, focus on gridstack code

### Checklist
ran each demos