### PR TITLE
corrected the alphabetical order of options in doc

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -71,18 +71,18 @@ gridstack.js API
   * a string (ex: '10em', '100px', '10rem')
   * 0 or null, in which case the library will not generate styles for rows. Everything must be defined in CSS files.
   * `'auto'` - height will be calculated from cell width.
+- `column` - amount of columns (default: `12`)
 - `ddPlugin` - class that implement drag'n'drop functionallity for gridstack. If `false` grid will be static. (default: `null` - first available plugin will be used)
 - `disableDrag` - disallows dragging of widgets (default: `false`).
+- `disableOneColumnMode` - disables the onColumnMode when the window width is less than minWidth (default: 'false')
 - `disableResize` - disallows resizing of widgets (default: `false`).
 - `draggable` - allows to override jQuery UI draggable options. (default: `{handle: '.grid-stack-item-content', scroll: false, appendTo: 'body'}`)
+- `float` - enable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
 - `handle` - draggable handle selector (default: `'.grid-stack-item-content'`)
 - `handleClass` - draggable handle class (e.g. `'grid-stack-item-content'`). If set `handle` is ignored (default: `null`)
-- `column` - amount of columns (default: `12`)
-- `maxRow` - maximum rows amount. Default is `0` which means no maximum rows
-- `float` - enable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
 - `itemClass` - widget class (default: `'grid-stack-item'`)
+- `maxRow` - maximum rows amount. Default is `0` which means no maximum rows
 - `minWidth` - minimal width. If window width is less than or equal to, grid will be shown in one-column mode (default: `768`)
-- `disableOneColumnMode` - disables the onColumnMode when the window width is less than minWidth (default: 'false')
 - `oneColumnModeClass` - class set on grid when in one column mode (default: 'grid-stack-one-column-mode')
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)
 - `placeholderText` - placeholder default content (default: `''`)


### PR DESCRIPTION
### Description
Corrected the alphabetical order of options in doc.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
