### PR TITLE
`gridstack()` init method return GridStack ** BREAKING CHANGE***

### DIFF
--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -10,12 +10,9 @@
   <link rel="stylesheet" href="demo.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <!--
   <script src="../dist/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-  -->
-  <script src="../dist/gridstack.all.js"></script>
 </head>
 <body>
   <div class="container-fluid">
@@ -31,9 +28,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/AniJS/0.9.3/anijs.js"></script>
   <script type="text/javascript">
     $(function () {
-      $('.grid-stack').gridstack();
+      var grid = $('.grid-stack').gridstack();
       var self = this;
-      this.grid = $('.grid-stack').data('gridstack');
       $('.grid-stack').on('added', function(event, items) {
         // add anijs data to gridstack item
         for (var i = 0; i < items.length; i++) {
@@ -44,14 +40,10 @@
         // fire added event!
         self.gridstackNotifier.dispatchEvent('added');
       });
-      $('#add-widget').click(function() {
-        addNewWidget();
-      });
 
-      function addNewWidget() {
-        var grid = $('.grid-stack').data('gridstack');
+      $('#add-widget').click(function() {
         grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), 0, 0, Math.floor(1 + 3 * Math.random()), Math.floor(1 + 3 * Math.random()), true);
-      }
+      });
 
       var animationHelper = AniJS.getHelper();
 

--- a/demo/column.html
+++ b/demo/column.html
@@ -38,8 +38,7 @@
   <script type="text/javascript">
     $(function () {
       var $grid = $('.grid-stack');
-      $grid.gridstack({float: true});
-      grid = $grid.data('gridstack');
+      var grid = $grid.gridstack({float: true});
       var $text = $('#column-text');
 
       $grid.on('added', function(e, items) {log(' added ', items)});

--- a/demo/float.html
+++ b/demo/float.html
@@ -28,39 +28,35 @@
 
   <script type="text/javascript">
     $(function () {
-      $('.grid-stack').gridstack({float: true});
+      this.grid = $('.grid-stack').gridstack({float: true});
 
-      new function () {
-        this.items = [
-          {x: 2, y: 5, width: 1, height: 1},
-          {x: 2, y: 3, width: 3, height: 1},
-          {x: 4, y: 2, width: 1, height: 1},
-          {x: 3, y: 1, width: 1, height: 2},
-          {x: 0, y: 6, width: 2, height: 2}
-        ];
-        var count = 0;
+      this.items = [
+        {x: 2, y: 5, width: 1, height: 1},
+        {x: 2, y: 3, width: 3, height: 1},
+        {x: 4, y: 2, width: 1, height: 1},
+        {x: 3, y: 1, width: 1, height: 2},
+        {x: 0, y: 6, width: 2, height: 2}
+      ];
+      var count = 0;
 
-        this.grid = $('.grid-stack').data('gridstack');
+      this.addNewWidget = function() {
+        var node = this.items[count] || {
+          x: Math.round(12 * Math.random()),
+          y: Math.round(5 * Math.random()),
+          width: Math.round(1 + 3 * Math.random()),
+          height: Math.round(1 + 3 * Math.random())
+        };
+        this.grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + '</div></div>'), node);
+        return false;
+      }.bind(this);
 
-        this.addNewWidget = function() {
-          var node = this.items[count] || {
-            x: Math.round(12 * Math.random()),
-            y: Math.round(5 * Math.random()),
-            width: Math.round(1 + 3 * Math.random()),
-            height: Math.round(1 + 3 * Math.random())
-          };
-          this.grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + '</div></div>'), node);
-          return false;
-        }.bind(this);
+      this.toggleFloat = function() {
+        this.grid.float(! this.grid.float());
+        $('#float').html('float: ' + this.grid.float());
+      }.bind(this);
 
-        this.toggleFloat = function() {
-          this.grid.float(! this.grid.float());
-          $('#float').html('float: ' + this.grid.float());
-        }.bind(this);;
-
-        $('#add-widget').click(this.addNewWidget);
-        $('#float').click(this.toggleFloat);
-      };
+      $('#add-widget').click(this.addNewWidget);
+      $('#float').click(this.toggleFloat);
     });
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
   <h1>Demos</h1>
   <ul>
     <li><a href="advance.html">Advance</a></li>
-    <li><a href="anijs.html">AniJS</a></li>
+    <li><a href="anijs.html">AniJS Animation</a></li>
     <li><a href="column.html">Column</a></li>
     <li><a href="float.html">Float grid</a></li>
     <li><a href="knockout.html">Knockout.js</a></li>

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -34,10 +34,8 @@
             this.widgets = controller.widgets;
 
             this.afterAddWidget = function (items) {
-              if (grid == null) {
-                grid = $(componentInfo.element).find('.grid-stack').gridstack({
-                  auto: false
-                }).data('gridstack');
+              if (!grid ) {
+                grid = $(componentInfo.element).find('.grid-stack').gridstack({auto: false});
               }
 
               var item = items.find(function (i) { return i.nodeType == 1 });

--- a/demo/knockout2.html
+++ b/demo/knockout2.html
@@ -34,10 +34,8 @@
             this.widgets = controller.widgets;
 
             this.afterAddWidget = function (items) {
-              if (grid == null) {
-                grid = $(componentInfo.element).find('.grid-stack').gridstack({
-                  auto: false
-                }).data('gridstack');
+              if (!grid) {
+                grid = $(componentInfo.element).find('.grid-stack').gridstack({auto: false});
               }
 
               var item = items.find(function (i) { return i.nodeType == 1 });

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -65,9 +65,9 @@
         dragOut: true // let us drag them out!
       };
       $('.grid-stack.top').gridstack();
-      var grid1 = $('.grid-stack.nested1').gridstack(nestOptions).data('gridstack');
+      var grid1 = $('.grid-stack.nested1').gridstack(nestOptions);
       nestOptions.dragOut = false;
-      var grid2 = $('.grid-stack.nested2').gridstack(nestOptions).data('gridstack');
+      var grid2 = $('.grid-stack.nested2').gridstack(nestOptions);
 
       var count = 9;
       addNewWidget = function(grid) {

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -26,7 +26,7 @@
     $(function () {
       var grid = $('.grid-stack').gridstack({
         disableOneColumnMode: true, // will manually do 1 column
-        float: true }).data('gridstack');
+        float: true });
       var $text = $('#column-text');
       
       function resizeGrid() {

--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -39,10 +39,8 @@
             this.widgets = controller.widgets;
 
             this.afterAddWidget = function (items) {
-              if (grid == null) {
-                grid = $(componentInfo.element).find('.grid-stack').gridstack({
-                  auto: false
-                }).data('gridstack');
+              if (!grid) {
+                grid = $(componentInfo.element).find('.grid-stack').gridstack({auto: false});
               }
 
               var item = items.find(function (i) { return i.nodeType == 1 });

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -28,7 +28,8 @@
   <script type="text/javascript">
     $(function () {
       var $grid = $('.grid-stack');
-      
+      var grid = $grid.gridstack();
+    
       $grid.on('added', function(e, items) { log(' added ', items) });
       $grid.on('removed', function(e, items) { log(' removed ', items) });
       $grid.on('change', function(e, items) { log(' change ', items) });
@@ -39,59 +40,50 @@
         console.log(type + items.length + ' items.' + str );
       }
 
-      $grid.gridstack();
+      var serializedData = [
+        {x: 0, y: 0, width: 2, height: 2},
+        {x: 3, y: 1, width: 1, height: 2},
+        {x: 4, y: 1, width: 1, height: 1},
+        {x: 2, y: 3, width: 3, height: 1},
+        {x: 1, y: 4, width: 1, height: 1},
+        {x: 1, y: 3, width: 1, height: 1},
+        {x: 2, y: 4, width: 1, height: 1},
+        {x: 2, y: 5, width: 1, height: 1}
+      ];
 
-      new function () {
-        this.serializedData = [
-          {x: 0, y: 0, width: 2, height: 2},
-          {x: 3, y: 1, width: 1, height: 2},
-          {x: 4, y: 1, width: 1, height: 1},
-          {x: 2, y: 3, width: 3, height: 1},
-          {x: 1, y: 4, width: 1, height: 1},
-          {x: 1, y: 3, width: 1, height: 1},
-          {x: 2, y: 4, width: 1, height: 1},
-          {x: 2, y: 5, width: 1, height: 1}
-        ];
-
-        this.grid = $('.grid-stack').data('gridstack');
-
-        this.loadGrid = function () {
-          this.grid.removeAll();
-          var items = GridStackUI.Utils.sort(this.serializedData);
-          this.grid.batchUpdate();
-          items.forEach(function (node) {
-            this.grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), node);
-          }, this);
-          this.grid.commit();
-          return false;
-        }.bind(this);
-
-        this.saveGrid = function () {
-          this.serializedData = $('.grid-stack > .grid-stack-item:visible').map(function (i, el) {
-            el = $(el);
-            var node = el.data('_gridstack_node');
-            return {
-              x: node.x,
-              y: node.y,
-              width: node.width,
-              height: node.height
-            };
-          }).toArray();
-          $('#saved-data').val(JSON.stringify(this.serializedData, null, '  '));
-          return false;
-        }.bind(this);
-
-        this.clearGrid = function () {
-          this.grid.removeAll();
-          return false;
-        }.bind(this);
-
-        $('#save-grid').click(this.saveGrid);
-        $('#load-grid').click(this.loadGrid);
-        $('#clear-grid').click(this.clearGrid);
-
-        this.loadGrid();
+      loadGrid = function () {
+        grid.removeAll();
+        var items = GridStackUI.Utils.sort(serializedData);
+        grid.batchUpdate();
+        items.forEach(function (node) {
+          grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), node);
+        });
+        grid.commit();
       };
+
+      saveGrid = function () {
+        serializedData = $('.grid-stack > .grid-stack-item:visible').map(function (i, el) {
+          el = $(el);
+          var node = el.data('_gridstack_node');
+          return {
+            x: node.x,
+            y: node.y,
+            width: node.width,
+            height: node.height
+          };
+        }).toArray();
+        $('#saved-data').val(JSON.stringify(serializedData, null, '  '));
+      };
+
+      clearGrid = function () {
+        grid.removeAll();
+      }
+
+      $('#save-grid').click(saveGrid);
+      $('#load-grid').click(loadGrid);
+      $('#clear-grid').click(clearGrid);
+
+      loadGrid();
     });
   </script>
 </body>

--- a/demo/two.html
+++ b/demo/two.html
@@ -157,8 +157,8 @@
 
       $('#compact1').click(function() { compact('#grid1') });
       $('#compact2').click(function() { compact('#grid2') });
-      function compact(grid) {
-        var grid = $(grid).data('gridstack');
+      function compact(id) {
+        var grid = $(id).data('gridstack');
         grid.compact();
       }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [v0.6.3-dev (upcoming changes)](#v063-dev-upcoming-changes)
+- [v0.7.0 (upcoming changes)](#v070-upcoming-changes)
 - [v0.6.3 (2020-02-05)](#v063-2020-02-05)
 - [v0.6.2 (2020-02-03)](#v062-2020-02-03)
 - [v0.6.1 (2020-02-02)](#v061-2020-02-02)
@@ -29,7 +29,17 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## v0.6.3-dev (upcoming changes)
+## v0.7.0 (upcoming changes)
+
+- **breaking**: `gridstack()` init method will no longer return a JQuery object (part of removing JQ from our API), but rather `GridStack | GridStack[]` (if multiple are present) making it much more convenient. Instead of:
+```javascript
+$('.grid-stack').gridstack(opt);
+var grid = $('.grid-stack').data('gridstack');
+```
+you can now just:
+```javascript
+var grid = $('.grid-stack').gridstack(opt);
+```
 
 - del `bower` since dead for a while now (https://snyk.io/blog/bower-is-dead/)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -247,8 +247,7 @@ Widget will be always placed even if result height is more than actual grid heig
 before calling `addWidget` for additional check.
 
 ```javascript
-$('.grid-stack').gridstack();
-var grid = $('.grid-stack').data('gridstack');
+var grid = $('.grid-stack').gridstack();
 grid.addWidget(el, 0, 0, 3, 2, true);
 ```
 
@@ -361,10 +360,9 @@ Parameters:
 - `el` - element to convert to a widget
 
 ```javascript
-$('.grid-stack').gridstack();
+var grid = $('.grid-stack').gridstack();
 
 $('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="true"></div>')
-var grid = $('.grid-stack').data('gridstack');
 grid.makeWidget('gsi-1');
 ```
 

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -34,22 +34,17 @@
         cellHeight: 'auto',
         float: false
       };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack(options);
 
-      new function () {
-        this.grid = $('.grid-stack').data('gridstack');
-
-        this.addNewWidget = function(i) {
-          this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), {id: i});
-          return false;
-        }.bind(this);
-
-        for (; count < COLUMNS; count++) {
-          this.addNewWidget(count); 
-        }
-
-        $('#add-widget').click(this.addNewWidget(count++));
+      addNewWidget = function(i) {
+        grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), {id: i});
       };
+
+      for (; count < COLUMNS; count++) {
+        addNewWidget(count); 
+      }
+
+      $('#add-widget').click(function() { addNewWidget(count++) });
     });
   </script>
 </body>

--- a/spec/e2e/html/gridstack-with-height.html
+++ b/spec/e2e/html/gridstack-with-height.html
@@ -23,29 +23,21 @@
 
   <script type="text/javascript">
     $(function() {
-      var options = {
-        height: 5
-      };
-      $('.grid-stack').gridstack(options);
+      var grid = $('.grid-stack').gridstack({maxRow: 5});
 
-      new function() {
-        var items = [
-          {x: 0, y: 0, width: 2, height: 2},
-          {x: 2, y: 5, width: 1, height: 1}
-        ];
+      var items = [
+        {x: 0, y: 0, width: 2, height: 2},
+        {x: 2, y: 5, width: 1, height: 1}
+      ];
+      var id = 0;
 
-        this.grid = $('.grid-stack').data('gridstack');
-        this.grid.removeAll();
-        items = GridStackUI.Utils.sort(items);
-        var id = 0;
-        this.grid.batchUpdate();
-        items.forEach(function(node) {
-          var w = $('<div><div class="grid-stack-item-content"></div></div>');
-          w.attr('id', 'item-' + (++id));
-          this.grid.addWidget(w, node);
-        }, this);
-        this.grid.commit();
-      };
+      grid.batchUpdate();
+      items.forEach(function(node) {
+        var w = $('<div><div class="grid-stack-item-content"></div></div>');
+        w.attr('id', 'item-' + (++id));
+        grid.addWidget(w, node);
+      });
+      grid.commit();
     });
   </script>
 </body>

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -114,7 +114,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       $('.grid-stack').removeClass('grid-stack-animate');
       grid.setAnimation(true);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(true);
@@ -124,7 +124,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       $('.grid-stack').addClass('grid-stack-animate');
       grid.setAnimation(false);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(false);
@@ -144,7 +144,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       $('.grid-stack').removeClass('grid-stack-static');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(true);
@@ -155,7 +155,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: false
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       $('.grid-stack').addClass('grid-stack-static');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(false);
@@ -174,7 +174,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var container = $('.grid-stack');
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel);
@@ -186,7 +186,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, false);
       expect(cell.x).toBe(2);
@@ -197,7 +197,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, true);
       expect(cell.x).toBe(2);
@@ -218,7 +218,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var res = Math.round($('.grid-stack').outerWidth() / 12);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -228,7 +228,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var res = Math.round($('.grid-stack').outerWidth() / 10);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -249,9 +249,8 @@ describe('gridstack', function() {
         verticalMargin: verticalMargin,
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var container = $('.grid-stack');
-      var grid = container.data('gridstack');
       var rows = container.attr('data-gs-current-height');
 
       expect(grid.cellHeight()).toBe(cellHeight);
@@ -281,7 +280,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should have no changes', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       expect(grid.opts.column).toBe(12);
       grid.setColumn(12);
       expect(grid.opts.column).toBe(12);
@@ -290,7 +289,7 @@ describe('gridstack', function() {
       var options = {
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.setColumn(10, false);
       expect(grid.opts.column).toBe(10);
@@ -313,7 +312,7 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var el1 = $('#item1')
       var el2 = $('#item2')
 
@@ -437,7 +436,7 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
       var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
       var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
@@ -481,7 +480,7 @@ describe('gridstack', function() {
         oneColumnModeDomSort: true,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
       var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
       var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
@@ -533,7 +532,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minWidth(items[i], 2);
@@ -556,7 +555,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxWidth(items[i], 2);
@@ -579,7 +578,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minHeight(items[i], 2);
@@ -602,7 +601,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxHeight(items[i], 2);
@@ -625,7 +624,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var shouldBeFalse = grid.isAreaEmpty(1, 1, 1, 1);
       expect(shouldBeFalse).toBe(false);
     });
@@ -634,7 +633,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var shouldBeTrue = grid.isAreaEmpty(5, 5, 1, 1);
       expect(shouldBeTrue).toBe(true);
     });
@@ -648,19 +647,19 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove all children by default', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       grid.removeAll();
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove all children', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       grid.removeAll(true);
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove gridstack part, leave DOM behind', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       grid.removeAll(false);
       expect(grid.grid.nodes).toEqual([]);
       expect(document.getElementById('item1')).not.toBe(null);
@@ -675,7 +674,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove first item (default), then second (true), then third (false)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       expect(grid.grid.nodes.length).toEqual(2);
 
       var el1 = document.getElementById('item1');
@@ -711,7 +710,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -727,7 +726,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -751,7 +750,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should keep all widget options the same (autoPosition off', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');;
+      var grid = $('.grid-stack').gridstack({float: true});;
       var widget = grid.addWidget(widgetHTML, 6, 7, 2, 3, false, 1, 4, 2, 5, 'coolWidget');
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(6);
@@ -804,7 +803,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should change x, y coordinates for widgets.', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true});
       var widget = grid.addWidget(widgetHTML, 9, 7, 2, 3, true);
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).not.toBe(9);
@@ -820,7 +819,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should autoPosition (missing X,Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -835,7 +834,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing X)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {y: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -850,7 +849,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {x: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -865,7 +864,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (correct X, missing Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -880,7 +879,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (empty options)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -904,7 +903,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should use default', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       var widget = grid.addWidget(widgetHTML, {x: 'foo', y: null, width: 'bar', height: ''});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -922,7 +921,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should clear x position', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true});
       var widgetHTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
       var widget = grid.addWidget(widgetHTML, null, null, undefined);
       var $widget = $(widget);
@@ -939,7 +938,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should match true/false only', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true});
       expect(grid.float()).toBe(true);
       grid.float(0);
       expect(grid.float()).toBe(false);
@@ -964,7 +963,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       grid.destroy();
       expect($('.grid-stack').length).toBe(0);
       expect(grid.grid).toBe(null);
@@ -974,7 +973,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       grid.destroy(false);
       expect($('.grid-stack').length).toBe(1);
       expect($('.grid-stack-item').length).toBe(2);
@@ -995,7 +994,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.resize(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1016,7 +1015,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.move(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-x'), 10)).toBe(5);
@@ -1036,7 +1035,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid._updateElement(items[0], function(el, node) {
         var newNode = grid.grid.moveNode(node);
@@ -1048,7 +1047,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.minWidth(items[0], 1);
       grid.maxWidth(items[0], 2);
@@ -1074,7 +1073,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.update(items[0], 5, 5, 5 ,5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1096,7 +1095,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var vm = grid.verticalMargin();
       expect(vm).toBe(10);
     });
@@ -1105,7 +1104,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       grid.verticalMargin(11);
       expect(grid.verticalMargin()).toBe(11);
     });
@@ -1114,7 +1113,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10,
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       expect(grid.verticalMargin()).toBe(10);
       grid.verticalMargin(10);
       expect(grid.verticalMargin()).toBe(10);
@@ -1125,7 +1124,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       spyOn(grid, '_updateStyles');
       grid.verticalMargin(11, true);
       expect(grid._updateStyles).not.toHaveBeenCalled();
@@ -1145,7 +1144,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         rtl: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(true);
     });
     it('should not add grid-stack-rtl class', function() {
@@ -1153,7 +1152,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(false);
     });
   });
@@ -1172,7 +1171,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableDrag: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       expect(grid.opts.disableDrag).toBe(true);
       grid.enableMove(true, true);
@@ -1187,7 +1186,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.enableMove(false);
       for (var i = 0; i < items.length; i++) {
@@ -1211,7 +1210,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableResize: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       expect(grid.opts.disableResize).toBe(true);
       grid.enableResize(true, true);
@@ -1226,7 +1225,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       for (var i = 0; i < items.length; i++) {
@@ -1249,7 +1248,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       grid.enableMove(false);
@@ -1277,7 +1276,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], true);
@@ -1289,7 +1288,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = $('.grid-stack').gridstack(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], false);
@@ -1343,7 +1342,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should move all 3 items to top-left with no space', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true});
 
       var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5});
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
@@ -1354,7 +1353,7 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
     });
     it('not move locked item', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = $('.grid-stack').gridstack({float: true});
 
       var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true});
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
@@ -1379,19 +1378,19 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('warning if OLD setGridWidth is called', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = $('.grid-stack').gridstack();
       grid.setGridWidth(11); // old 0.5.2 API
       expect(grid.opts.column).toBe(11);
       expect(console.warn).toHaveBeenCalledWith('gridstack.js: Function `setGridWidth` is deprecated in v0.5.3 and has been replaced with `setColumn`. It will be **completely** removed in v1.0');
     });
     it('warning if OLD grid height is set', function() {
-      var grid = $('.grid-stack').gridstack({height: 10}).data('gridstack'); // old 0.5.2 Opt now maxRow
+      var grid = $('.grid-stack').gridstack({height: 10}); // old 0.5.2 Opt now maxRow
       expect(grid.opts.maxRow).toBe(10);
       expect(grid.grid.maxRow).toBe(10);
       expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `height` is deprecated in v0.5.3 and has been replaced with `maxRow`. It will be **completely** removed in v1.0');
     });
     it('warning if OLD oneColumnModeClass is set (no changes)', function() {
-      $('.grid-stack').gridstack({oneColumnModeClass: 'foo'}).data('gridstack'); // deleted 0.6.3 Opt
+      $('.grid-stack').gridstack({oneColumnModeClass: 'foo'}); // deleted 0.6.3 Opt
       expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `oneColumnModeClass` is deprecated in v0.6.3. Use class `.grid-stack-1` instead');
     });
   });

--- a/spec/gridstack-tests.ts
+++ b/spec/gridstack-tests.ts
@@ -1,0 +1,20 @@
+import { GridStack, GridstackOptions, MousePosition } from '../src/gridstack';
+
+var options: GridstackOptions = {
+    float: true
+};
+var grid: GridStack = $(document).gridstack(options);
+var gsFromElement: GridStack = $(document).data("grid");
+
+if (gsFromElement !== grid) throw Error('These should match!');
+
+grid.addWidget("test", 1, 2, 3, 4, true);
+grid.addWidget(document.createElement('div'), 1, 2, 3, 4, true);
+grid.addWidget($(document.createElement('div')), 1, 2, 3, 4, true);
+grid.makeWidget($(document.createElement('div')));
+grid.batchUpdate();
+grid.cellHeight();;
+grid.cellHeight(2);
+grid.cellWidth();
+grid.getCellFromPixel(<MousePosition>{ left:20, top: 20 });
+grid.removeAll(false);

--- a/src/gridstack.d.ts
+++ b/src/gridstack.d.ts
@@ -9,7 +9,10 @@
 // TypeScript Version: 2.8
 
 interface JQuery {
-  gridstack(options: GridstackOptions): JQuery;
+  /** initializing the element will return the grid or grids if multiple were present */
+  gridstack(options: GridstackOptions): GridStack | GridStack[];
+
+  /** method to access the grid after the fact from the element */
   data(key: 'gridstack'): GridStack;
 }
 
@@ -30,8 +33,7 @@ interface GridStack {
    * See also `makeWidget()`.
    *
    * @example
-   * $('.grid-stack').gridstack();
-   * var grid = $('.grid-stack').data('gridstack');
+   * var grid = $('.grid-stack').gridstack();
    * grid.addWidget(el, {width: 3, autoPosition: true});
    *
    * @param el widget to add
@@ -44,8 +46,7 @@ interface GridStack {
    * Legacy: Spelled out version of the widgets options, recommend use new version instead.
    *
    * @example
-   * $('.grid-stack').gridstack();
-   * var grid = $('.grid-stack').data('gridstack');
+   * var grid = $('.grid-stack').gridstack();
    * grid.addWidget(el, 0, 0, 3, 2, true);
    *
    * @param el widget to add
@@ -194,10 +195,9 @@ interface GridStack {
    * @param el widget to convert.
    *
    * @example
-   * $('.grid-stack').gridstack();
+   * var grid = $('.grid-stack').gridstack();
    * $('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2"
    *                     data-gs-auto-position="true"></div>')
-   * var grid = $('.grid-stack').data('gridstack');
    * grid.makeWidget('gsi-1');
    */
   makeWidget(el: GridStackElement): JQuery;

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -2005,14 +2005,21 @@
   scope.GridStackUI.Engine = GridStackEngine;
   scope.GridStackUI.GridStackDragDropPlugin = GridStackDragDropPlugin;
 
+  /**
+   * initializing the element will return the grid or grids if multiple were present
+   */
   $.fn.gridstack = function(opts) {
-    return this.each(function() {
+    var grids = [];
+    this.each(function() {
       var o = $(this);
-      if (!o.data('gridstack')) {
-        o
-          .data('gridstack', new GridStack(this, opts));
+      var grid = o.data('gridstack');
+      if (!grid) {
+        grid = new GridStack(this, opts);
+        o.data('gridstack', grid);
       }
+      grids.push(grid);
     });
+    return grids.length > 1 ? grids : grids[0];
   };
 
   return scope.GridStackUI;


### PR DESCRIPTION
### Description
***BREAKING CHANGE***
* `gridstack()` init method will no longer return a JQuery object
(part of removing JQ from our API),
 but rather `GridStack | GridStack[]` (if multiple are present) making it much more convenient.
* Instead of:
`
$('.grid-stack').gridstack(opt);
var grid = $('.grid-stack').data('gridstack');
`
you can now just:
`
var grid = $('.grid-stack').gridstack(opt);
`
### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
