### PR TITLE
Custom Responsive Sort Order

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -22,6 +22,7 @@
     <div>
       <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
       <a class="btn btn-primary" id="1column" href="#">1 Column</a>
+      <a class="btn btn-primary" id="1columnDOM" href="#">1 Column DOM</a>
       <a class="btn btn-primary" id="2column" href="#">2 Column</a>
       <a class="btn btn-primary" id="3column" href="#">3 Column</a>
       <a class="btn btn-primary" id="4column" href="#">4 Column</a>
@@ -54,15 +55,15 @@
       var items = [
         {x: 0, y: 0, width: 2, height: 2},
         {x: 2, y: 0, width: 2, height: 1},
-        {x: 5, y: 0, width: 1, height: 1},
+        {x: 5, y: 1, width: 1, height: 1},
+        {x: 5, y: 0, width: 2, height: 1},
         {text: ' auto'}, // autoPosition testing
-        {x: 1, y: 3, width: 4, height: 1},
         {x: 5, y: 3, width: 2, height: 1},
         {x: 0, y: 4, width: 12, height: 1}
       ];
       var count = 0;
       grid.batchUpdate();
-      for (count=0; count<3;) {
+      for (count=0; count<4;) {
         var n = items[count];
         grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + (n.text ? n.text : '') + '</div></div>'), n);
       };
@@ -78,7 +79,8 @@
         grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + (n.text ? n.text : '') + '</div></div>'), n);
       });
 
-      $('#1column').click(function() { grid.setColumn(1); $text.text(1);});
+      $('#1column').click(function() { delete grid.opts.oneColumnModeDomSort; grid.setColumn(1); $text.text(1);});
+      $('#1columnDOM').click(function() { grid.opts.oneColumnModeDomSort = true; grid.setColumn(1); $text.text('1 DOM');});
       $('#2column').click(function() { grid.setColumn(2); $text.text(2);});
       $('#3column').click(function() { grid.setColumn(3); $text.text(3);});
       $('#4column').click(function() { grid.setColumn(4); $text.text(4);});

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,6 +29,7 @@ Change log
 
 ## v0.6.1-dev (upcoming changes)
 
+- add `oneColumnModeDomSort` true|false to let you specify a custom layout (use dom order instead of x,y) for oneColumnMode `setColumn(1)` [#713](https://github.com/gridstack/gridstack.js/issues/713)
 - fix oneColumnMode to only restore if we auto went to it as window sizes up [#1125](https://github.com/gridstack/gridstack.js/pull/1125)
 
 ## v0.6.1 (2020-02-02)

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -15,6 +15,12 @@ describe('gridstack', function() {
     '    </div>' +
     '  </div>' +
     '</div>';
+  // empty grid
+  var gridstackEmptyHTML =
+    '<div style="width: 992px; height: 800px" id="gs-cont">' +
+    '  <div class="grid-stack">' +
+    '  </div>' +
+    '</div>';
   // generic widget with no param
   var widgetHTML = '<div class="grid-stack-item" id="item3"><div class="grid-stack-item-content"> hello </div></div>';
 
@@ -438,6 +444,104 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-y'))).toBe(3);
       expect(parseInt(el2.attr('data-gs-width'))).toBe(1);
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
+    });
+  });
+
+  describe('oneColumnModeDomSort', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackEmptyHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should support default going to 1 column', function() {
+      var options = {
+        column: 12,
+        float: true
+      };
+      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').data('gridstack');
+      var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
+      var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
+      var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
+
+      // items are item1[1x1], item3[1x1], item2[2x1]
+      expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el1.attr('data-gs-height'))).toBe(1);
+
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-height'))).toBe(2);
+
+      expect(parseInt(el2.attr('data-gs-x'))).toBe(2);
+      expect(parseInt(el2.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el2.attr('data-gs-width'))).toBe(2);
+      expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
+
+      // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
+      grid.setColumn(1);
+      expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el1.attr('data-gs-height'))).toBe(1);
+
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-height'))).toBe(2);
+
+      expect(parseInt(el2.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el2.attr('data-gs-y'))).toBe(3);
+      expect(parseInt(el2.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
+    });
+    it('should support oneColumnModeDomSort ON going to 1 column', function() {
+      var options = {
+        column: 12,
+        oneColumnModeDomSort: true,
+        float: true
+      };
+      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').data('gridstack');
+      var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
+      var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
+      var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
+
+      // items are item1[1x1], item3[1x1], item2[2x1]
+      expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el1.attr('data-gs-height'))).toBe(1);
+
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-height'))).toBe(2);
+
+      expect(parseInt(el2.attr('data-gs-x'))).toBe(2);
+      expect(parseInt(el2.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el2.attr('data-gs-width'))).toBe(2);
+      expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
+
+      // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
+      grid.setColumn(1);
+      expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
+      expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el1.attr('data-gs-height'))).toBe(1);
+
+      expect(parseInt(el2.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el2.attr('data-gs-y'))).toBe(1);
+      expect(parseInt(el2.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
+
+      expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
+      expect(parseInt(el3.attr('data-gs-y'))).toBe(2);
+      expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
+      expect(parseInt(el3.attr('data-gs-height'))).toBe(2);
     });
   });
 

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -497,6 +497,12 @@ interface GridstackOptions {
   oneColumnModeClass ? : string;
 
   /**
+   * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column 
+   * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
+   */
+  oneColumnModeDomSort?: boolean;
+
+  /**
    * class for placeholder (default?: 'grid-stack-placeholder')
    */
   placeholderClass ? : string;


### PR DESCRIPTION
### Description
* add `oneColumnModeDomSort` true|false to let you specify a custom layout (use dom order instead of x,y) for oneColumnMode `setColumn(1)`
* fix for #713
* better than PR #966 which attempted to make a generic support for oneColumn only mode, yet didn't modify the other layouts sorting.
Instead user will have complete control (dom order) iresptive of layouts sort.
Also works with current setColumn() implementation
* added karma tests

* Note: you cannot change this flag and expect 1 column (which is cached) to change (can see in column.html,
unless you add/remove items in larger layouts the blows caches). Future todo.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
