### PR TITLE
new compact() method, improved setColumn()

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -48,30 +48,30 @@
       }
 
       var items = [
-        {x: 0, y: 4, width: 12, height: 1},
-        {x: 5, y: 3, width: 2, height: 1},
-        {x: 1, y: 3, width: 4, height: 1},
-        {x: 0, y: 0, width: 1, height: 1},
-        {}, // autoPosition testing
-        {x: 5, y: 0, width: 1, height: 1},
+        {x: 0, y: 0, width: 2, height: 2},
         {x: 2, y: 0, width: 2, height: 1},
-        {x: 0, y: 0, width: 2, height: 2}
+        {x: 5, y: 0, width: 1, height: 1},
+        {text: ' auto'}, // autoPosition testing
+        {x: 1, y: 3, width: 4, height: 1},
+        {x: 5, y: 3, width: 2, height: 1},
+        {x: 0, y: 4, width: 12, height: 1}
       ];
       var count = 0;
       grid.batchUpdate();
       for (count=0; count<3; count++) {
-        grid.addWidget($('<div><div class="grid-stack-item-content">' + count + '</div></div>'), items.pop());
+        var n = items[count];
+        grid.addWidget($('<div><div class="grid-stack-item-content">' + count + (n.text ? n.text : '') + '</div></div>'), n);
       };
       grid.commit();
 
       $('#add-widget').click(function() {
-        var node = items.pop() || {
+        var n = items[count++] || {
           x: Math.round(12 * Math.random()),
           y: Math.round(5 * Math.random()),
           width: Math.round(1 + 3 * Math.random()),
           height: Math.round(1 + 3 * Math.random())
         };
-        grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + '</div></div>'), node);
+        grid.addWidget($('<div><div class="grid-stack-item-content">' + count + (n.text ? n.text : '') + '</div></div>'), n);
       });
 
       $('#1column').click(function() { grid.setColumn(1); });

--- a/demo/two.html
+++ b/demo/two.html
@@ -74,11 +74,13 @@
     <div class="row">
       <div class="col-md-6">
         <a class="btn btn-primary" id="float1" href="#">float: false</a>
+        <a class="btn btn-primary" id="compact1" href="#">Compact</a>
         <div class="grid-stack grid-stack-6" id="grid1">
         </div>
       </div>
       <div class="col-md-6">
         <a class="btn btn-primary" id="float2" href="#">float: true</a>
+        <a class="btn btn-primary" id="compact2" href="#">Compact</a>
         <div class="grid-stack grid-stack-6" id="grid2">
           </div>
       </div>
@@ -136,13 +138,21 @@
         appendTo: 'body',
       });
 
-      $('#float1').click(function() { toggleFloat('#float1', '#grid1'); });
-      $('#float2').click(function() { toggleFloat('#float2', '#grid2'); });
+      $('#float1').click(function() { toggleFloat('#float1', '#grid1') });
+      $('#float2').click(function() { toggleFloat('#float2', '#grid2') });
       function toggleFloat(button, grid) {
         var grid = $(grid).data('gridstack');
         grid.float(! grid.float());
         $(button).html('float: ' + grid.float());
       }
+
+      $('#compact1').click(function() { compact('#grid1') });
+      $('#compact2').click(function() { compact('#grid2') });
+      function compact(grid) {
+        var grid = $(grid).data('gridstack');
+        grid.compact();
+      }
+
     });
   </script>
 </body>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,6 +28,7 @@ Change log
 ## v0.5.5-dev (upcoming changes)
 
 - add `float(val)` to set/get the grid float mode [#1088](https://github.com/gridstack/gridstack.js/pull/1088)
+- add `compact()` relayout grid items to reclaim any empty space [#1101](https://github.com/gridstack/gridstack.js/pull/1101)
 - Allow percentage as a valid unit for height [#1093](https://github.com/gridstack/gridstack.js/pull/1093)
 - fixed callbacks to get either `added, removed, change` or combination if adding a node require also to change its (x,y) for example.
 Also you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).

--- a/doc/README.md
+++ b/doc/README.md
@@ -23,6 +23,7 @@ gridstack.js API
   - [addWidget(el, [options])](#addwidgetel-options)
   - [addWidget(el, [x, y, width, height, autoPosition, minWidth, maxWidth, minHeight, maxHeight, id])](#addwidgetel-x-y-width-height-autoposition-minwidth-maxwidth-minheight-maxheight-id)
   - [batchUpdate()](#batchupdate)
+  - [compact()](#compact)
   - [cellHeight()](#cellheight)
   - [cellHeight(val, noUpdate)](#cellheightval-noupdate)
   - [cellWidth()](#cellwidth)
@@ -251,6 +252,10 @@ grid.addWidget(el, 0, 0, 3, 2, true);
 ### batchUpdate()
 
 starts batch updates. You will see no changes until `commit()` method is called.
+
+### compact()
+
+relayout grid items to reclaim any empty space.
 
 ### cellHeight()
 

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -276,7 +276,7 @@ describe('gridstack', function() {
     });
   });
 
-  describe('grid.column', function() {
+  describe('grid.setColumn', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
     });
@@ -341,7 +341,7 @@ describe('gridstack', function() {
       expect(node2.width).toBe(4);
       expect(node2.height).toBe(4);
       
-      // one column will have item1, item2
+      // 1 column will have item1, item2
       grid.setColumn(1);
       node1 = $('#item1').data('_gridstack_node');
       node2 = $('#item2').data('_gridstack_node');
@@ -365,6 +365,27 @@ describe('gridstack', function() {
       expect(node3.width).toBe(1);
       expect(node3.height).toBe(1);
 
+      // 2 column will have item1, item2, item3 in 1 column still
+      grid.setColumn(2);
+      node1 = $('#item1').data('_gridstack_node');
+      node2 = $('#item2').data('_gridstack_node');
+      node3 = $('#item3').data('_gridstack_node');
+      expect(grid.opts.column).toBe(2);
+      expect(node1.x).toBe(0);
+      expect(node1.y).toBe(0);
+      expect(node1.width).toBe(1);
+      expect(node1.height).toBe(2);
+
+      expect(node2.x).toBe(1);
+      expect(node2.y).toBe(0);
+      expect(node2.width).toBe(1);
+      expect(node2.height).toBe(4);
+
+      expect(node3.x).toBe(0);
+      expect(node3.y).toBe(6);
+      expect(node3.width).toBe(1); // ??? could stay at 1 or take entire width still ?
+      expect(node3.height).toBe(1);      
+
       // back to 12 column and initial layout (other than new item3)
       grid.setColumn(12);
       expect(grid.opts.column).toBe(12);
@@ -383,7 +404,7 @@ describe('gridstack', function() {
 
       expect(node3.x).toBe(0);
       expect(node3.y).toBe(6);
-      expect(node3.width).toBe(12); // take entire row still
+      expect(node3.width).toBe(6); // ??? could 6 or taken entire width if it did above
       expect(node3.height).toBe(1);
     });
   });

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -1251,4 +1251,38 @@ describe('gridstack', function() {
       }
     });
   });
+
+  describe('grid.compact', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should move all 3 items to top-left with no space', function() {
+      $('.grid-stack').gridstack({float: true});
+      var grid = $('.grid-stack').data('gridstack');
+
+      var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5});
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
+
+      grid.compact();
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(8);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
+    });
+    it('not move locked item', function() {
+      $('.grid-stack').gridstack({float: true});
+      var grid = $('.grid-stack').data('gridstack');
+
+      var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true});
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
+
+      grid.compact();
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
+    });
+
+  });
 });

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -97,6 +97,11 @@ interface GridStack {
   commit(): void;
 
   /**
+   * relayout grid items to reclaim any empty space
+   */
+  compact(): void;
+
+  /**
    * Destroys a grid instance.
    * @param detachGrid if false nodes and grid will not be removed from the DOM (Optional. Default true).
    */


### PR DESCRIPTION
### Description
new compact() method
* relayout grid items to reclaim any empty space
* update two.html demo to have a compact button, and test case

also (separate PR)
tweaks to setColumn()

* improved code, now using gridEngine.addNode() instead of removeAll() + addWidget() which is much lighter now
* use a higher res layout when going up and cache is missing
(better to down-sample say from 12 then up-sample from 1!)

#1098 part 2

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
