### PR TITLE
much faster removeAll(), single event trigger

### DIFF
--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -85,9 +85,9 @@
         this.grid = $('.grid-stack').data('gridstack');
 
         this.loadGrid = function () {
-          this.grid.batchUpdate();
           this.grid.removeAll();
           var items = GridStackUI.Utils.sort(this.serializedData);
+          this.grid.batchUpdate();
           items.forEach(function (node, i) {
             this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), node);
           }.bind(this));

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -56,9 +56,9 @@
         this.grid = $('.grid-stack').data('gridstack');
 
         this.loadGrid = function () {
-          this.grid.batchUpdate();
           this.grid.removeAll();
           var items = GridStackUI.Utils.sort(this.serializedData);
+          this.grid.batchUpdate();
           items.forEach(function (node) {
             this.grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), node);
           }, this);

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -32,6 +32,7 @@ Change log
 - fixed callbacks to get either `added, removed, change` or combination if adding a node require also to change its (x,y) for example.
 Also you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).
 [#1096](https://github.com/gridstack/gridstack.js/pull/1096)
+- `removeAll()` is now much faster (no relayout) and calls `removed` event just once with a list
 
 ## v0.5.5 (2019-11-27)
 

--- a/spec/e2e/html/gridstack-with-height.html
+++ b/spec/e2e/html/gridstack-with-height.html
@@ -35,10 +35,10 @@
         ];
 
         this.grid = $('.grid-stack').data('gridstack');
-        this.grid.batchUpdate();
         this.grid.removeAll();
         items = GridStackUI.Utils.sort(items);
         var id = 0;
+        this.grid.batchUpdate();
         items.forEach(function(node) {
           var w = $('<div><div class="grid-stack-item-content"></div></div>');
           w.attr('id', 'item-' + (++id));

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -7,10 +7,10 @@ describe('gridstack', function() {
   var gridstackHTML =
     '<div style="width: 992px; height: 800px" id="gs-cont">' +
     '  <div class="grid-stack">' +
-    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2">' +
+    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2" id="item1">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
-    '    <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4">' +
+    '    <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4" id="item2">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
     '  </div>' +
@@ -454,6 +454,36 @@ describe('gridstack', function() {
       var grid = $('.grid-stack').data('gridstack');
       var shouldBeTrue = grid.isAreaEmpty(5, 5, 1, 1);
       expect(shouldBeTrue).toBe(true);
+    });
+  });
+
+  describe('grid.removeAll', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should remove all children by default', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      grid.removeAll();
+      expect(grid.grid.nodes).toEqual([]);
+      expect(document.getElementById('item1')).toBe(null);
+    });
+    it('should remove all children', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      grid.removeAll(true);
+      expect(grid.grid.nodes).toEqual([]);
+      expect(document.getElementById('item1')).toBe(null);
+    });
+    it('should remove gridstack part, leave DOM behind', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      grid.removeAll(false);
+      expect(grid.grid.nodes).toEqual([]);
+      expect(document.getElementById('item1')).not.toBe(null);
     });
   });
 

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -16,7 +16,7 @@ describe('gridstack', function() {
     '  </div>' +
     '</div>';
   // generic widget with no param
-  var widgetHTML = '<div class="grid-stack-item"><div class="grid-stack-item-content"> hello </div></div>';
+  var widgetHTML = '<div class="grid-stack-item" id="item3"><div class="grid-stack-item-content"> hello </div></div>';
 
   beforeEach(function() {
     w = window;
@@ -484,6 +484,38 @@ describe('gridstack', function() {
       grid.removeAll(false);
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).not.toBe(null);
+    });
+  });
+
+  describe('grid.removeWidget', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should remove first item (default), then second (true), then third (false)', function() {
+      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').data('gridstack');
+      expect(grid.grid.nodes.length).toEqual(2);
+
+      var el1 = document.getElementById('item1');
+      expect(el1).not.toBe(null);
+      grid.removeWidget(el1);
+      expect(grid.grid.nodes.length).toEqual(1);
+      expect(document.getElementById('item1')).toBe(null);
+      expect(document.getElementById('item2')).not.toBe(null);
+
+      var el2 = document.getElementById('item2');
+      grid.removeWidget(el2, true);
+      expect(grid.grid.nodes.length).toEqual(0);
+      expect(document.getElementById('item2')).toBe(null);
+
+      var el3 = grid.addWidget(widgetHTML);
+      expect(el3).not.toBe(null);
+      grid.removeWidget(el3, false);
+      expect(grid.grid.nodes.length).toEqual(0);
+      expect(document.getElementById('item3')).not.toBe(null);
     });
   });
 


### PR DESCRIPTION
### Description
* `removeAll()` is now much faster as it doesn't cause any relayout (added GridStackEngine.removeAll to optimize)
* it now calls `removed` event back just once with a list of nodes
* _removedNodes uses actual nodes (not clones)

better fix than #551, related to previous #1096

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
