### PR TITLE
add float(val?) set/get method

### DIFF
--- a/demo/float.html
+++ b/demo/float.html
@@ -19,6 +19,7 @@
     <h1>Float grid demo</h1>
     <div>
       <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
+      <a class="btn btn-primary" id="float" href="#">float: true</a>
     </div>
     <br><br>
     <div class="grid-stack"></div>
@@ -34,19 +35,16 @@
 
       new function () {
         this.items = [
-          {x: 0, y: 0, width: 2, height: 2},
+          {x: 0, y: 6, width: 2, height: 2},
           {x: 3, y: 1, width: 1, height: 2},
-          {x: 4, y: 1, width: 1, height: 1},
+          {x: 4, y: 2, width: 1, height: 1},
           {x: 2, y: 3, width: 3, height: 1},
-//          {x: 1, y: 4, width: 1, height: 1},
-//          {x: 1, y: 3, width: 1, height: 1},
-//          {x: 2, y: 4, width: 1, height: 1},
           {x: 2, y: 5, width: 1, height: 1}
         ];
 
         this.grid = $('.grid-stack').data('gridstack');
 
-        this.addNewWidget = function () {
+        this.addNewWidget = function() {
           var node = this.items.pop() || {
                 x: 12 * Math.random(),
                 y: 5 * Math.random(),
@@ -57,7 +55,13 @@
           return false;
         }.bind(this);
 
+        this.toggleFloat = function() {
+          this.grid.float(! this.grid.float());
+          $('#float').html('float: ' + this.grid.float());
+        }.bind(this);;
+
         $('#add-widget').click(this.addNewWidget);
+        $('#float').click(this.toggleFloat);
       };
     });
   </script>

--- a/demo/two.html
+++ b/demo/two.html
@@ -76,15 +76,17 @@
 
     <div class="row">
       <div class="col-md-6">
+        <a class="btn btn-primary" id="float1" href="#">float: false</a>
         <div class="grid-stack grid-stack-6" id="grid1">
         </div>
       </div>
       <div class="col-md-6">
+        <a class="btn btn-primary" id="float2" href="#">float: true</a>
         <div class="grid-stack grid-stack-6" id="grid2">
-        </div>
-      </div>
+          </div>
     </div>
   </div>
+</div>
 
 
   <script type="text/javascript">
@@ -124,6 +126,14 @@
         scroll: false,
         appendTo: 'body',
       });
+
+      $('#float1').click(function() { toggleFloat('#float1', '#grid1'); });
+      $('#float2').click(function() { toggleFloat('#float2', '#grid2'); });
+      function toggleFloat(button, grid) {
+        var grid = $(grid).data('gridstack');
+        grid.float(! grid.float());
+        $(button).html('float: ' + grid.float());
+      }
     });
   </script>
 </body>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -27,7 +27,7 @@ Change log
 
 ## v0.5.5-dev (upcoming changes)
 
-TBD
+- add `float(val)` to set/get the grid float mode
 
 ## v0.5.5 (2019-11-27)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,6 +32,7 @@ gridstack.js API
   - [enable()](#enable)
   - [enableMove(doEnable, includeNewWidgets)](#enablemovedoenable-includenewwidgets)
   - [enableResize(doEnable, includeNewWidgets)](#enableresizedoenable-includenewwidgets)
+  - [float(val?)](#floatval)
   - [getCellFromPixel(position[, useOffset])](#getcellfrompixelposition-useoffset)
   - [isAreaEmpty(x, y, width, height)](#isareaemptyx-y-width-height)
   - [locked(el, val)](#lockedel-val)
@@ -313,6 +314,12 @@ Enables/disables widget resizing. `includeNewWidgets` will force new widgets to 
 ```javascript
 grid.resizable(this.container.children('.' + this.opts.itemClass), doEnable);
 ```
+
+### float(val?)
+
+set/get floating widgets (default: `false`)
+
+- `val` - boolean to set true/false, else get the current value
 
 ### getCellFromPixel(position[, useOffset])
 

--- a/spec/gridstack-engine-spec.js
+++ b/spec/gridstack-engine-spec.js
@@ -83,7 +83,7 @@ describe('gridstack engine', function() {
     });
 
     beforeEach(function() {
-      engine._updateCounter = 0;
+      engine._batchMode = false;
     });
 
     it('should return all dirty nodes', function() {
@@ -94,8 +94,8 @@ describe('gridstack engine', function() {
       expect(nodes[1].idx).toEqual(2);
     });
 
-    it('should\'n clean nodes if _updateCounter > 0', function() {
-      engine._updateCounter = 1;
+    it('should\'n clean nodes if _batchMode true', function() {
+      engine._batchMode = true;
       engine.cleanNodes();
 
       expect(engine.getDirtyNodes().length).toBeGreaterThan(0);
@@ -118,11 +118,21 @@ describe('gridstack engine', function() {
     it('should work on not float grids', function() {
       expect(engine.float).toEqual(false);
       engine.batchUpdate();
-      expect(engine._updateCounter).toBeGreaterThan(0);
+      expect(engine._batchMode).toBeTrue();
       expect(engine.float).toEqual(true);
       engine.commit();
-      expect(engine._updateCounter).toEqual(0);
+      expect(engine._batchMode).toBeFalse();
       expect(engine.float).toEqual(false);
+    });
+
+    it('should work on float grids', function() {
+      engine.float = true;
+      engine.batchUpdate();
+      expect(engine._batchMode).toBeTrue();
+      expect(engine.float).toEqual(true);
+      engine.commit();
+      expect(engine._batchMode).toBeFalse();
+      expect(engine.float).toEqual(true);
     });
   });
 
@@ -136,10 +146,10 @@ describe('gridstack engine', function() {
     it('should work on float grids', function() {
       expect(engine.float).toEqual(true);
       engine.batchUpdate();
-      expect(engine._updateCounter).toBeGreaterThan(0);
+      expect(engine._batchMode).toBeTrue();
       expect(engine.float).toEqual(true);
       engine.commit();
-      expect(engine._updateCounter).toEqual(0);
+      expect(engine._batchMode).toBeFalse();
       expect(engine.float).toEqual(true);
     });
   });
@@ -163,8 +173,8 @@ describe('gridstack engine', function() {
       ];
     });
 
-    it('should\'n be called if _updateCounter > 0', function() {
-      engine._updateCounter = 1;
+    it('should\'n be called if _batchMode true', function() {
+      engine._batchMode = true;
       engine._notify();
 
       expect(spy.callback).not.toHaveBeenCalled();

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -143,6 +143,19 @@ interface GridStack {
   enableResize(doEnable: boolean, includeNewWidgets: boolean): void;
 
   /**
+   * enable/disable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
+   * @param mode 
+   */
+  float(mode: boolean): void;
+  
+  /**
+   * get the current float mode
+   */
+  float(): boolean;
+
+
+
+  /**
    * Get the position of the cell under a pixel on screen.
    * @param position the position of the pixel to resolve in
    * absolute coordinates, as an object with top and left properties
@@ -263,8 +276,9 @@ interface GridStack {
 
   /**
    * (Experimental) Modify number of columns in the grid. Will attempt to update existing widgets
-   * to conform to new number of columns. Requires `gridstack-extra.css` or `gridstack-extra.min.css`.
-   * @param column - Integer between 1 and 12.
+   * to conform to new number of columns. Requires `gridstack-extra.css` or `gridstack-extra.min.css` for [1-11],
+   * else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
+   * @param column - Integer > 0 (default 12).
    * @param doNotPropagate if true existing widgets will not be updated (optional) 
    */
   setColumn(column: number, doNotPropagate ? : boolean): void;


### PR DESCRIPTION
### Description
* add `float(val?)` set/get method to change the grid option, which will relayout widgets when gravity is back on
* renamed internal `_updateCounter` (number)  to `_batchMode` (boolean) was never a counter to begin with.
* float.html and two.html now has buttons to toggles mode

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
