### PR TITLE
npm package fix to exclude more temporary content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 *.tgz
+*.zip
 .npmrc
 bower_components
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ yarn.lock
 .jscsrc
 .npmignore
 .travis.yml
+.eslint*
 Gruntfile.js
 ISSUE_TEMPLATE.md
 PULL_REQUEST_TEMPLATE.md
@@ -22,6 +23,7 @@ protractor.conf.js
 ## From .gitignore:
 *.log
 *.tgz
+*.zip
 bower_components
 coverage/
 node_modules/

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -26,7 +26,8 @@ Change log
 
 ## v0.5.4-dev (upcoming changes)
 
-- min files include rev number/license
+- min files include rev number/license [#1075](https://github.com/gridstack/gridstack.js/pull/1075)
+- npm package fix to exclude more temporary content
 
 ## v0.5.4 (2019-11-26)
 
@@ -36,7 +37,7 @@ Change log
 - add `jquery-ui.js` (and min.js) as minimal subset we need (55k vs 248k), which is now part of `gridstack.all.js`. Include individual parts if you need your own lib instead of all.js
 ([#1064](https://github.com/gridstack/gridstack.js/pull/1064)).
 - changed jquery dependency to lowest we can use (>=1.8) ([#629](https://github.com/gridstack/gridstack.js/issues/629)).
-- add advance demo from web site ([#1073](https://github.com/gridstack/gridstack.js/issues/1073)).
+- add advance demo from web site ([#1073](https://github.com/gridstack/gridstack.js/pull/1073)).
 
 ## v0.5.3 (2019-11-20)
 

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -265,9 +265,9 @@ interface GridStack {
    * (Experimental) Modify number of columns in the grid. Will attempt to update existing widgets
    * to conform to new number of columns. Requires `gridstack-extra.css` or `gridstack-extra.min.css`.
    * @param column - Integer between 1 and 12.
-   * @param doNotPropagate if true existing widgets will not be updated.
+   * @param doNotPropagate if true existing widgets will not be updated (optional) 
    */
-  setColumn(column: number, doNotPropagate: boolean): void;
+  setColumn(column: number, doNotPropagate ? : boolean): void;
 
   /**
    * Toggle the grid static state. Also toggle the grid-stack-static class.


### PR DESCRIPTION
need to verify before pushing new NPM images... had extra stuff in 0.5.4 (since it includes everything but listed skip items).