### PR TITLE
fixed callbacks types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ Using gridstack.js with jQuery UI
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.min.css" />
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.all.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.all.js"></script>
 ```
 
 * Using CDN (debug):
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.css" />
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/jquery-ui.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.jQueryUI.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/jquery-ui.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.jQueryUI.js"></script>
 ```
 
 * or local:

--- a/demo/advance.html
+++ b/demo/advance.html
@@ -53,7 +53,7 @@
       </div>
     </div>
     <div class="col-sm-12 col-md-10">
-      <div class="grid-stack" id="advanced-grid" data-gs-width="12" data-gs-animate="yes">
+      <div class="grid-stack" id="advanced-grid" data-gs-animate="yes">
         <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2">
           <div class="grid-stack-item-content">1</div>
         </div>
@@ -105,7 +105,19 @@
 
   <script type="text/javascript">
     $(function () {
-      $('#advanced-grid').gridstack({
+      var $grid = $('#advanced-grid');
+      
+      $grid.on('added', function(e, items) { log(' added ', items) });
+      $grid.on('removed', function(e, items) { log(' removed ', items) });
+      $grid.on('change', function(e, items) { log(' change ', items) });
+      function log(type, items) {
+        if (!items) { return; }
+        var str = '';
+        for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
+        console.log(type + items.length + ' items.' + str );
+      }
+
+      $grid.gridstack({
         alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
           navigator.userAgent
         ),
@@ -116,6 +128,7 @@
         removeTimeout: 100,
         acceptWidgets: '.newWidget'
       });
+
       $('.newWidget').draggable({
         revert: 'invalid',
         scroll: false,

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -85,11 +85,13 @@
         this.grid = $('.grid-stack').data('gridstack');
 
         this.loadGrid = function () {
+          this.grid.batchUpdate();
           this.grid.removeAll();
           var items = GridStackUI.Utils.sort(this.serializedData);
           items.forEach(function (node, i) {
             this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), node);
           }.bind(this));
+          this.grid.commit();
           return false;
         }.bind(this);
 

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -27,9 +27,19 @@
 
   <script type="text/javascript">
     $(function () {
-      var options = {
-      };
-      $('.grid-stack').gridstack(options);
+      var $grid = $('.grid-stack');
+      
+      $grid.on('added', function(e, items) { log(' added ', items) });
+      $grid.on('removed', function(e, items) { log(' removed ', items) });
+      $grid.on('change', function(e, items) { log(' change ', items) });
+      function log(type, items) {
+        if (!items) { return; }
+        var str = '';
+        for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
+        console.log(type + items.length + ' items.' + str );
+      }
+
+      $grid.gridstack();
 
       new function () {
         this.serializedData = [
@@ -46,11 +56,13 @@
         this.grid = $('.grid-stack').data('gridstack');
 
         this.loadGrid = function () {
+          this.grid.batchUpdate();
           this.grid.removeAll();
           var items = GridStackUI.Utils.sort(this.serializedData);
           items.forEach(function (node) {
             this.grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), node);
           }, this);
+          this.grid.commit();
           return false;
         }.bind(this);
 

--- a/demo/two.html
+++ b/demo/two.html
@@ -81,10 +81,9 @@
         <a class="btn btn-primary" id="float2" href="#">float: true</a>
         <div class="grid-stack grid-stack-6" id="grid2">
           </div>
+      </div>
     </div>
   </div>
-</div>
-
 
   <script type="text/javascript">
     $(function () {
@@ -109,12 +108,24 @@
       ];
 
       $('.grid-stack').each(function () {
-        var grid = $(this).data('gridstack');
+        var $grid = $(this);
+        var id = $grid.attr('id');
+        $grid.on('added', function(e, items) { log(id, ' added ', items) });
+        $grid.on('removed', function(e, items) { log(id, ' removed ', items) });
+        $grid.on('change', function(e, items) { log(id, ' change ', items) });
+        function log(id, type, items) {
+          var str = '';
+          for (let i=0; i<items.length; i++ ) { str += ' (x,y)=' + items[i].x + ',' + items[i].y /*+ ' ' + items[i].width + 'x' + items[i].height*/ }
+          console.log(id + type + items.length + ' items.' + str );
+        }
 
+        var grid = $grid.data('gridstack');
+        grid.batchUpdate();
         items.forEach(function (node) {
           grid.addWidget($('<div><div class="grid-stack-item-content">' 
             + (node.text? node.text : '') + '</div></div>'), node);
         });
+        grid.commit();
       });
 
       $('.sidebar .grid-stack-item').draggable({

--- a/demo/two.html
+++ b/demo/two.html
@@ -114,8 +114,9 @@
         $grid.on('removed', function(e, items) { log(id, ' removed ', items) });
         $grid.on('change', function(e, items) { log(id, ' change ', items) });
         function log(id, type, items) {
+          if (!items) { return; }
           var str = '';
-          for (let i=0; i<items.length; i++ ) { str += ' (x,y)=' + items[i].x + ',' + items[i].y /*+ ' ' + items[i].width + 'x' + items[i].height*/ }
+          for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
           console.log(id + type + items.length + ' items.' + str );
         }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,6 +29,8 @@ Change log
 
 - add `float(val)` to set/get the grid float mode [#1088](https://github.com/gridstack/gridstack.js/pull/1088)
 - Allow percentage as a valid unit for height [#1093](https://github.com/gridstack/gridstack.js/pull/1093)
+- fixed callbacks to get either `added, removed, change` or combination if adding a node require also to change its (x,y) for example.
+Also you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).
 
 ## v0.5.5 (2019-11-27)
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -31,6 +31,7 @@ Change log
 - Allow percentage as a valid unit for height [#1093](https://github.com/gridstack/gridstack.js/pull/1093)
 - fixed callbacks to get either `added, removed, change` or combination if adding a node require also to change its (x,y) for example.
 Also you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).
+[#1096](https://github.com/gridstack/gridstack.js/pull/1096)
 
 ## v0.5.5 (2019-11-27)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -250,7 +250,7 @@ grid.addWidget(el, 0, 0, 3, 2, true);
 
 ### batchUpdate()
 
-Initializes batch updates. You will see no changes until `commit` method is called.
+starts batch updates. You will see no changes until `commit()` method is called.
 
 ### cellHeight()
 
@@ -271,7 +271,7 @@ Gets current cell width.
 
 ### commit()
 
-Finishes batch updates. Updates DOM nodes. You must call it after `batchUpdate`.
+Ends batch updates. Updates DOM nodes. You must call it after `batchUpdate()`.
 
 ### destroy([detachGrid])
 
@@ -355,7 +355,7 @@ Parameters:
 ```javascript
 $('.grid-stack').gridstack();
 
-$('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="1"></div>')
+$('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="true"></div>')
 var grid = $('.grid-stack').data('gridstack');
 grid.makeWidget('gsi-1');
 ```

--- a/spec/e2e/html/column.html
+++ b/spec/e2e/html/column.html
@@ -37,9 +37,11 @@
         {x: 2, y: 0, width: 2, height: 1},
         {x: 5, y: 0, width: 1, height: 1},
       ];
+      self.grid.batchUpdate();
       items.forEach(function (node, i) {
         self.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), node);
       });
+      self.grid.batchUpdate();
 
       $('#1column').click(function() { self.grid.setColumn(1); });
       $('#2column').click(function() { self.grid.setColumn(2); });

--- a/spec/e2e/html/gridstack-with-height.html
+++ b/spec/e2e/html/gridstack-with-height.html
@@ -35,6 +35,7 @@
         ];
 
         this.grid = $('.grid-stack').data('gridstack');
+        this.grid.batchUpdate();
         this.grid.removeAll();
         items = GridStackUI.Utils.sort(items);
         var id = 0;
@@ -43,6 +44,7 @@
           w.attr('id', 'item-' + (++id));
           this.grid.addWidget(w, node);
         }, this);
+        this.grid.commit();
       };
     });
   </script>

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -979,12 +979,13 @@ describe('gridstack', function() {
     afterEach(function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
-    it('should keep all widget options the same (autoPosition off)', function() {
+    it('should autoPosition (missing X,Y)', function() {
       $('.grid-stack').gridstack();
       var grid = $('.grid-stack').data('gridstack');
-      var widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
+      var widget = grid.addWidget(widgetHTML, {height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
+      expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
       expect($widget.attr('data-gs-auto-position')).toBe(undefined);
@@ -994,6 +995,55 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-max-height')).toBe(undefined);
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
+    it('should autoPosition (missing X)', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      var widget = grid.addWidget(widgetHTML, {y: 9, height: 2, id: 'optionWidget'});
+      var $widget = $(widget);
+      expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
+      expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
+      expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
+      expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
+      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-min-width')).toBe(undefined);
+      expect($widget.attr('data-gs-max-width')).toBe(undefined);
+      expect($widget.attr('data-gs-min-height')).toBe(undefined);
+      expect($widget.attr('data-gs-max-height')).toBe(undefined);
+      expect($widget.attr('data-gs-id')).toBe('optionWidget');
+    });
+    it('should autoPosition (missing Y)', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      var widget = grid.addWidget(widgetHTML, {x: 9, height: 2, id: 'optionWidget'});
+      var $widget = $(widget);
+      expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
+      expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
+      expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
+      expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
+      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-min-width')).toBe(undefined);
+      expect($widget.attr('data-gs-max-width')).toBe(undefined);
+      expect($widget.attr('data-gs-min-height')).toBe(undefined);
+      expect($widget.attr('data-gs-max-height')).toBe(undefined);
+      expect($widget.attr('data-gs-id')).toBe('optionWidget');
+    });
+    it('should not autoPosition (correct X, missing Y)', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      var widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
+      var $widget = $(widget);
+      expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
+      expect($widget.attr('data-gs-y')).toBe(undefined);
+      expect($widget.attr('data-gs-width')).toBe(undefined);
+      expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
+      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-min-width')).toBe(undefined);
+      expect($widget.attr('data-gs-max-width')).toBe(undefined);
+      expect($widget.attr('data-gs-min-height')).toBe(undefined);
+      expect($widget.attr('data-gs-max-height')).toBe(undefined);
+      expect($widget.attr('data-gs-id')).toBe('optionWidget');
+    });
+
   });
 
   describe('addWidget() with bad string value widget options', function() {

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -191,7 +191,7 @@ interface GridStack {
    * @example
    * $('.grid-stack').gridstack();
    * $('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2"
-   *                     data-gs-auto-position="1"></div>')
+   *                     data-gs-auto-position="true"></div>')
    * var grid = $('.grid-stack').data('gridstack');
    * grid.makeWidget('gsi-1');
    */

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -309,7 +309,7 @@
     if (this._batchMode) return;
     this._batchMode = true;
     this._prevFloat = this.float;
-    this.float = true;
+    this.float = true; // let things go anywhere for now... commit() will restore and possibly reposition
   };
 
   GridStackEngine.prototype.commit = function() {
@@ -379,9 +379,7 @@
       }, this);
     } else {
       this.nodes.forEach(function(n, i) {
-        if (n.locked) {
-          return;
-        }
+        if (n.locked) { return; }
         while (n.y > 0) {
           var newY = n.y - 1;
           var canBeMoved = i === 0;
@@ -393,10 +391,11 @@
             canBeMoved = collisionNode === undefined;
           }
 
-          if (!canBeMoved) {
-            break;
-          }
-          n._dirty = n.y !== newY;
+          if (!canBeMoved) { break; }
+          // Note: must be dirty (from last position) for GridStack::OnChange CB to update positions
+          // and move items back. The user 'change' CB should detect changes from the original
+          // starting position instead.
+          n._dirty = (n.y !== newY);
           n.y = newY;
         }
       }, this);
@@ -459,21 +458,17 @@
   };
 
   GridStackEngine.prototype._notify = function() {
+    if (this._batchMode) { return; }
     var args = Array.prototype.slice.call(arguments, 0);
     args[0] = args[0] === undefined ? [] : [args[0]];
     args[1] = args[1] === undefined ? true : args[1];
-    if (this._batchMode) {
-      return;
-    }
-    var deletedNodes = args[0].concat(this.getDirtyNodes());
-    this.onchange(deletedNodes, args[1]);
+    var dirtyNodes = args[0].concat(this.getDirtyNodes());
+    this.onchange(dirtyNodes, args[1]);
   };
 
   GridStackEngine.prototype.cleanNodes = function() {
-    if (this._batchMode) {
-      return;
-    }
-    this.nodes.forEach(function(n) { n._dirty = false; });
+    if (this._batchMode) { return; }
+    this.nodes.forEach(function(n) { delete n._dirty; });
   };
 
   GridStackEngine.prototype.getDirtyNodes = function() {
@@ -489,7 +484,7 @@
     if (node.minHeight !== undefined) { node.height = Math.max(node.height, node.minHeight); }
 
     node._id = ++idSeq;
-    node._dirty = true;
+    // node._dirty = true; will be addEvent instead
 
     if (node.autoPosition) {
       this._sortNodes();
@@ -501,6 +496,7 @@
           continue;
         }
         if (!this.nodes.find(Utils._isAddNodeIntercepted, {x: x, y: y, node: node})) {
+          node._dirty = (node.x !== x || node.y !== y);
           node.x = x;
           node.y = y;
           break;
@@ -510,7 +506,7 @@
 
     this.nodes.push(node);
     if (triggerAddEvent) {
-      this._addedNodes.push(Utils.clone(node));
+      this._addedNodes.push(node);
     }
 
     this._fixCollisions(node);
@@ -645,19 +641,16 @@
   };
 
   GridStackEngine.prototype.beginUpdate = function(node) {
-    this.nodes.forEach(function(n) {
-      n._origY = n.y;
-    });
+    if (node._updating) return;
     node._updating = true;
+    this.nodes.forEach(function(n) { n._origY = n.y; });
   };
 
   GridStackEngine.prototype.endUpdate = function() {
-    this.nodes.forEach(function(n) {
-      n._origY = n.y;
-    });
     var n = this.nodes.find(function(n) { return n._updating; });
     if (n) {
       n._updating = false;
+      this.nodes.forEach(function(n) { delete n._origY; });
     }
   };
 
@@ -1036,21 +1029,25 @@
   };
 
   GridStack.prototype._triggerChangeEvent = function(forceTrigger) {
+    if (this.grid._batchMode) { return; }
+    // TODO: compare original X,Y,W,H (or entire node?) instead as _dirty can be a temporary state
     var elements = this.grid.getDirtyNodes();
     var hasChanges = false;
 
-    var eventParams = [];
+    var eventParams = []; // eventParams[0] has to be the list of items...
     if (elements && elements.length) {
-      eventParams.push(elements);
+      eventParams[0] = elements;
       hasChanges = true;
     }
 
     if (hasChanges || forceTrigger === true) {
       this.container.trigger('change', eventParams);
+      this.grid.cleanNodes(); // clear dirty flags now that we called
     }
   };
 
   GridStack.prototype._triggerAddEvent = function() {
+    if (this.grid._batchMode) { return; }
     if (this.grid._addedNodes && this.grid._addedNodes.length > 0) {
       this.container.trigger('added', [this.grid._addedNodes.map(Utils.clone)]);
       this.grid._addedNodes = [];
@@ -1058,6 +1055,7 @@
   };
 
   GridStack.prototype._triggerRemoveEvent = function() {
+    if (this.grid._batchMode) { return; }
     if (this.grid._removedNodes && this.grid._removedNodes.length > 0) {
       this.container.trigger('removed', [this.grid._removedNodes.map(Utils.clone)]);
       this.grid._removedNodes = [];
@@ -1145,9 +1143,7 @@
   };
 
   GridStack.prototype._updateContainerHeight = function() {
-    if (this.grid._batchMode) {
-      return;
-    }
+    if (this.grid._batchMode) { return; }
     var height = this.grid.getGridHeight();
     // check for css min height. Each row is cellHeight + verticalMargin, until last one which has no margin below
     var cssMinHeight = parseInt(this.container.css('min-height'));
@@ -1436,30 +1432,37 @@
     }
   };
 
-  GridStack.prototype.addWidget = function(el, x, y, width, height, autoPosition, minWidth, maxWidth, minHeight, maxHeight, id) {
+  GridStack.prototype.addWidget = function(el, node, y, width, height, autoPosition, minWidth, maxWidth, minHeight, maxHeight, id) {
 
-    // instead of passing all the params, the user might pass an object with all fields instead, if so extract them and call us back
-    if (x !== null && typeof x === 'object') {
-      return this.addWidget(el, x.x, x.y, x.width, x.height, x.autoPosition, x.minWidth, x.maxWidth, x.minHeight, x.maxHeight, x.id);
+    // new way of calling with an object - make sure all items have been properly initialized
+    if (node === undefined || typeof node === 'object') {
+      // Tempting to initialize the passed in node with default and valid values, but this break knockout demos
+      // as the actual value are filled in when _prepareElement() calls el.attr('data-gs-xyz) before adding the node.
+      // node = this.grid._prepareNode(node);
+      node = node || {};
+    } else {
+      // old legacy way of calling with items spelled out - call us back with single object instead (so we can properly initialized values)
+      return this.addWidget(el, {x: node, y: y, width: width, height: height, autoPosition: autoPosition,
+        minWidth: minWidth, maxWidth: maxWidth, minHeight: minHeight, maxHeight: maxHeight, id: id});
     }
 
     el = $(el);
     // Note: passing null removes the attr in jquery
-    if (x !== undefined) { el.attr('data-gs-x', x); }
-    if (y !== undefined) { el.attr('data-gs-y', y); }
-    if (width !== undefined) { el.attr('data-gs-width', width); }
-    if (height !== undefined) { el.attr('data-gs-height', height); }
-    if (autoPosition !== undefined) { el.attr('data-gs-auto-position', autoPosition ? 'yes' : null); }
-    if (minWidth !== undefined) { el.attr('data-gs-min-width', minWidth); }
-    if (maxWidth !== undefined) { el.attr('data-gs-max-width', maxWidth); }
-    if (minHeight !== undefined) { el.attr('data-gs-min-height', minHeight); }
-    if (maxHeight !== undefined) { el.attr('data-gs-max-height', maxHeight); }
-    if (id !== undefined) { el.attr('data-gs-id', id); }
+    if (node.x !== undefined) { el.attr('data-gs-x', node.x); }
+    if (node.y !== undefined) { el.attr('data-gs-y', node.y); }
+    if (node.width !== undefined) { el.attr('data-gs-width', node.width); }
+    if (node.height !== undefined) { el.attr('data-gs-height', node.height); }
+    if (node.autoPosition !== undefined) { el.attr('data-gs-auto-position', node.autoPosition ? true : null); }
+    if (node.minWidth !== undefined) { el.attr('data-gs-min-width', node.minWidth); }
+    if (node.maxWidth !== undefined) { el.attr('data-gs-max-width', node.maxWidth); }
+    if (node.minHeight !== undefined) { el.attr('data-gs-min-height', node.minHeight); }
+    if (node.maxHeight !== undefined) { el.attr('data-gs-max-height', node.maxHeight); }
+    if (node.id !== undefined) { el.attr('data-gs-id', node.id); }
     this.container.append(el);
     this._prepareElement(el, true);
-    this._triggerAddEvent();
     this._updateContainerHeight();
-    this._triggerChangeEvent(true);
+    this._triggerAddEvent();
+    // this._triggerChangeEvent(true); already have AddEvent
 
     return el;
   };
@@ -1467,9 +1470,9 @@
   GridStack.prototype.makeWidget = function(el) {
     el = $(el);
     this._prepareElement(el, true);
-    this._triggerAddEvent();
     this._updateContainerHeight();
-    this._triggerChangeEvent(true);
+    this._triggerAddEvent();
+    // this._triggerChangeEvent(true); already have AddEvent
 
     return el;
   };
@@ -1495,8 +1498,8 @@
     if (detachNode) {
       el.remove();
     }
-    this._triggerChangeEvent(true);
     this._triggerRemoveEvent();
+    // this._triggerChangeEvent(true); already have removeEvent
   };
 
   GridStack.prototype.removeAll = function(detachNode) {
@@ -1767,6 +1770,9 @@
   GridStack.prototype.commit = function() {
     this.grid.commit();
     this._updateContainerHeight();
+    this._triggerAddEvent();
+    this._triggerRemoveEvent();
+    this._triggerChangeEvent();
   };
 
   GridStack.prototype.isAreaEmpty = function(x, y, width, height) {
@@ -1792,14 +1798,14 @@
 
   GridStack.prototype._updateNodeWidths = function(oldWidth, newWidth) {
     this.grid._sortNodes();
-    this.grid.batchUpdate();
+    this.batchUpdate();
     var node = {};
     for (var i = 0; i < this.grid.nodes.length; i++) {
       node = this.grid.nodes[i];
       this.update(node.el, Math.round(node.x * newWidth / oldWidth), undefined,
         Math.round(node.width * newWidth / oldWidth), undefined);
     }
-    this.grid.commit();
+    this.commit();
   };
 
   GridStack.prototype.setColumn = function(column, doNotPropagate) {


### PR DESCRIPTION
### Description
* fixed callbacks to get either `added, removed, change` or combination if adding a node require also to change its (x,y) for example
(we use to always get 'change' duplicated callback)
* you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).
* update two.hml to show callbacks (good debuging setup)
Note: moving items in float=false will still sometimes have change CB with all items, not just those that moved. this is due to how _fixCollisions() does this
`
if (!this.float && !hasLocked) {
  nn = {x: 0, y: node.y, width: this.column, height: node.height};
}`
causing all items to temporarly move. I don't claim to understand that code yet...
* added a comment for #789 as to why _packNodes() can't check for
`n._dirty = n._origY != newY;`
* pass the original nodes for addEvent/removeEvent instead of clones
* _triggerChangeEvent() no longer forced called (with no data, what's the point ?)
* commit() calls remove, added, change in that order
* updated more samples - use batch calls
(the difference in callbacks noise of 0.5.5 vs this code is UDGE for serialize.html as an example)
* fixed error when dragging add item over the trash, and then over second grid

### Test
best way to test how much better the callback noise is vs before is to run the local
serialize.html copy with these changes. First use
`<script src="https://cdn.jsdelivr.net/npm/gridstack@0.5.5/dist/gridstack.all.js"></script>`
then the fixed lib code.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
