### PR TITLE
oneColumnMode bug fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,11 +29,11 @@ Change log
 
 ## v0.6.1-dev (upcoming changes)
 
-- TBD
+- fix oneColumnMode to only restore if we auto went to it as window sizes up [#1125](https://github.com/gridstack/gridstack.js/pull/1125)
 
 ## v0.6.1 (2020-02-02)
 
-- one column mode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore). This gives
+- fix [#37](https://github.com/gridstack/gridstack.js/issues/37) oneColumnMode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore). This gives
 us full resize/re-order of items capabilities rather than a locked CSS only layout (see prev rev changes). [#1120](https://github.com/gridstack/gridstack.js/pull/1120)
 - fixed responsive.html demo [#1121](https://github.com/gridstack/gridstack.js/pull/1121)
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -666,7 +666,7 @@
 
   var GridStack = function(el, opts) {
     var self = this;
-    var oneColumnAutoMode, _prevColumn, isAutoCellHeight;
+    var oneColumnMode, _prevColumn, isAutoCellHeight;
 
     opts = opts || {};
 
@@ -826,16 +826,16 @@
       if (self.opts.staticGrid) { return; }
 
       if (!self.opts.disableOneColumnMode && (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= self.opts.minWidth) {
-        if (self.oneColumnAutoMode) {  return; }
+        if (self.oneColumnMode) {  return; }
 
         self.container.addClass(self.opts.oneColumnModeClass); // TODO: legacy do people still depend on style being there ?
-        self.oneColumnAutoMode = true;
+        self.oneColumnMode = true;
         self.setColumn(1);
       } else {
-        if (!self.oneColumnAutoMode) { return; }
+        if (!self.oneColumnMode) { return; }
 
         self.container.removeClass(self.opts.oneColumnModeClass);
-        self.oneColumnAutoMode = false;
+        self.oneColumnMode = false;
         self.setColumn(self._prevColumn);
       }
     };

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -666,7 +666,7 @@
 
   var GridStack = function(el, opts) {
     var self = this;
-    var _prevColumn, isAutoCellHeight;
+    var oneColumnAutoMode, _prevColumn, isAutoCellHeight;
 
     opts = opts || {};
 
@@ -823,17 +823,19 @@
         self._updateHeightsOnResize();
       }
 
-      var oneColumnWidth = (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= self.opts.minWidth;
+      if (self.opts.staticGrid) { return; }
 
-      if (oneColumnWidth && !self.opts.disableOneColumnMode) {
-        if (self._prevColumn || self.opts.staticGrid) {  return; }
+      if (!self.opts.disableOneColumnMode && (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= self.opts.minWidth) {
+        if (self.oneColumnAutoMode) {  return; }
 
         self.container.addClass(self.opts.oneColumnModeClass); // TODO: legacy do people still depend on style being there ?
+        self.oneColumnAutoMode = true;
         self.setColumn(1);
       } else {
-        if (!self._prevColumn || self.opts.staticGrid) { return; }
+        if (!self.oneColumnAutoMode) { return; }
 
         self.container.removeClass(self.opts.oneColumnModeClass);
+        self.oneColumnAutoMode = false;
         self.setColumn(self._prevColumn);
       }
     };


### PR DESCRIPTION
### Description
* window resize only need to restor back to non oneColumn if we auto went into 1 column (as opposed to user calling setColumn(1) in a large window)
* this was causing column.html editing in 1 column to jump back to 12.
* introduced by my last change #1120

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
