### PR TITLE
removed `oneColumnModeClass` and associated code

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -31,6 +31,7 @@ Change log
 ## v0.6.2-dev (upcoming changes)
 
 - fix [#1132](https://github.com/gridstack/gridstack.js/issues/1132) oneColumnMode missing CSS to do layout
+- del `oneColumnModeClass` / `.grid-stack-one-column-mode` and associated code. If you depended on this, use class `.grid-stack-1` instead since it is 1 column layout anyway [1134](https://github.com/gridstack/gridstack.js/pull/1134)
 
 ## v0.6.2 (2020-02-03)
 
@@ -43,7 +44,7 @@ Tracking item swap would be even better still. [#1127](https://github.com/gridst
 
 - fix [#37](https://github.com/gridstack/gridstack.js/issues/37) oneColumnMode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore). This gives
 us full resize/re-order of items capabilities rather than a locked CSS only layout (see prev rev changes). [#1120](https://github.com/gridstack/gridstack.js/pull/1120)
-- fixed responsive.html demo [#1121](https://github.com/gridstack/gridstack.js/pull/1121)
+- fix [responsive.html](https://gridstackjs.com/demo/responsive.html) demo [#1121](https://github.com/gridstack/gridstack.js/pull/1121)
 
 ## v0.6.0 (2019-12-24)
 
@@ -92,11 +93,11 @@ thanks [@ermcgrat](https://github.com/ermcgrat) and others for pointing out code
 
 ## v0.5.2 (2019-11-13)
 
-- undefined `x,y` position messes up grid ([#1017](https://github.com/gridstack/gridstack.js/issues/1017)).
+- fix undefined `x,y` position messes up grid ([#1017](https://github.com/gridstack/gridstack.js/issues/1017)).
 - changed code to 2 spaces.
 - fix minHeight during `onStartMoving()` ([#999](https://github.com/gridstack/gridstack.js/issues/999)).
-- TypeScript definition file now included - no need to include @types/gridstack, easier to update ([#1036](https://github.com/gridstack/gridstack.js/pull/1036)).
-- new `addWidget(el, options)` to pass object so you don't have to spell 10 params. ([#907](https://github.com/gridstack/gridstack.js/issues/907)).
+- add `gridstack.d.ts` TypeScript definition file now included - no need to include `@types/gridstack`, easier to update ([#1036](https://github.com/gridstack/gridstack.js/pull/1036)).
+- add `addWidget(el, options)` to pass object so you don't have to spell 10 params. ([#907](https://github.com/gridstack/gridstack.js/issues/907)).
 
 ## v0.5.1 (2019-11-07)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -88,7 +88,6 @@ gridstack.js API
 - `itemClass` - widget class (default: `'grid-stack-item'`)
 - `maxRow` - maximum rows amount. Default is `0` which means no maximum rows
 - `minWidth` - minimal width. If window width is less than or equal to, grid will be shown in one-column mode (default: `768`)
-- `oneColumnModeClass` - class set on grid when in one column mode (default: 'grid-stack-one-column-mode')
 - `oneColumnModeDomSort` - set to `true` if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: `false`)
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)
 - `placeholderText` - placeholder default content (default: `''`)

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -114,9 +114,8 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       $('.grid-stack').removeClass('grid-stack-animate');
-      var grid = $('.grid-stack').data('gridstack');
       grid.setAnimation(true);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(true);
     });
@@ -125,9 +124,8 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       $('.grid-stack').addClass('grid-stack-animate');
-      var grid = $('.grid-stack').data('gridstack');
       grid.setAnimation(false);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(false);
     });
@@ -146,9 +144,8 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: true
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       $('.grid-stack').removeClass('grid-stack-static');
-      var grid = $('.grid-stack').data('gridstack');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(true);
     });
@@ -158,9 +155,8 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: false
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       $('.grid-stack').addClass('grid-stack-static');
-      var grid = $('.grid-stack').data('gridstack');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(false);
     });
@@ -178,9 +174,8 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var container = $('.grid-stack');
-      var grid = $('.grid-stack').data('gridstack');
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel);
       expect(cell.x).toBe(2);
@@ -191,8 +186,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, false);
       expect(cell.x).toBe(2);
@@ -203,8 +197,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, true);
       expect(cell.x).toBe(2);
@@ -225,8 +218,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 12
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var res = Math.round($('.grid-stack').outerWidth() / 12);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -236,8 +228,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var res = Math.round($('.grid-stack').outerWidth() / 10);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -258,7 +249,7 @@ describe('gridstack', function() {
         verticalMargin: verticalMargin,
         column: 12
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var container = $('.grid-stack');
       var grid = container.data('gridstack');
       var rows = container.attr('data-gs-current-height');
@@ -290,37 +281,27 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should have no changes', function() {
-      var options = {
-        column: 12
-      };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       expect(grid.opts.column).toBe(12);
       grid.setColumn(12);
-      expect(grid.opts.column).toBe(12);
-      grid.setGridWidth(12); // old 0.5.2 API
       expect(grid.opts.column).toBe(12);
     });
     it('should SMALL change column number, no relayout', function() {
       var options = {
         column: 12
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
-      
       grid.setColumn(10, false);
       expect(grid.opts.column).toBe(10);
       for (var j = 0; j < items.length; j++) {
         expect(parseInt($(items[j]).attr('data-gs-y'), 10)).toBe(0);
       }
-      
       grid.setColumn(9, true);
       expect(grid.opts.column).toBe(9);
       for (var j = 0; j < items.length; j++) {
         expect(parseInt($(items[j]).attr('data-gs-y'), 10)).toBe(0);
       }
-      
       grid.setColumn(12);
       expect(grid.opts.column).toBe(12);
       for (var j = 0; j < items.length; j++) {
@@ -332,8 +313,7 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var el1 = $('#item1')
       var el2 = $('#item2')
 
@@ -347,7 +327,6 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el2.attr('data-gs-width'))).toBe(4);
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
-      
       // 1 column will have item1, item2
       grid.setColumn(1);
       expect(grid.opts.column).toBe(1);
@@ -391,7 +370,6 @@ describe('gridstack', function() {
       grid.setColumn(1);
       expect(grid.opts.column).toBe(1);
       grid.move(el3, 0, 0);
-      
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
@@ -410,7 +388,6 @@ describe('gridstack', function() {
       // back to 12 column, el3 to be beginning still, but [1][2] to be in 1 columns still but wide 4x2 and 4x still
       grid.setColumn(12);
       expect(grid.opts.column).toBe(12);
-      
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
@@ -460,8 +437,7 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
       var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
       var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
@@ -505,8 +481,7 @@ describe('gridstack', function() {
         oneColumnModeDomSort: true,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
       var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
       var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
@@ -558,8 +533,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minWidth(items[i], 2);
@@ -582,8 +556,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxWidth(items[i], 2);
@@ -606,8 +579,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minHeight(items[i], 2);
@@ -630,8 +602,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxHeight(items[i], 2);
@@ -654,8 +625,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var shouldBeFalse = grid.isAreaEmpty(1, 1, 1, 1);
       expect(shouldBeFalse).toBe(false);
     });
@@ -664,8 +634,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var shouldBeTrue = grid.isAreaEmpty(5, 5, 1, 1);
       expect(shouldBeTrue).toBe(true);
     });
@@ -679,22 +648,19 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove all children by default', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       grid.removeAll();
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove all children', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       grid.removeAll(true);
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove gridstack part, leave DOM behind', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       grid.removeAll(false);
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).not.toBe(null);
@@ -709,8 +675,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove first item (default), then second (true), then third (false)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       expect(grid.grid.nodes.length).toEqual(2);
 
       var el1 = document.getElementById('item1');
@@ -746,8 +711,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -763,8 +727,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -788,8 +751,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should keep all widget options the same (autoPosition off', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');;
       var widget = grid.addWidget(widgetHTML, 6, 7, 2, 3, false, 1, 4, 2, 5, 'coolWidget');
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(6);
@@ -842,8 +804,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should change x, y coordinates for widgets.', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
       var widget = grid.addWidget(widgetHTML, 9, 7, 2, 3, true);
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).not.toBe(9);
@@ -859,8 +820,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should autoPosition (missing X,Y)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       var widget = grid.addWidget(widgetHTML, {height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -875,8 +835,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing X)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       var widget = grid.addWidget(widgetHTML, {y: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -891,8 +850,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing Y)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       var widget = grid.addWidget(widgetHTML, {x: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -907,8 +865,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (correct X, missing Y)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       var widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -923,8 +880,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (empty options)', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack().data('gridstack');
       var widget = grid.addWidget(widgetHTML, {});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -948,9 +904,8 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should use default', function() {
-      $('.grid-stack').gridstack();
-      var grid = $('.grid-stack').data('gridstack');
-      var widget = grid.addWidget(widgetHTML, {x: 'foo', height: null, width: 'bar', height: ''});
+      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var widget = grid.addWidget(widgetHTML, {x: 'foo', y: null, width: 'bar', height: ''});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
@@ -967,8 +922,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should clear x position', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
       var widgetHTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
       var widget = grid.addWidget(widgetHTML, null, null, undefined);
       var $widget = $(widget);
@@ -985,8 +939,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should match true/false only', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
       expect(grid.float()).toBe(true);
       grid.float(0);
       expect(grid.float()).toBe(false);
@@ -1011,8 +964,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       grid.destroy();
       expect($('.grid-stack').length).toBe(0);
       expect(grid.grid).toBe(null);
@@ -1022,8 +974,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       grid.destroy(false);
       expect($('.grid-stack').length).toBe(1);
       expect($('.grid-stack-item').length).toBe(2);
@@ -1044,8 +995,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.resize(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1066,8 +1016,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.move(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-x'), 10)).toBe(5);
@@ -1087,8 +1036,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid._updateElement(items[0], function(el, node) {
         var newNode = grid.grid.moveNode(node);
@@ -1100,8 +1048,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.minWidth(items[0], 1);
       grid.maxWidth(items[0], 2);
@@ -1127,8 +1074,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.update(items[0], 5, 5, 5 ,5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1150,8 +1096,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var vm = grid.verticalMargin();
       expect(vm).toBe(10);
     });
@@ -1160,40 +1105,27 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       grid.verticalMargin(11);
       expect(grid.verticalMargin()).toBe(11);
     });
     it('should do nothing', function() {
       var options = {
         cellHeight: 80,
-        verticalMargin: 10
-      };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
-      var vm = grid.verticalMargin(10);
-      expect(grid.verticalMargin()).toBe(10);
-    });
-    it('should do nothing', function() {
-      var options = {
-        cellHeight: 80,
         verticalMargin: 10,
-        height: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
-      var vm = grid.verticalMargin(10);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       expect(grid.verticalMargin()).toBe(10);
+      grid.verticalMargin(10);
+      expect(grid.verticalMargin()).toBe(10);
+      // expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `height` is deprecated in v0.5.3 and has been replaced with `maxRow`. It will be **completely** removed in v1.0');
     });
     it('should not update styles', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
-
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       spyOn(grid, '_updateStyles');
       grid.verticalMargin(11, true);
       expect(grid._updateStyles).not.toHaveBeenCalled();
@@ -1213,7 +1145,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         rtl: true
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(true);
     });
     it('should not add grid-stack-rtl class', function() {
@@ -1221,7 +1153,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(false);
     });
   });
@@ -1240,8 +1172,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableDrag: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       expect(grid.opts.disableDrag).toBe(true);
       grid.enableMove(true, true);
@@ -1256,8 +1187,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.enableMove(false);
       for (var i = 0; i < items.length; i++) {
@@ -1281,8 +1211,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableResize: true
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       expect(grid.opts.disableResize).toBe(true);
       grid.enableResize(true, true);
@@ -1297,8 +1226,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       for (var i = 0; i < items.length; i++) {
@@ -1321,8 +1249,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       grid.enableMove(false);
@@ -1350,8 +1277,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], true);
@@ -1363,8 +1289,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      $('.grid-stack').gridstack(options);
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack(options).data('gridstack');
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], false);
@@ -1418,8 +1343,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should move all 3 items to top-left with no space', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
 
       var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5});
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
@@ -1430,8 +1354,7 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
     });
     it('not move locked item', function() {
-      $('.grid-stack').gridstack({float: true});
-      var grid = $('.grid-stack').data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
 
       var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true});
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
@@ -1442,5 +1365,34 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
     });
 
+  });
+
+  /*
+  * ...and finally track log warnings at the end, instead of displaying them....
+  */
+  describe('obsolete warnings', function() {
+    console.warn = jasmine.createSpy('log'); // track warnings instead of displaying them
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('warning if OLD setGridWidth is called', function() {
+      var grid = $('.grid-stack').gridstack().data('gridstack');
+      grid.setGridWidth(11); // old 0.5.2 API
+      expect(grid.opts.column).toBe(11);
+      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Function `setGridWidth` is deprecated in v0.5.3 and has been replaced with `setColumn`. It will be **completely** removed in v1.0');
+    });
+    it('warning if OLD grid height is set', function() {
+      var grid = $('.grid-stack').gridstack({height: 10}).data('gridstack'); // old 0.5.2 Opt now maxRow
+      expect(grid.opts.maxRow).toBe(10);
+      expect(grid.grid.maxRow).toBe(10);
+      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `height` is deprecated in v0.5.3 and has been replaced with `maxRow`. It will be **completely** removed in v1.0');
+    });
+    it('warning if OLD oneColumnModeClass is set (no changes)', function() {
+      $('.grid-stack').gridstack({oneColumnModeClass: 'foo'}).data('gridstack'); // deleted 0.6.3 Opt
+      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `oneColumnModeClass` is deprecated in v0.6.3. Use class `.grid-stack-1` instead');
+    });
   });
 });

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -492,11 +492,6 @@ interface GridstackOptions {
   disableOneColumnMode ? : boolean;
 
   /**
-   * class set on grid when in one column mode (default?: 'grid-stack-one-column-mode')
-   */
-  oneColumnModeClass ? : string;
-
-  /**
    * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column 
    * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
    */

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -20,10 +20,10 @@
 })(function($, scope) {
 
   // checks for obsolete method names
-  var obsolete = function(f, oldName, newName) {
+  var obsolete = function(f, oldName, newName, rev) {
     var wrapper = function() {
-      console.warn('gridstack.js: Function `' + oldName + '` is deprecated as of v0.5.2 and has been replaced ' +
-      'with `' + newName + '`. It will be **completely** removed in v1.0.');
+      console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
+      'with `' + newName + '`. It will be **completely** removed in v1.0');
       return f.apply(this, arguments);
     };
     wrapper.prototype = f.prototype;
@@ -31,22 +31,29 @@
     return wrapper;
   };
 
-  // checks for obsolete grid options 9can be used for any fields, but msg is about options)
-  var obsoleteOpts = function(opts, oldName, newName) {
+  // checks for obsolete grid options (can be used for any fields, but msg is about options)
+  var obsoleteOpts = function(opts, oldName, newName, rev) {
     if (opts[oldName] !== undefined) {
       opts[newName] = opts[oldName];
-      console.warn('gridstack.js: Option `' + oldName + '` is deprecated as of v0.5.2 and has been replaced with `' +
-        newName + '`. It will be **completely** removed in v1.0.');
+      console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
+        newName + '`. It will be **completely** removed in v1.0');
+    }
+  };
+
+  // checks for obsolete grid options which are gone
+  var obsoleteOptsDel = function(opts, oldName, rev, info) {
+    if (opts[oldName] !== undefined) {
+      console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
     }
   };
 
   // checks for obsolete Jquery element attributes
-  var obsoleteAttr = function(el, oldName, newName) {
+  var obsoleteAttr = function(el, oldName, newName, rev) {
     var oldAttr = el.attr(oldName);
     if (oldAttr !== undefined) {
       el.attr(newName, oldAttr);
-      console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object as of v0.5.2 and has been replaced with `' +
-        newName + '`. It will be **completely** removed in v1.0.');
+      console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
+        newName + '`. It will be **completely** removed in v1.0');
     }
   };
 
@@ -672,12 +679,13 @@
 
     this.container = $(el);
 
-    obsoleteOpts(opts, 'width', 'column');
-    obsoleteOpts(opts, 'height', 'maxRow');
+    obsoleteOpts(opts, 'width', 'column', 'v0.5.3');
+    obsoleteOpts(opts, 'height', 'maxRow', 'v0.5.3');
+    obsoleteOptsDel(opts, 'oneColumnModeClass', 'v0.6.3', '. Use class `.grid-stack-1` instead');
 
     // container attributes
-    obsoleteAttr(this.container, 'data-gs-width', 'data-gs-column');
-    obsoleteAttr(this.container, 'data-gs-height', 'data-gs-max-row');
+    obsoleteAttr(this.container, 'data-gs-width', 'data-gs-column', 'v0.5.3');
+    obsoleteAttr(this.container, 'data-gs-height', 'data-gs-max-row', 'v0.5.3');
 
     opts.itemClass = opts.itemClass || 'grid-stack-item';
     var isNested = this.container.closest('.' + opts.itemClass).length > 0;
@@ -720,7 +728,6 @@
       verticalMarginUnit: 'px',
       cellHeightUnit: 'px',
       disableOneColumnMode: opts.disableOneColumnMode || false,
-      oneColumnModeClass: opts.oneColumnModeClass || 'grid-stack-one-column-mode',
       oneColumnModeDomSort: opts.oneColumnModeDomSort,
       ddPlugin: null
     });
@@ -828,14 +835,10 @@
 
       if (!self.opts.disableOneColumnMode && (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= self.opts.minWidth) {
         if (self.oneColumnMode) {  return; }
-
-        self.container.addClass(self.opts.oneColumnModeClass); // TODO: legacy do people still depend on style being there ?
         self.oneColumnMode = true;
         self.setColumn(1);
       } else {
         if (!self.oneColumnMode) { return; }
-
-        self.container.removeClass(self.opts.oneColumnModeClass);
         self.oneColumnMode = false;
         self.setColumn(self._prevColumn);
       }
@@ -1994,7 +1997,7 @@
 
   // legacy method renames
   GridStack.prototype.setGridWidth = obsolete(GridStack.prototype.setColumn,
-    'setGridWidth', 'setColumn'); // 0.5.3
+    'setGridWidth', 'setColumn', 'v0.5.3');
 
   scope.GridStackUI = GridStack;
 


### PR DESCRIPTION
### Description
* If you depended on this, use class `.grid-stack-1` instead of `.grid-stack-one-column-mode` since it is 1 column layout anyway
* updated jasmin test
* should have been done in #1120

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
