### PR TITLE
OneColumnMode use setColumn(1)

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,7 +28,8 @@ Change log
 
 ## v0.6.0-dev (upcoming changes)
 
-- TBD
+- one column mode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore). This gives
+us full resize/re-order of items capabilities rathern than a locked CSS only layout (see prev rev changes).
 
 ## v0.6.0 (2019-12-24)
 

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -484,7 +484,7 @@ interface GridstackOptions {
   itemClass ? : string;
 
   /**
-   * minimal width. If window width is less, grid will be shown in one - column mode (default?: 768)
+   * minimal width. If window width is less, grid will be shown in one column mode (default?: 768)
    */
   minWidth ? : number;
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -129,18 +129,4 @@ $animation_speed: .3s !default;
   &.grid-stack-animate .grid-stack-item.grid-stack-placeholder{
     @include vendor(transition, left .0s, top .0s, height .0s, width .0s);
   }
-  
-  &.grid-stack-one-column-mode {
-    height: auto !important;
-    &> .grid-stack-item {
-      position: relative !important;
-      width: auto !important;
-      left: 0 !important;
-      top: auto !important;
-      margin-bottom: $vertical_padding;
-      max-width: none !important;
-
-      &> .ui-resizable-handle { display: none; }
-    }
-  }
 }


### PR DESCRIPTION
### Description
* one column mode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore).
* This gives us full resize/re-order of items capabilities rather than a locked CSS only layout (see prev rev changes).
* continuation of #1098, will affect #966 as well

* NEXT: fix responsive.html which has been broken for a while.

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
