### PR TITLE
optimized `change` callback

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -62,7 +62,9 @@
         {x: 2, y: 0, width: 2, height: 1},
         {x: 5, y: 1, width: 1, height: 1},
         {x: 5, y: 0, width: 2, height: 1},
+        // {x: 0, y: 0, width: 1, height: 1}, // conflict
         {text: ' auto'}, // autoPosition testing
+        // {x: 4, y: 0, width: 1, height: 1}, // same auto-pos
         {x: 5, y: 3, width: 2, height: 1},
         {x: 0, y: 4, width: 12, height: 1}
       ];

--- a/demo/two.html
+++ b/demo/two.html
@@ -11,6 +11,13 @@
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <!--
+
+  <script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.3/dist/gridstack.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.3/dist/jquery-ui.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.3/dist/gridstack.jQueryUI.js"></script>
+    -->
+
   <script src="../dist/jquery-ui.min.js"></script>
   <script src="../src/gridstack.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -31,8 +31,9 @@ Change log
 
 ## v0.6.3-dev (upcoming changes)
 
-- fix [#1142](https://github.com/gridstack/gridstack.js/issues/1142) RemoveWidget() doesn't also trigger change events when it should
-- del `bower` since dead for a while now (https://snyk.io/blog/bower-is-dead/)
+- fix [#1142](https://github.com/gridstack/gridstack.js/issues/1142) add/remove widget will also trigger change events when it should.
+- optimized `change` callback to save original x,y,w,h values and only call those that changed [1148](https://github.com/gridstack/gridstack.js/pull/1148)
+- delete `bower` since [dead](https://snyk.io/blog/bower-is-dead) for a while now
 
 ## v0.6.3 (2020-02-05)
 


### PR DESCRIPTION
### Description
* save original x,y,w,h values and only call those that changed
(and not just tempory flag _dirty)
* getting all the test cases was tricky. Used all demos with some mods.
* related to #1147 which fixes #1142

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
