### PR TITLE
Typescript + remove jQuery from API **BREAKING**

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 dist/*.js
 demo/*
 spec/*
+src/jquery.js
 src/jquery-ui.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "cSpell.words": [
+    "Pavel",
+    "Reznikov",
+    "dragdrop",
+    "dragstop",
+    "dropover",
+    "droppable",
+    "gsresize",
+    "gsresizestop",
+    "resizestart"
+  ]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,7 @@ module.exports = function(grunt) {
           'dist/gridstack.d.ts': ['src/gridstack.d.ts'],
           'dist/gridstack.jQueryUI.js': ['src/gridstack.jQueryUI.js'],
           'dist/gridstack-poly.js': ['src/gridstack-poly.js'],
+          'dist/jquery.js': ['src/jquery.js'],
           'dist/jquery-ui.js': ['src/jquery-ui.js'],
         }
       }
@@ -57,8 +58,9 @@ module.exports = function(grunt) {
           'dist/gridstack.min.js': ['src/gridstack.js'],
           'dist/gridstack.jQueryUI.min.js': ['src/gridstack.jQueryUI.js'],
           'dist/gridstack-poly.min.js': ['src/gridstack-poly.js'],
+          'dist/jquery.min.js': ['src/jquery.js'],
           'dist/jquery-ui.min.js': ['src/jquery-ui.js'],
-          'dist/gridstack.all.js': ['src/gridstack-poly.js', 'src/gridstack.js', 'src/jquery-ui.js', 'src/gridstack.jQueryUI.js']
+          'dist/gridstack.all.js': ['src/gridstack-poly.js', 'src/jquery.js', 'src/gridstack.js', 'src/jquery-ui.js', 'src/gridstack.jQueryUI.js']
         }
       }
     },

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 gridstack.js
 ============
 
-[![Build Status](https://travis-ci.org/gridstack/gridstack.js.svg?branch=develop)](https://travis-ci.org/gridstack/gridstack.js)
-[![Coverage Status](https://coveralls.io/repos/github/gridstack/gridstack.js/badge.svg?branch=develop)](https://coveralls.io/github/gridstack/gridstack.js?branch=develop)
+[![NPM version](https://img.shields.io/npm/v/gridstack.svg)](https://www.npmjs.com/package/gridstack)
 [![Dependency Status](https://david-dm.org/gridstack/gridstack.js.svg)](https://david-dm.org/gridstack/gridstack.js)
 [![devDependency Status](https://david-dm.org/gridstack/gridstack.js/dev-status.svg)](https://david-dm.org/gridstack/gridstack.js#info=devDependencies)
+[![Coverage Status](https://coveralls.io/repos/github/gridstack/gridstack.js/badge.svg?branch=develop)](https://coveralls.io/github/gridstack/gridstack.js?branch=develop)
+[![downloads](https://img.shields.io/npm/dm/gridstack.svg)](https://www.npmjs.com/package/gridstack)
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/alaind831)
 
-Mobile-friendly Javascript library for dashboard layout and creation. Making a drag-and-drop, multi-column dashboard has never been easier. Allows you to build draggable, responsive bootstrap v3-friendly layouts. It also has multiple bindings and works great with [React](https://reactjs.org/), [Angular](https://angular.io/), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others, and comes with a Typescript definition out of the box.
+Mobile-friendly Javascript library for dashboard layout and creation. Making a drag-and-drop, multi-column dashboard has never been easier. Allows you to build draggable, responsive bootstrap v4-friendly layouts. It also has multiple bindings and works great with [React](https://reactjs.org/), [Angular](https://angular.io/), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others, and comes with a Typescript definition out of the box.
 
 Inspired by no-longer maintained gridster.js, built with love.
 
@@ -33,7 +35,7 @@ Join us on Slack: https://gridstackjs.troolee.com
   - [Change grid columns](#change-grid-columns)
   - [Custom columns CSS](#custom-columns-css)
   - [Override resizable/draggable options](#override-resizabledraggable-options)
-  - [Migrating to v0.3.0](#migrating-to-v030)
+  - [Migrating to v1.0.0](#migrating-to-v100)
 - [Changes](#changes)
 - [The Team](#the-team)
 
@@ -43,7 +45,7 @@ Join us on Slack: https://gridstackjs.troolee.com
 Demo and examples
 ====
 
-Please visit http://gridstackjs.com and [these demos](http://gridstackjs.com/demo/).
+Please visit http://gridstackjs.com and [these demos](http://gridstackjs.com/demo/)
 
 
 Usage
@@ -56,39 +58,41 @@ Usage
 [![NPM version](https://img.shields.io/npm/v/gridstack.svg)](https://www.npmjs.com/package/gridstack)
 
 ```bash
-$ yarn install gridstack
+yarn install gridstack
+or
+npm install --save gridstack
 ```
 
 ## Include
 
 * local:
 
-
 ```html
 <link rel="stylesheet" href="gridstack.css" />
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="gridstack.all.js"></script>
 ```
 
 * Using CDN (minimized):
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/gridstack.min.css" />
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/gridstack.all.js"></script>
-```
-
-* Using CDN (debug):
-
-```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/gridstack.css" />
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/gridstack.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/jquery-ui.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gridstack@0.6.4/dist/gridstack.jQueryUI.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@1.0.0/dist/gridstack.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/gridstack@1.0.0/dist/gridstack.all.js"></script>
 ```
 
 ## Basic usage
+
+creating items dynamically...
+
+```html
+<div class="grid-stack"></div>
+
+<script type="text/javascript">
+  var grid = GridStack.init();
+  grid.addWidget('<div><div class="grid-stack-item-content"> test </div></div>', {width: 2});
+</script>
+```
+
+... or DOM created items
 
 ```html
 <div class="grid-stack">
@@ -101,9 +105,7 @@ $ yarn install gridstack
 </div>
 
 <script type="text/javascript">
-$(function () {
-  $('.grid-stack').gridstack();
-});
+  GridStack.init();
 </script>
 ```
 
@@ -111,17 +113,7 @@ see [jsfiddle sample](https://jsfiddle.net/adumesny/jqhkry7g) as running example
 
 ## Requirements
 
-* [jQuery](http://jquery.com) (>= 1.8)
-* `Array.prototype.find`, and `Number.isNaN()` for IE and older browsers.
-  * Note: as of v0.5.4 We supply a separate `gridstack-poly.js` for that 
-(part of `gridstack.all.js`) or you can look at other pollyfills 
-([core.js](https://github.com/zloirock/core-js#ecmascript-6-array) and [mozilla.org](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)).
-
-Using gridstack.js with jQuery UI
-
-* [jQuery UI](http://jqueryui.com) (>= 1.12.0). Minimum required components: Draggable, Droppable, Resizable (Widget, Mouse, core).
-  * Note: as of v0.5.4 we include this subset as `jquery-ui.js` (and min.js) which is part of `gridstack.all.js`. If you wish to bring your own lib, include the individual gridstack parts instead of all.js
-* (Optional) [jquery-ui-touch-punch](https://github.com/furf/jquery-ui-touch-punch) for touch-based devices support
+gridstack.js no longer requires external dependencies as of v1.0.0 (lodash was removed in v0.5.0 and jquery API in v1.0.0). All you need to include is `gridstack.all.js` and `gridstack.css` (layouts are done using CSS column based %).
 
 ## API Documentation
 
@@ -132,18 +124,16 @@ Documentation can be found [here](https://github.com/gridstack/gridstack.js/tree
 
 You can easily extend or patch gridstack with code like this:
 
-```javascript
-$(function () {
-  // extend gridstack with our own custom method
-  window.GridStackUI.prototype.printCount = function() {
-    console.log('grid has ' + this.grid.nodes.length + ' items');
-  };
+```js
+// extend gridstack with our own custom method
+window.GridStack.prototype.printCount = function() {
+  console.log('grid has ' + this.grid.nodes.length + ' items');
+};
 
-  $('.grid-stack').gridstack();
+var grid = GridStack.init();
 
-  // you can now call on any grid this...
-  $('.grid-stack').data('gridstack').printCount();
-});
+// you can now call on any grid this...
+grid.printCount();
 ```
 
 ## Touch devices support
@@ -152,23 +142,17 @@ Please use [jQuery UI Touch Punch](https://github.com/furf/jquery-ui-touch-punch
 working on touch-based devices.
 
 ```html
-<script src="core-js/client/shim.min.js"></script>
-<script src="jquery.min.js"></script>
-<script src="jquery-ui.min.js"></script>
+<script src="gridstack.all.js"></script>
 <script src="jquery.ui.touch-punch.min.js"></script>
-
-<script src="gridstack.js"></script>
 ```
 
 Also `alwaysShowResizeHandle` option may be useful:
 
-```javascript
-$(function () {
-  var options = {
-    alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
-  };
-  $('.grid-stack').gridstack(options);
-});
+```js
+var options = {
+  alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+};
+GridStack.init(options);
 ```
 
 If you're still experiencing issues on touch devices please check [#444](https://github.com/gridstack/gridstack.js/issues/444)
@@ -190,7 +174,7 @@ GridStack makes it very easy if you need [1-12] columns out of the box (default 
 
 1) Change the `column` grid option when creating a grid to your number N
 ```js
-$('.grid-stack').gridstack( {column: N} );
+GridStack.init( {column: N} );
 ```
 
 2) include `gridstack-extra.css` if **N < 12** (else custom CSS - see next). Without these, things will not render/work correctly.
@@ -260,8 +244,8 @@ and also have the `.grid-stack-N` prefix to support letting the user change colu
 You can override default `resizable`/`draggable` options. For instance to enable other then bottom right resizing handle
 you can init gridstack like:
 
-```javascript
-$('.grid-stack').gridstack({
+```js
+GridStack.init({
   resizable: {
     handles: 'e, se, s, sw, w'
   }
@@ -270,22 +254,53 @@ $('.grid-stack').gridstack({
 
 Note: It's not recommended to enable `nw`, `n`, `ne` resizing handles. Their behaviour may be unexpected.
 
-## Migrating to v0.3.0
+## Migrating to v1.0.0
 
-As of v0.3.0, gridstack introduces a new plugin system. The drag'n'drop functionality has been modified to take advantage of this system. Because of this, and to avoid dependency on core code from jQuery UI, the plugin functionality was moved to a separate file.
+v1.0.0 removed Jquery from the API and external dependencies, which will require some code changes. Here is a list of the changes:
 
-To ensure gridstack continues to work, either include the additional `gridstack.jQueryUI.js` file into your HTML or use `gridstack.all.js`:
+1. your code only needs to include `gridstack.all.js` and `gristack.css` (don't include or depend on jquery) and is recommended you do that as internal dependencies will change. Right now jquery+jquery-ui (trimmed versions) are still being used internally for a short while.
 
-```html
-<script src="gridstack.js"></script>
-<script src="gridstack.jQueryUI.js"></script>
+2. code change:
+
+**OLD** initializing code + adding a widget + adding an event:
+```js
+// initialization returned Jquery element, requiring second call to get GridStack var
+$('.grid-stack').gridstack(opts?);
+var grid = $('.grid-stack').data('gridstack');
+
+// returned Jquery element
+grid.addWidget($('<div><div class="grid-stack-item-content"> test </div></div>'), {width: 2});
+
+// jquery event handler
+$('.grid-stack').on('added', function(e, items) {/* items contains info */});
+
 ```
-or
-```html
-<script src="gridstack.all.js"></script>
+**NEW**
+```js
+// element identifier defaults to '.grid-stack', returns the grid
+// for Typescript use window.GridStack.init()
+var grid = GridStack.init(opts?, element?);
+
+// returns DOM element
+grid.addWidget('<div><div class="grid-stack-item-content"> test </div></div>', {width: 2});
+
+// event handler
+grid.on('added', function(e, items) {/* items contains info */});
+
 ```
 
-We're working on implementing support for other drag'n'drop libraries through the new plugin system.
+Other  vars/global changes
+```
+`GridStackUI` --> `GridStack`
+`GridStackUI.GridStackEngine` --> `GridStack.Engine`
+`grid.container` (jquery grid wrapper) --> `grid.el` (grid DOM element)
+`grid.grid` (GridStackEngine) --> `grid.engine`
+`grid.setColumn(N)` --> `grid.column(N)` and new `grid.column()` to get value, old API still supported though
+```
+
+Recommend looking at the [many samples](../demo) for more code examples.
+
+We're working on implementing support for other drag'n'drop libraries through the plugin system. Right now it is still jquery-ui based (but minimal build content)
 
 Changes
 =====

--- a/demo/advance.html
+++ b/demo/advance.html
@@ -12,9 +12,10 @@
 
   <script type="module" src="https://unpkg.com/ionicons@4.5.10-0/dist/ionicons/ionicons.esm.js"></script>
   <script nomodule="" src="https://unpkg.com/ionicons@4.5.10-0/dist/ionicons/ionicons.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 
   <style type="text/css">
@@ -53,7 +54,7 @@
       </div>
     </div>
     <div class="col-sm-12 col-md-10">
-      <div class="grid-stack" id="advanced-grid" data-gs-animate="yes">
+      <div class="grid-stack" data-gs-animate="yes">
         <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2">
           <div class="grid-stack-item-content">1</div>
         </div>
@@ -104,37 +105,33 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var $grid = $('#advanced-grid');
-      
-      $grid.on('added', function(e, items) { log(' added ', items) });
-      $grid.on('removed', function(e, items) { log(' removed ', items) });
-      $grid.on('change', function(e, items) { log(' change ', items) });
-      function log(type, items) {
-        if (!items) { return; }
-        var str = '';
-        for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
-        console.log(type + items.length + ' items.' + str );
-      }
+    var grid = GridStack.init({
+      alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent
+      ),
+      resizable: {
+        handles: 'e, se, s, sw, w'
+      },
+      removable: '#trash',
+      removeTimeout: 100,
+      acceptWidgets: '.newWidget'
+    });
 
-      $grid.gridstack({
-        alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-          navigator.userAgent
-        ),
-        resizable: {
-          handles: 'e, se, s, sw, w'
-        },
-        removable: '#trash',
-        removeTimeout: 100,
-        acceptWidgets: '.newWidget'
-      });
+    grid.on('added', function(e, items) { log('added ', items) });
+    grid.on('removed', function(e, items) { log('removed ', items) });
+    grid.on('change', function(e, items) { log('change ', items) });
+    function log(type, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(type + items.length + ' items.' + str );
+    }
 
-      $('.newWidget').draggable({
-        revert: 'invalid',
-        scroll: false,
-        appendTo: 'body',
-        helper: 'clone'
-      });
+    // TODO: switch jquery-ui out
+    $('.newWidget').draggable({
+      revert: 'invalid',
+      scroll: false,
+      appendTo: 'body',
+      helper: 'clone'
     });
   </script>
 </body>

--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -9,57 +9,51 @@
   <link rel="stylesheet" href="https://anijs.github.io/lib/anicollection/anicollection.css" />
   <link rel="stylesheet" href="demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <!--
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
-  -->
-  <script src="../dist/gridstack.all.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/AniJS/0.9.3/anijs.js"></script>
 </head>
 <body>
   <div class="container-fluid">
     <h1>AniJS demo</h1>
     <div>
-      <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
+      <a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a>
     </div>
     <h4>Widget added</h4>
     <br>
     <div class="grid-stack"></div>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/AniJS/0.9.3/anijs.js"></script>
   <script type="text/javascript">
-    $(function () {
-      $('.grid-stack').gridstack();
-      var self = this;
-      this.grid = $('.grid-stack').data('gridstack');
-      $('.grid-stack').on('added', function(event, items) {
-        // add anijs data to gridstack item
-        for (var i = 0; i < items.length; i++) {
-          $(items[i].el[0]).attr('data-anijs', 'if: added, do: swing animated, after: $removeAnimations, on: $gridstack');
-        }
-        AniJS.run();
-        self.gridstackNotifier = AniJS.getNotifier('gridstack');
-        // fire added event!
-        self.gridstackNotifier.dispatchEvent('added');
-      });
-      $('#add-widget').click(function() {
-        addNewWidget();
-      });
-
-      function addNewWidget() {
-        var grid = $('.grid-stack').data('gridstack');
-        grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), 0, 0, Math.floor(1 + 3 * Math.random()), Math.floor(1 + 3 * Math.random()), true);
+    var grid = GridStack.init();
+    var self = this;
+    grid.on('added', function(e, items) {
+      // add anijs data to gridstack item
+      for (var i = 0; i < items.length; i++) {
+        items[i].el.setAttribute('data-anijs', 'if: added, do: swing animated, after: $removeAnimations, on: $gridstack');
       }
-
-      var animationHelper = AniJS.getHelper();
-
-      //Defining removeAnimations to remove existing animations
-      animationHelper.removeAnimations = function(e, animationContext){
-        $('.grid-stack-item').attr('data-anijs', '');
-      };
+      AniJS.run();
+      self.gridstackNotifier = AniJS.getNotifier('gridstack');
+      // fire added event!
+      self.gridstackNotifier.dispatchEvent('added');
     });
+
+    function addWidget() {
+      grid.addWidget('<div><div class="grid-stack-item-content"></div></div>', 0, 0, Math.floor(1 + 3 * Math.random()), Math.floor(1 + 3 * Math.random()), true);
+    };
+
+    var animationHelper = AniJS.getHelper();
+
+    //Defining removeAnimations to remove existing animations
+    animationHelper.removeAnimations = function(e, animationContext) {
+      document.querySelectorAll('.grid-stack-item').forEach( function(el) {
+        el.removeAttribute('data-anijs');
+      });
+    }
+
+    addWidget();
   </script>
 </body>
 </html>

--- a/demo/column.html
+++ b/demo/column.html
@@ -9,92 +9,86 @@
   <link rel="stylesheet" href="demo.css"/>
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
-  <script src="../src/gridstack-poly.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 </head>
 <body>
   <div class="container-fluid">
-    <h1>setColumn() grid demo</h1>
+    <h1>column() grid demo</h1>
     <div><span>Number of Columns:</span> <span id="column-text">12</span></div>
     <div>
-      <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
-      <a class="btn btn-primary" id="1column" href="#">1 Column</a>
-      <a class="btn btn-primary" id="1columnDOM" href="#">1 Column DOM</a>
-      <a class="btn btn-primary" id="2column" href="#">2 Column</a>
-      <a class="btn btn-primary" id="3column" href="#">3 Column</a>
-      <a class="btn btn-primary" id="4column" href="#">4 Column</a>
-      <a class="btn btn-primary" id="6column" href="#">6 Column</a>
-      <a class="btn btn-primary" id="8column" href="#">8 Column</a>
-      <a class="btn btn-primary" id="10column" href="#">10 Column</a>
-      <a class="btn btn-primary" id="12column" href="#">12 Column</a>
+      <a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a>
+      <a onClick="setOneColumn(false)" class="btn btn-primary" href="#">1 Column</a>
+      <a onClick="setOneColumn(true)" class="btn btn-primary" href="#">1 Column DOM</a>
+      <a onClick="column(2)" class="btn btn-primary" href="#">2 Column</a>
+      <a onClick="column(3)" class="btn btn-primary" href="#">3 Column</a>
+      <a onClick="column(4)" class="btn btn-primary" href="#">4 Column</a>
+      <a onClick="column(6)" class="btn btn-primary" href="#">6 Column</a>
+      <a onClick="column(8)" class="btn btn-primary" href="#">8 Column</a>
+      <a onClick="column(10)" class="btn btn-primary" href="#">10 Column</a>
+      <a onClick="column(12)" class="btn btn-primary" href="#">12 Column</a>
     </div>
     <br>
     <div class="grid-stack"></div>
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var $grid = $('.grid-stack');
-      $grid.gridstack({float: true});
-      grid = $grid.data('gridstack');
-      var $text = $('#column-text');
+    var grid = GridStack.init({float: true});
+    var text = document.querySelector('#column-text');
 
-      $grid.on('added', function(e, items) {log(' added ', items)});
-      $grid.on('removed', function(e, items) {log(' removed ', items)});
-      $grid.on('change', function(e, items) {log(' change ', items)});
-      function log(type, items) {
-        if (!items) { return; }
-        var str = '';
-        for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
-        console.log(type + items.length + ' items.' + str );
-      }
+    grid.on('added', function(e, items) {log('added ', items)});
+    grid.on('removed', function(e, items) {log('removed ', items)});
+    grid.on('change', function(e, items) {log('change ', items)});
+    function log(type, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(type + items.length + ' items.' + str );
+    }
 
-      var items = [
-        /* match karma testing
-        {x: 0, y: 0, width: 4, height: 2},
-        {x: 4, y: 0, width: 4, height: 4},
-        {text: ' auto'},
-        */
-        {x: 0, y: 0, width: 2, height: 2},
-        {x: 2, y: 0, width: 2, height: 1},
-        {x: 5, y: 1, width: 1, height: 1},
-        {x: 5, y: 0, width: 2, height: 1},
-        // {x: 0, y: 0, width: 1, height: 1}, // conflict
-        {text: ' auto'}, // autoPosition testing
-        // {x: 4, y: 0, width: 1, height: 1}, // same auto-pos
-        {x: 5, y: 3, width: 2, height: 1},
-        {x: 0, y: 4, width: 12, height: 1}
-      ];
-      var count = 0;
-      grid.batchUpdate();
-      addWidget(); addWidget(); addWidget(); addWidget();
-      grid.commit();
+    var items = [
+      /* match karma testing
+      {x: 0, y: 0, width: 4, height: 2},
+      {x: 4, y: 0, width: 4, height: 4},
+      {text: ' auto'},
+      */
+      {x: 0, y: 0, width: 2, height: 2},
+      {x: 2, y: 0, width: 2, height: 1},
+      {x: 5, y: 1, width: 1, height: 1},
+      {x: 5, y: 0, width: 2, height: 1},
+      // {x: 0, y: 0, width: 1, height: 1}, // conflict
+      {text: ' auto'}, // autoPosition testing
+      // {x: 4, y: 0, width: 1, height: 1}, // same auto-pos
+      {x: 5, y: 3, width: 2, height: 1},
+      {x: 0, y: 4, width: 12, height: 1}
+    ];
+    var count = 0;
+    grid.batchUpdate();
+    addWidget(); addWidget(); addWidget(); addWidget();
+    grid.commit();
 
-      function addWidget() {
-        var n = items[count] || {
-          x: Math.round(12 * Math.random()),
-          y: Math.round(5 * Math.random()),
-          width: Math.round(1 + 3 * Math.random()),
-          height: Math.round(1 + 3 * Math.random())
-        };
-        grid.addWidget($('<div><div class="grid-stack-item-content"><button onclick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>'
-          + count++ + (n.text ? n.text : '') + '</div></div>'), n);
+    function addWidget() {
+      var n = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        width: Math.round(1 + 3 * Math.random()),
+        height: Math.round(1 + 3 * Math.random())
       };
+      grid.addWidget('<div><div class="grid-stack-item-content"><button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>'
+        + count++ + (n.text ? n.text : '') + '</div></div>', n);
+    };
 
-      $('#add-widget').click(function() { addWidget() });
-      $('#1column').click(function() { delete grid.opts.oneColumnModeDomSort; grid.setColumn(1); $text.text(1);});
-      $('#1columnDOM').click(function() { grid.opts.oneColumnModeDomSort = true; grid.setColumn(1); $text.text('1 DOM');});
-      $('#2column').click(function() { grid.setColumn(2); $text.text(2);});
-      $('#3column').click(function() { grid.setColumn(3); $text.text(3);});
-      $('#4column').click(function() { grid.setColumn(4); $text.text(4);});
-      $('#6column').click(function() { grid.setColumn(6); $text.text(6);});
-      $('#8column').click(function() { grid.setColumn(8); $text.text(8);});
-      $('#10column').click(function() { grid.setColumn(10); $text.text(10);});
-      $('#12column').click(function() { grid.setColumn(12); $text.text(12);});
-    });
+    function column(n) {
+      grid.column(n);
+      text.innerHTML = n;
+    }
+    function setOneColumn(dom) {
+      grid.opts.oneColumnModeDomSort = dom;
+      grid.column(1);
+      text.innerHTML = dom ? '1 DOM' : '1';
+    }
+
   </script>
 </body>
 </html>

--- a/demo/experiment/test.html
+++ b/demo/experiment/test.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Drag demo</title>
+  <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/cash/6.0.2/cash.min.js"></script>-->\
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <style>
+    .item {
+      width: 100px;
+      height: 100px;
+      display: inline-block;
+      margin: 10px;
+      color: #2c3e50;
+      text-align: center;
+      background-color: #18bc9c;
+    }
+    .item.jq {
+      background-color: #4078b8;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container-fluid">
+    <h1>Drag demo</h1>
+    <br><br>
+    <div class="item jq"> Manual </div>
+    <div class="item" draggable="true"> HTML5 D&D </div>
+  </div>
+
+  <script type="text/javascript">
+    $(function () {
+      $.fn.drags = function (opt) {
+
+        opt = $.extend({
+          handle: "",
+          cursor: "move"
+        }, opt);
+
+        if (opt.handle === "") {
+          var $el = this;
+        } else {
+          var $el = this.find(opt.handle);
+        }
+
+        return $el.css('cursor', opt.cursor).on("mousedown", function (e) {
+          if (opt.handle === "") {
+            var $drag = $(this).addClass('draggable');
+          } else {
+            var $drag = $(this).addClass('active-handle').parent().addClass('draggable');
+          }
+          var z_idx = $drag.css('z-index'),
+            drg_h = $drag.outerHeight(),
+            drg_w = $drag.outerWidth(),
+            pos_y = $drag.offset().top + drg_h - e.pageY,
+            pos_x = $drag.offset().left + drg_w - e.pageX;
+          $drag.css('z-index', 1000).parents().on("mousemove", function (e) {
+            $('.draggable').offset({
+              top: e.pageY + pos_y - drg_h,
+              left: e.pageX + pos_x - drg_w
+            }).on("mouseup", function () {
+              $(this).removeClass('draggable').css('z-index', z_idx);
+            });
+          });
+          e.preventDefault(); // disable selection
+        }).on("mouseup", function () {
+          if (opt.handle === "") {
+            $(this).removeClass('draggable');
+          } else {
+            $(this).removeClass('active-handle').parent().removeClass('draggable');
+          }
+        });
+
+      }
+
+      $('.item.jq').drags();
+    });
+
+  </script>
+</body>
+
+</html>

--- a/demo/experiment/test2.html
+++ b/demo/experiment/test2.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+#div1 {
+  width: 350px;
+  height: 70px;
+  padding: 10px;
+  border: 1px solid #aaaaaa;
+}
+</style>
+<script>
+function allowDrop(ev) {
+  ev.preventDefault();
+}
+
+function drag(ev) {
+  ev.dataTransfer.setData("text", ev.target.id);
+}
+
+function drop(ev) {
+  ev.preventDefault();
+  var data = ev.dataTransfer.getData("text");
+  ev.target.appendChild(document.getElementById(data));
+}
+</script>
+</head>
+<body>
+
+<p>Drag the W3Schools image into the rectangle:</p>
+
+<div id="div1" ondrop="drop(event)" ondragover="allowDrop(event)"></div>
+<br>
+<img id="drag1" src="img_logo.gif" draggable="true" ondragstart="drag(event)" width="336" height="69">
+
+</body>
+</html>

--- a/demo/float.html
+++ b/demo/float.html
@@ -7,10 +7,9 @@
   <title>Float grid demo</title>
 
   <link rel="stylesheet" href="demo.css"/>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
   </style>
 </head>
@@ -18,8 +17,8 @@
   <div class="container-fluid">
     <h1>Float grid demo</h1>
     <div>
-      <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
-      <a class="btn btn-primary" id="float" href="#">float: true</a>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
+      <a class="btn btn-primary" onclick="toggleFloat()" id="float" href="#">float: true</a>
     </div>
     <br><br>
     <div class="grid-stack"></div>
@@ -27,41 +26,32 @@
 
 
   <script type="text/javascript">
-    $(function () {
-      $('.grid-stack').gridstack({float: true});
+    var grid = GridStack.init({float: true});
 
-      new function () {
-        this.items = [
-          {x: 2, y: 5, width: 1, height: 1},
-          {x: 2, y: 3, width: 3, height: 1},
-          {x: 4, y: 2, width: 1, height: 1},
-          {x: 3, y: 1, width: 1, height: 2},
-          {x: 0, y: 6, width: 2, height: 2}
-        ];
-        var count = 0;
+    var items = [
+      {x: 2, y: 1, width: 1, height: 1},
+      {x: 2, y: 3, width: 3, height: 1},
+      {x: 4, y: 2, width: 1, height: 1},
+      {x: 3, y: 1, width: 1, height: 2},
+      {x: 0, y: 6, width: 2, height: 2}
+    ];
+    var count = 0;
 
-        this.grid = $('.grid-stack').data('gridstack');
-
-        this.addNewWidget = function() {
-          var node = this.items[count] || {
-            x: Math.round(12 * Math.random()),
-            y: Math.round(5 * Math.random()),
-            width: Math.round(1 + 3 * Math.random()),
-            height: Math.round(1 + 3 * Math.random())
-          };
-          this.grid.addWidget($('<div><div class="grid-stack-item-content">' + count++ + '</div></div>'), node);
-          return false;
-        }.bind(this);
-
-        this.toggleFloat = function() {
-          this.grid.float(! this.grid.float());
-          $('#float').html('float: ' + this.grid.float());
-        }.bind(this);;
-
-        $('#add-widget').click(this.addNewWidget);
-        $('#float').click(this.toggleFloat);
+    addNewWidget = function() {
+      var node = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        width: Math.round(1 + 3 * Math.random()),
+        height: Math.round(1 + 3 * Math.random())
       };
-    });
+      grid.addWidget('<div><div class="grid-stack-item-content">' + count++ + '</div></div>', node);
+    };
+
+    toggleFloat = function() {
+      grid.float(! grid.float());
+      document.querySelector('#float').innerHTML = 'float: ' + grid.float();
+    };
+    addNewWidget();
   </script>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,6 @@
     <li><a href="column.html">Column</a></li>
     <li><a href="float.html">Float grid</a></li>
     <li><a href="knockout.html">Knockout.js</a></li>
-    <li><a href="knockout2.html">Knockout.js (2)</a></li>
     <li><a href="nested.html">Nested grids</a></li>
     <li><a href="responsive.html">Responsive</a></li>
     <li><a href="right-to-left(rtl).html">Right-To-Left (RTL)</a></li>

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -8,10 +8,11 @@
 
   <link rel="stylesheet" href="demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-debug.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 </head>
 <body>
@@ -34,10 +35,8 @@
             this.widgets = controller.widgets;
 
             this.afterAddWidget = function (items) {
-              if (grid == null) {
-                grid = $(componentInfo.element).find('.grid-stack').gridstack({
-                  auto: false
-                }).data('gridstack');
+              if (!grid ) {
+                grid = GridStack.init({auto: false});
               }
 
               var item = items.find(function (i) { return i.nodeType == 1 });
@@ -55,45 +54,43 @@
         [
           '<div class="grid-stack" data-bind="foreach: {data: widgets, afterRender: afterAddWidget}">',
           '   <div class="grid-stack-item" data-bind="attr: {\'data-gs-x\': $data.x, \'data-gs-y\': $data.y, \'data-gs-width\': $data.width, \'data-gs-height\': $data.height, \'data-gs-auto-position\': $data.auto_position, \'data-gs-id\': $data.id}">',
-            '     <div class="grid-stack-item-content"><button data-bind="click: $root.deleteWidget">Delete me</button></div>',
+          '     <div class="grid-stack-item-content"><button data-bind="click: $root.deleteWidget">Delete me</button></div>',
           '   </div>',
           '</div> '
         ].join('')
     });
 
-    $(function () {
-      var Controller = function (widgets) {
-        var self = this;
+    var Controller = function (widgets) {
+      var self = this;
 
-        this.widgets = ko.observableArray(widgets);
+      this.widgets = ko.observableArray(widgets);
 
-        this.addNewWidget = function () {
-          this.widgets.push({
-            x: 0,
-            y: 0,
-            width: Math.floor(1 + 3 * Math.random()),
-            height: Math.floor(1 + 3 * Math.random()),
-            auto_position: true
-          });
-          return false;
-        };
-
-        this.deleteWidget = function (item) {
-          self.widgets.remove(item);
-          return false;
-        };
+      this.addNewWidget = function () {
+        this.widgets.push({
+          x: 0,
+          y: 0,
+          width: Math.floor(1 + 3 * Math.random()),
+          height: Math.floor(1 + 3 * Math.random()),
+          auto_position: true
+        });
+        return false;
       };
 
-      var widgets = [
-        {x: 0, y: 0, width: 2, height: 2, id: '0'},
-        {x: 2, y: 0, width: 4, height: 2, id: '1'},
-        {x: 6, y: 0, width: 2, height: 4, id: '2'},
-        {x: 1, y: 2, width: 4, height: 2, id: '3'}
-      ];
+      this.deleteWidget = function (item) {
+        self.widgets.remove(item);
+        return false;
+      };
+    };
 
-      var controller = new Controller(widgets);
-      ko.applyBindings(controller);
-    });
+    var widgets = [
+      {x: 0, y: 0, width: 2, height: 2, id: '0'},
+      {x: 2, y: 0, width: 4, height: 2, id: '1'},
+      {x: 6, y: 0, width: 2, height: 4, id: '2'},
+      {x: 1, y: 2, width: 4, height: 2, id: '3'}
+    ];
+
+    var controller = new Controller(widgets);
+    ko.applyBindings(controller);
   </script>
 </body>
 </html>

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -8,9 +8,9 @@
 
   <link rel="stylesheet" href="demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 
   <style type="text/css">
@@ -26,8 +26,8 @@
 <body>
   <div class="container-fluid">
     <h1>Nested grids demo</h1>
-    <a class="btn btn-primary" id="add-widget1" href="#">Add Widget Grid1</a>
-    <a class="btn btn-primary" id="add-widget2" href="#">Add Widget Grid2</a>
+    <a class="btn btn-primary" onClick="addNewWidget(grid1)" href="#">Add Widget Grid1</a>
+    <a class="btn btn-primary" onClick="addNewWidget(grid2)" href="#">Add Widget Grid2</a>
     <br><br>
 
     <div class="grid-stack top">
@@ -59,30 +59,26 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var nestOptions = {
-        acceptWidgets: '.grid-stack-item.sub', // only pink sub items can be inserted, otherwise grid-items causes all sort of issues
-        dragOut: true // let us drag them out!
-      };
-      $('.grid-stack.top').gridstack();
-      var grid1 = $('.grid-stack.nested1').gridstack(nestOptions).data('gridstack');
-      nestOptions.dragOut = false;
-      var grid2 = $('.grid-stack.nested2').gridstack(nestOptions).data('gridstack');
+    var nestOptions = {
+      acceptWidgets: '.grid-stack-item.sub', // only pink sub items can be inserted, otherwise grid-items causes all sort of issues
+      dragOut: true // let us drag them out!
+    };
+    GridStack.init(null, '.grid-stack.top');
+    var grid1 = GridStack.init(nestOptions, '.grid-stack.nested1');
+    nestOptions.dragOut = false;
+    var grid2 = GridStack.init(nestOptions, '.grid-stack.nested2');
 
-      var count = 9;
-      addNewWidget = function(grid) {
-        var node = {
-          x: Math.round(12 * Math.random()),
-          y: Math.round(5 * Math.random()),
-          width: Math.round(1 + 3 * Math.random()),
-          height: Math.round(1 + 3 * Math.random())
-        };
-        grid.addWidget($('<div class="grid-stack-item sub"><div class="grid-stack-item-content">' + count++ + '</div></div>'), node);
-        return false;
+    var count = 9;
+    addNewWidget = function(grid) {
+      var node = {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        width: Math.round(1 + 3 * Math.random()),
+        height: Math.round(1 + 3 * Math.random())
       };
-      $('#add-widget1').click(function () { addNewWidget(grid1)});
-      $('#add-widget2').click(function () { addNewWidget(grid2)});
-    });
+      grid.addWidget('<div class="grid-stack-item sub"><div class="grid-stack-item-content">' + count++ + '</div></div>', node);
+      return false;
+    };
   </script>
 </body>
 </html>

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -6,9 +6,9 @@
   <link rel="stylesheet" href="demo.css"/>
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 </head>
 <body>
@@ -23,49 +23,47 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var grid = $('.grid-stack').gridstack({
-        disableOneColumnMode: true, // will manually do 1 column
-        float: true }).data('gridstack');
-      var $text = $('#column-text');
-      
-      function resizeGrid() {
-        var width = document.body.clientWidth;
-        if (width < 700) {
-          grid.setColumn(1);
-          $text.text(1);
-        } else if (width < 850) {
-          grid.setColumn(3);
-          $text.text(3);
-        } else if (width < 950) {
-          grid.setColumn(6);
-          $text.text(6);
-        } else {
-          grid.setColumn(12);
-          $text.text(12);
-        }
-      };
-      $(window).resize(function () {
-        resizeGrid();
-      });
-      $(document).ready(function() {
-        resizeGrid();
-      });
-      
-      var items = [
-        {x: 0, y: 0, width: 2, height: 2},
-        {x: 2, y: 0, width: 2, height: 1},
-        {x: 5, y: 0, width: 1, height: 1},
-        {x: 1, y: 3, width: 4, height: 1},
-        {x: 5, y: 2, width: 2, height: 1},
-        {x: 0, y: 4, width: 12, height: 1}
-      ];
-      grid.batchUpdate();
-      items.forEach(function (node, index) {
-        grid.addWidget($('<div><div class="grid-stack-item-content">' + index + '</div></div>'), node);
-      });
-      grid.commit();
+    var grid = GridStack.init({
+      disableOneColumnMode: true, // will manually do 1 column
+      float: true });
+    var text = document.querySelector('#column-text');
+    
+    function resizeGrid() {
+      var width = document.body.clientWidth;
+      if (width < 700) {
+        grid.column(1);
+        text.innerHTML = 1;
+      } else if (width < 850) {
+        grid.column(3);
+        text.innerHTML = 3;
+      } else if (width < 950) {
+        grid.column(6);
+        text.innerHTML = 6;
+      } else if (width < 1100) {
+        grid.column(8);
+        text.innerHTML = 8;
+      } else {
+        grid.column(12);
+        text.innerHTML = 12;
+      }
+    };
+    
+    var items = [
+      {x: 0, y: 0, width: 2, height: 2},
+      {x: 2, y: 0, width: 2, height: 1},
+      {x: 5, y: 0, width: 1, height: 1},
+      {x: 1, y: 3, width: 4, height: 1},
+      {x: 5, y: 2, width: 2, height: 1},
+      {x: 0, y: 4, width: 12, height: 1}
+    ];
+    grid.batchUpdate();
+    items.forEach(function(node, index) {
+      grid.addWidget('<div><div class="grid-stack-item-content">' + index + '</div></div>', node);
     });
+    grid.commit();
+    resizeGrid();
+
+    window.addEventListener('resize', function() {resizeGrid()});
   </script>
 </body>
 </html>

--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -13,10 +13,11 @@
     }
   </style>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 </head>
 <body>
@@ -39,10 +40,8 @@
             this.widgets = controller.widgets;
 
             this.afterAddWidget = function (items) {
-              if (grid == null) {
-                grid = $(componentInfo.element).find('.grid-stack').gridstack({
-                  auto: false
-                }).data('gridstack');
+              if (!grid) {
+                grid = GridStack.init({auto: false});
               }
 
               var item = items.find(function (i) { return i.nodeType == 1 });
@@ -66,40 +65,38 @@
         ].join('')
     });
 
-    $(function () {
-      var Controller = function (widgets) {
-        var self = this;
+    var Controller = function (widgets) {
+      var self = this;
 
-        this.widgets = ko.observableArray(widgets);
+      this.widgets = ko.observableArray(widgets);
 
-        this.addNewWidget = function () {
-          this.widgets.push({
-            x: 0,
-            y: 0,
-            width: Math.floor(1 + 3 * Math.random()),
-            height: Math.floor(1 + 3 * Math.random()),
-            auto_position: true,
-            index: 'auto'
-          });
-          return false;
-        };
-
-        this.deleteWidget = function (item) {
-          self.widgets.remove(item);
-          return false;
-        };
+      this.addNewWidget = function () {
+        this.widgets.push({
+          x: 0,
+          y: 0,
+          width: Math.floor(1 + 3 * Math.random()),
+          height: Math.floor(1 + 3 * Math.random()),
+          auto_position: true,
+          index: 'auto'
+        });
+        return false;
       };
 
-      var widgets = [
-        {x: 0, y: 0, width: 2, height: 2, index: 1},
-        {x: 2, y: 0, width: 4, height: 2, index: 2},
-        {x: 6, y: 0, width: 2, height: 4, index: 3},
-        {x: 1, y: 2, width: 4, height: 2, index: 4}
-      ];
+      this.deleteWidget = function (item) {
+        self.widgets.remove(item);
+        return false;
+      };
+    };
 
-      var controller = new Controller(widgets);
-      ko.applyBindings(controller);
-    });
+    var widgets = [
+      {x: 0, y: 0, width: 2, height: 2, index: 1},
+      {x: 2, y: 0, width: 4, height: 2, index: 2},
+      {x: 6, y: 0, width: 2, height: 4, index: 3},
+      {x: 1, y: 2, width: 4, height: 2, index: 4}
+    ];
+
+    var controller = new Controller(widgets);
+    ko.applyBindings(controller);
   </script>
 </body>
 </html>

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -8,17 +8,17 @@
 
   <link rel="stylesheet" href="demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 </head>
 <body>
   <div class="container-fluid">
     <h1>Serialization demo</h1>
-    <a class="btn btn-primary" id="save-grid" href="#">Save Grid</a>
-    <a class="btn btn-primary" id="load-grid" href="#">Load Grid</a>
-    <a class="btn btn-primary" id="clear-grid" href="#">Clear Grid</a>
+    <a onClick="saveGrid()" class="btn btn-primary" href="#">Save</a>
+    <a onClick="loadGrid()" class="btn btn-primary" href="#">Load</a>
+    <a onClick="clearGrid()" class="btn btn-primary" href="#">Clear</a>
     <br/><br/>
     <div class="grid-stack"></div>
     <hr/>
@@ -26,73 +26,53 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var $grid = $('.grid-stack');
-      
-      $grid.on('added', function(e, items) { log(' added ', items) });
-      $grid.on('removed', function(e, items) { log(' removed ', items) });
-      $grid.on('change', function(e, items) { log(' change ', items) });
-      function log(type, items) {
-        if (!items) { return; }
-        var str = '';
-        for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
-        console.log(type + items.length + ' items.' + str );
-      }
+    var grid = GridStack.init();
+    
+    grid.on('added', function(e, items) {log('added ', items)});
+    grid.on('removed', function(e, items) {log('removed ', items)});
+    grid.on('change', function(e, items) {log('change ', items)});
+    function log(type, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(type + items.length + ' items.' + str );
+    }
 
-      $grid.gridstack();
+    var serializedData = [
+      {x: 0, y: 0, width: 2, height: 2},
+      {x: 3, y: 1, width: 1, height: 2},
+      {x: 4, y: 1, width: 1, height: 1},
+      {x: 2, y: 3, width: 3, height: 1},
+      {x: 1, y: 3, width: 1, height: 1}
+    ];
 
-      new function () {
-        this.serializedData = [
-          {x: 0, y: 0, width: 2, height: 2},
-          {x: 3, y: 1, width: 1, height: 2},
-          {x: 4, y: 1, width: 1, height: 1},
-          {x: 2, y: 3, width: 3, height: 1},
-          {x: 1, y: 4, width: 1, height: 1},
-          {x: 1, y: 3, width: 1, height: 1},
-          {x: 2, y: 4, width: 1, height: 1},
-          {x: 2, y: 5, width: 1, height: 1}
-        ];
+    loadGrid = function() {
+      grid.removeAll();
+      var items = GridStack.Utils.sort(serializedData);
+      grid.batchUpdate();
+      items.forEach(function (node) {
+        grid.addWidget('<div><div class="grid-stack-item-content"></div></div>', node);
+      });
+      grid.commit();
+    };
 
-        this.grid = $('.grid-stack').data('gridstack');
+    saveGrid = function() {
+      serializedData = [];
+      grid.engine.nodes.forEach(function(node) {
+        serializedData.push({
+          x: node.x,
+          y: node.y,
+          width: node.width,
+          height: node.height
+        });
+      });
+      document.querySelector('#saved-data').value = JSON.stringify(serializedData, null, '  ');
+    };
 
-        this.loadGrid = function () {
-          this.grid.removeAll();
-          var items = GridStackUI.Utils.sort(this.serializedData);
-          this.grid.batchUpdate();
-          items.forEach(function (node) {
-            this.grid.addWidget($('<div><div class="grid-stack-item-content"></div></div>'), node);
-          }, this);
-          this.grid.commit();
-          return false;
-        }.bind(this);
+    clearGrid = function() {
+      grid.removeAll();
+    }
 
-        this.saveGrid = function () {
-          this.serializedData = $('.grid-stack > .grid-stack-item:visible').map(function (i, el) {
-            el = $(el);
-            var node = el.data('_gridstack_node');
-            return {
-              x: node.x,
-              y: node.y,
-              width: node.width,
-              height: node.height
-            };
-          }).toArray();
-          $('#saved-data').val(JSON.stringify(this.serializedData, null, '  '));
-          return false;
-        }.bind(this);
-
-        this.clearGrid = function () {
-          this.grid.removeAll();
-          return false;
-        }.bind(this);
-
-        $('#save-grid').click(this.saveGrid);
-        $('#load-grid').click(this.loadGrid);
-        $('#clear-grid').click(this.clearGrid);
-
-        this.loadGrid();
-      };
-    });
+    loadGrid();
   </script>
 </body>
 </html>

--- a/demo/two.html
+++ b/demo/two.html
@@ -10,9 +10,9 @@
   <link rel="stylesheet" href="demo.css"/>
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="../dist/jquery-ui.min.js"></script>
+  <script src="../src/jquery.js"></script>
   <script src="../src/gridstack.js"></script>
+  <script src="../src/jquery-ui.js"></script>
   <script src="../src/gridstack.jQueryUI.js"></script>
 
   <style type="text/css">
@@ -82,87 +82,73 @@
 
     <div class="row">
       <div class="col-md-6">
-        <a class="btn btn-primary" id="float1" href="#">float: false</a>
-        <a class="btn btn-primary" id="compact1" href="#">Compact</a>
-        <div class="grid-stack grid-stack-6" id="grid1">
+        <a onClick="toggleFloat(this, 0)" class="btn btn-primary" href="#">float: false</a>
+        <a onClick="compact(0)" class="btn btn-primary" href="#">Compact</a>
+        <div class="grid-stack grid-stack-6">
         </div>
       </div>
       <div class="col-md-6">
-        <a class="btn btn-primary" id="float2" href="#">float: true</a>
-        <a class="btn btn-primary" id="compact2" href="#">Compact</a>
-        <div class="grid-stack grid-stack-6" id="grid2">
+        <a onClick="toggleFloat(this, 1)" class="btn btn-primary" href="#">float: true</a>
+        <a onClick="compact(1)" class="btn btn-primary" href="#">Compact</a>
+        <div class="grid-stack grid-stack-6">
           </div>
       </div>
     </div>
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var options = {
-        column: 6,
-        float: false,
-        removable: '.trash',
-        removeTimeout: 100,
-        acceptWidgets: function(i, el) { return true; } // function example, else can be simple: true | false | '.someClass' value
-      };
-      $('#grid1').gridstack(options);
-      $('#grid2').gridstack($.extend({}, options, {
-        float: true
-      }));
+    var options = {
+      column: 6,
+      float: false,
+      removable: '.trash',
+      removeTimeout: 100,
+      acceptWidgets: function(i, el) { return true; } // function example, else can be simple: true | false | '.someClass' value
+    };
+    var grids = GridStack.initAll(options);
+    grids[1].float(true);
 
-      var items = [
-        {x: 0, y: 0, width: 2, height: 2},
-        {x: 3, y: 1, width: 1, height: 2},
-        {x: 4, y: 1, width: 1, height: 1},
-        {x: 2, y: 3, width: 3, height: 1, minWidth: 2, id: 'special', text: 'has minWidth=2'},
-        {x: 2, y: 5, width: 1, height: 1}
-      ];
+    var items = [
+      {x: 0, y: 0, width: 2, height: 2},
+      {x: 3, y: 1, width: 1, height: 2},
+      {x: 4, y: 1, width: 1, height: 1},
+      {x: 2, y: 3, width: 3, height: 1, minWidth: 2, id: 'special', text: 'has minWidth=2'},
+      {x: 2, y: 5, width: 1, height: 1}
+    ];
 
-      $('.grid-stack').each(function () {
-        var $grid = $(this);
-        var id = $grid.attr('id');
-        $grid.on('added', function(e, items) { log(id, ' added ', items) });
-        $grid.on('removed', function(e, items) { log(id, ' removed ', items) });
-        $grid.on('change', function(e, items) { log(id, ' change ', items) });
-        function log(id, type, items) {
-          if (!items) { return; }
-          var str = '';
-          for (let i=0; i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
-          console.log(id + type + items.length + ' items.' + str );
-        }
-
-        var grid = $grid.data('gridstack');
-        grid.batchUpdate();
-        items.forEach(function (node) {
-          grid.addWidget($('<div><div class="grid-stack-item-content">' 
-            + (node.text? node.text : '') + '</div></div>'), node);
-        });
-        grid.commit();
-      });
-
-      $('.sidebar .grid-stack-item').draggable({
-        revert: 'invalid',
-        handle: '.grid-stack-item-content',
-        scroll: false,
-        appendTo: 'body',
-      });
-
-      $('#float1').click(function() { toggleFloat('#float1', '#grid1') });
-      $('#float2').click(function() { toggleFloat('#float2', '#grid2') });
-      function toggleFloat(button, grid) {
-        var grid = $(grid).data('gridstack');
-        grid.float(! grid.float());
-        $(button).html('float: ' + grid.float());
+    grids.forEach(function (grid, i) {
+      grid.on('added', function(e, items) { log(i, ' added ', items) });
+      grid.on('removed', function(e, items) { log(i, ' removed ', items) });
+      grid.on('change', function(e, items) { log(i, ' change ', items) });
+      function log(id, type, items) {
+        var str = '';
+        items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+        console.log('grid' + id + type + items.length + ' items.' + str );
       }
 
-      $('#compact1').click(function() { compact('#grid1') });
-      $('#compact2').click(function() { compact('#grid2') });
-      function compact(grid) {
-        var grid = $(grid).data('gridstack');
-        grid.compact();
-      }
-
+      grid.batchUpdate();
+      items.forEach(function (node) {
+        grid.addWidget('<div><div class="grid-stack-item-content">' 
+          + (node.text? node.text : '') + '</div></div>', node);
+      });
+      grid.commit();
     });
+
+    // TODO: switch jquery-ui out
+    $('.sidebar .grid-stack-item').draggable({
+      revert: 'invalid',
+      handle: '.grid-stack-item-content',
+      scroll: false,
+      appendTo: 'body',
+    });
+
+    function toggleFloat(button, i) {
+      grids[i].float(! grids[i].float());
+      button.innerHTML = 'float: ' + grids[i].float();
+    }
+
+    function compact(i) {
+      grids[i].compact();
+    }
   </script>
 </body>
 </html>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [v0.6.4-dev (upcoming changes)](#v064-dev-upcoming-changes)
+- [v1.0.0 (upcoming changes)](#v100-upcoming-changes)
 - [v0.6.4 (2020-02-17)](#v064-2020-02-17)
 - [v0.6.3 (2020-02-05)](#v063-2020-02-05)
 - [v0.6.2 (2020-02-03)](#v062-2020-02-03)
@@ -30,9 +30,13 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## v0.6.4-dev (upcoming changes)
+## v1.0.0 (upcoming changes)
 
-- TBD
+- **breaking**: [(1084)](https://github.com/gridstack/gridstack.js/issues/1084) jquery was removed from the API and dependencies (initialize differently, and methods take/return `GridStack` or `HTMLElement` instead of `JQuery`), so your code will need to change. 
+See [Migrating to v1.0.0](https://github.com/gridstack/gridstack.js/blob/develop/README.md#migrating-to-v100)
+- add `column()` to get current column number, and `setColumn(N)` is now `column(N)` (matches other set/get methods)
+- add `grid.on(eventName, callback)` / `grid.off(eventName)` to hide native JQ events mix
+- add `grid.getRow()` to get the current grid row number
 
 ## v0.6.4 (2020-02-17)
 
@@ -49,14 +53,14 @@ Change log
 
 ## v0.6.2 (2020-02-03)
 
-- add `oneColumnModeDomSort` true|false to let you specify a custom layout (use dom order instead of x,y) for oneColumnMode `setColumn(1)` [#713](https://github.com/gridstack/gridstack.js/issues/713)
+- add `oneColumnModeDomSort` true|false to let you specify a custom layout (use dom order instead of x,y) for oneColumnMode `column(1)` [#713](https://github.com/gridstack/gridstack.js/issues/713)
 - fix oneColumnMode to only restore if we auto went to it as window sizes up [#1125](https://github.com/gridstack/gridstack.js/pull/1125)
 - editing in 1 column (or few columns) does a better job updating higher layout (track before and after and move items accordingly). 
 Tracking item swap would be even better still. [#1127](https://github.com/gridstack/gridstack.js/pull/1127)
 
 ## v0.6.1 (2020-02-02)
 
-- fix [#37](https://github.com/gridstack/gridstack.js/issues/37) oneColumnMode (<768px by default) now simply calls `setColumn(1)` and remembers prev columns (so we can restore). This gives
+- fix [#37](https://github.com/gridstack/gridstack.js/issues/37) oneColumnMode (<768px by default) now simply calls `column(1)` and remembers prev columns (so we can restore). This gives
 us full resize/re-order of items capabilities rather than a locked CSS only layout (see prev rev changes). [#1120](https://github.com/gridstack/gridstack.js/pull/1120)
 - fix [responsive.html](https://gridstackjs.com/demo/responsive.html) demo [#1121](https://github.com/gridstack/gridstack.js/pull/1121)
 
@@ -73,7 +77,7 @@ and jQuery UI `draggable.containment` can now be specified in options. You can n
 Also you can now call `batchUpdate()` before calling a bunch of `addWidget()` and get a single event callback (more efficient).
 [#1096](https://github.com/gridstack/gridstack.js/pull/1096)
 - `removeAll()` is now much faster (no relayout) and calls `removed` event just once with a list [#1097](https://github.com/gridstack/gridstack.js/pull/1097)
-- `setColumn()` complete re-write and is no longer "Experimental". We now do a reasonable job at sizing/position the widgets (especially 1 column) and
+- `column()` complete re-write and is no longer "Experimental". We now do a reasonable job at sizing/position the widgets (especially 1 column) and
 also now cache each column layout so you can go back to say 12 column and not loose original layout. [#1098](https://github.com/gridstack/gridstack.js/pull/1098)
 - fix `addWidget(el)` (no data) would not render item at correct location, and overlap item at (0,0) [#1098](https://github.com/gridstack/gridstack.js/pull/1098)
 - you can now pre-define size of dragable elements from a sidebar using standard `data-gs-width` and `data-gs-height` - fix 
@@ -99,7 +103,7 @@ thanks [@ermcgrat](https://github.com/ermcgrat) and others for pointing out code
 
 ## v0.5.3 (2019-11-20)
 
-- grid options `width` is now `column`, `height` now `maxRow`, and `setGridWidth()` now `setColumn()` to match what they are. Old names are still supported (console warnings). Various fixes for custom # of column and re-wrote entire doc section ([#1053](https://github.com/gridstack/gridstack.js/issues/1053)).
+- grid options `width` is now `column`, `height` now `maxRow`, and `setGridWidth()` now `column()` to match what they are. Old names are still supported (console warnings). Various fixes for custom # of column and re-wrote entire doc section ([#1053](https://github.com/gridstack/gridstack.js/issues/1053)).
 - fix widgets not animating when `animate: true` is used. on every move, styles were recreated-fix should slightly improve gridstack.js speed ([#937](https://github.com/gridstack/gridstack.js/issues/937)).
 - fix moving widgets when having multiple grids. jquery-ui workaround ([#1043](https://github.com/gridstack/gridstack.js/issues/1043)).
 - switch to eslint ([#763](https://github.com/gridstack/gridstack.js/issues/763)) thanks [@rwstoneback](https://github.com/rwstoneback).
@@ -182,7 +186,7 @@ thanks [@ermcgrat](https://github.com/ermcgrat) and others for pointing out code
 - `'auto'` value for `cellHeight` option
 - fix `setStatic` method
 - add `setAnimation` method to API
-- add `setColumn` method ([#227](https://github.com/gridstack/gridstack.js/issues/227))
+- add `column` method ([#227](https://github.com/gridstack/gridstack.js/issues/227))
 - add `removable`/`removeTimeout` *(experimental)*
 - add `detachGrid` parameter to `destroy` method ([#216](https://github.com/gridstack/gridstack.js/issues/216)) (thanks @jhpedemonte)
 - add `useOffset` parameter to `getCellFromPixel` method ([#237](https://github.com/gridstack/gridstack.js/issues/237))
@@ -239,7 +243,7 @@ thanks [@ermcgrat](https://github.com/ermcgrat) and others for pointing out code
 
 - add `height` option
 - auto-generate css rules (widgets `height` and `top`)
-- add `GridStackUI.Utils.sort` utility function
+- add `GridStack.Utils.sort` utility function
 - add `removeAll` API method
 - add `resize` and `move` API methods
 - add `resizable` and `movable` API methods

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ gridstack.js API
   - [cellHeight(val, noUpdate)](#cellheightval-noupdate)
   - [cellWidth()](#cellwidth)
   - [commit()](#commit)
+  - [column(column, doNotPropagate)](#columncolumn-donotpropagate)
   - [destroy([detachGrid])](#destroydetachgrid)
   - [disable()](#disable)
   - [enable()](#enable)
@@ -49,14 +50,13 @@ gridstack.js API
   - [resize(el, width, height)](#resizeel-width-height)
   - [resizable(el, val)](#resizableel-val)
   - [setAnimation(doAnimate)](#setanimationdoanimate)
-  - [setColumn(column, doNotPropagate)](#setcolumncolumn-donotpropagate)
   - [setStatic(staticValue)](#setstaticstaticvalue)
   - [update(el, x, y, width, height)](#updateel-x-y-width-height)
   - [verticalMargin()](#verticalmargin)
   - [verticalMargin(value, noUpdate)](#verticalmarginvalue-noupdate)
   - [willItFit(x, y, width, height, autoPosition)](#willitfitx-y-width-height-autoposition)
 - [Utils](#utils)
-  - [GridStackUI.Utils.sort(nodes[, dir[, width]])](#gridstackuiutilssortnodes-dir-width)
+  - [GridStack.Utils.sort(nodes[, dir[, width]])](#gridstackutilssortnodes-dir-width)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -75,7 +75,7 @@ gridstack.js API
   * a string (ex: '100px', '10em', '10rem', '10%')
   * 0 or null, in which case the library will not generate styles for rows. Everything must be defined in CSS files.
   * `'auto'` - height will be calculated to match cell width (initial square grid).
-- `column` - number of columns (default: `12`) which can change on the fly with `setColumn()` as well. See [example](http://gridstackjs.com/demo/column.html)
+- `column` - number of columns (default: `12`) which can change on the fly with `column(N)` as well. See [example](http://gridstackjs.com/demo/column.html)
 - `ddPlugin` - class that implement drag'n'drop functionallity for gridstack. If `false` grid will be static. (default: `null` - first available plugin will be used)
 - `disableDrag` - disallows dragging of widgets (default: `false`).
 - `disableOneColumnMode` - disables the onColumnMode when the window width is less than minWidth (default: 'false')
@@ -105,7 +105,7 @@ gridstack.js API
 - `data-gs-animate` - turns animation on
 - `data-gs-column` - amount of columns. Setting non-default value must be supported by equivalent change in CSS, [see docs here](https://github.com/gridstack/gridstack.js#change-grid-columns).
 - `data-gs-max-row` - maximum rows amount. Default is `0` which means no maximum rows.
-- `data-gs-current-height` - current rows amount. Set by the library only. Can be used by the CSS rules.
+- `data-gs-current-row` - current rows amount. Set by the library only. Can be used by the CSS rules.
 
 ## Item attributes
 
@@ -123,43 +123,41 @@ to completely lock the widget.
 
 ## Events
 
+Those are the events set by the grid when items are added/removed or changed - they use standard JS calls with a CustomElement that stores the list
+of nodes that changed (id, x, y, width, height, etc...)
+
 ### added(event, items)
 
-```javascript
-$('.grid-stack').on('added', function(event, items) {
-  for (var i = 0; i < items.length; i++) {
-    console.log('item added');
-    console.log(items[i]);
-  }
+Called when widgets are being added to a grid
+
+```js
+grid.on('added', function(event, items) {
+  /* items contains GridStackNode[] info */
 });
 ```
 
 ### change(event, items)
 
-Occurs when adding/removing widgets or existing widgets change their position/size
+Occurs when widgets change their position/size due to constrain or direct changes
 
-```javascript
-var serializeWidgetMap = function(items) {
-  console.log(items);
-};
-
-$('.grid-stack').on('change', function(event, items) {
-  serializeWidgetMap(items);
+```js
+grid.on('change', function(event, items) {
+  /* items contains GridStackNode[] info */
 });
 ```
 
 ### disable(event)
 
-```javascript
-$('.grid-stack').on('disable', function(event) {
+```js
+grid.on('disable', function(event) {
   var grid = event.target;
 });
 ```
 
 ### dragstart(event, ui)
 
-```javascript
-$('.grid-stack').on('dragstart', function(event, ui) {
+```js
+grid.on('dragstart', function(event, ui) {
   var grid = this;
   var element = event.target;
 });
@@ -167,8 +165,8 @@ $('.grid-stack').on('dragstart', function(event, ui) {
 
 ### dragstop(event, ui)
 
-```javascript
-$('.grid-stack').on('dragstop', function(event, ui) {
+```js
+grid.on('dragstop', function(event, ui) {
   var grid = this;
   var element = event.target;
 });
@@ -176,8 +174,8 @@ $('.grid-stack').on('dragstop', function(event, ui) {
 
 ### dropped(event, previousWidget, newWidget)
 
-```javascript
-$('.grid-stack').on('dropped', function(event, previousWidget, newWidget) {
+```js
+grid.on('dropped', function(event, previousWidget, newWidget) {
   console.log('Removed widget that was dragged out of grid:', previousWidget);
   console.log('Added widget in dropped grid:', newWidget);
 });
@@ -185,27 +183,26 @@ $('.grid-stack').on('dropped', function(event, previousWidget, newWidget) {
 
 ### enable(event)
 
-```javascript
-$('.grid-stack').on('enable', function(event) {
+```js
+grid.on('enable', function(event) {
   var grid = event.target;
 });
 ```
 
 ### removed(event, items)
 
-```javascript
-$('.grid-stack').on('removed', function(event, items) {
-  for (var i = 0; i < items.length; i++) {
-    console.log('item removed');
-    console.log(items[i]);
-  }
+Called when item is being removed from the grid
+
+```js
+grid.on('removed', function(event, items) {
+  /* items contains GridStackNode[] info */
 });
 ```
 
 ### resizestart(event, ui)
 
-```javascript
-$('.grid-stack').on('resizestart', function(event, ui) {
+```js
+grid.on('resizestart', function(event, ui) {
   var grid = this;
   var element = event.target;
 });
@@ -215,9 +212,11 @@ $('.grid-stack').on('resizestart', function(event, ui) {
 **Note**: this is a custom event name that is guaranteed to be called
 **after** the jqueryui resizestop event where we update `data-gs-width` and `data-gs-height`.
 
-```javascript
-$('.grid-stack').on('gsresizestop', function(event, elem) {
-  var newHeight = $(elem).attr('data-gs-height');
+You could instead use the `change` event which has the latest node sizing.
+
+```js
+grid.on('gsresizestop', function(event, element) {
+  var newHeight = element.getAttribute('data-gs-height');
 });
 ```
 
@@ -246,9 +245,8 @@ position (optional)
 Widget will be always placed even if result height is more than actual grid height. You need to use `willItFit` method
 before calling `addWidget` for additional check.
 
-```javascript
-$('.grid-stack').gridstack();
-var grid = $('.grid-stack').data('gridstack');
+```js
+var grid = GridStack.init();
 grid.addWidget(el, 0, 0, 3, 2, true);
 ```
 
@@ -269,7 +267,7 @@ Gets current cell height.
 Update current cell height. This method rebuilds an internal CSS stylesheet (unless optional noUpdate=true). Note: You can expect performance issues if
 call this method too often.
 
-```javascript
+```js
 grid.cellHeight(grid.cellWidth() * 1.2);
 ```
 
@@ -280,6 +278,16 @@ Gets current cell width.
 ### commit()
 
 Ends batch updates. Updates DOM nodes. You must call it after `batchUpdate()`.
+
+### column(column, doNotPropagate)
+
+set/get the number of columns in the grid. Will update existing widgets to conform to new number of columns,
+as well as cache the original layout so you can revert back to previous positions without loss.
+Requires `gridstack-extra.css` or `gridstack-extra.min.css` for [2-11],
+else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
+
+- `column` - Integer > 0 (default 12), if missing it will return the current count instead.
+- `doNotPropagate` - if true existing widgets will not be updated during a set.
 
 ### destroy([detachGrid])
 
@@ -293,34 +301,36 @@ Parameters:
 
 Disables widgets moving/resizing. This is a shortcut for:
 
-```javascript
-grid.movable('.grid-stack-item', false);
-grid.resizable('.grid-stack-item', false);
+```js
+grid.enableMove(false);
+grid.enableResize(false);
 ```
 
 ### enable()
 
 Enables widgets moving/resizing. This is a shortcut for:
 
-```javascript
-grid.movable('.grid-stack-item', true);
-grid.resizable('.grid-stack-item', true);
+```js
+grid.enableMove(true);
+grid.enableResize(true);
 ```
 
 ### enableMove(doEnable, includeNewWidgets)
 
-Enables/disables widget moving. `includeNewWidgets` will force new widgets to be draggable as per `doEnable`'s value by changing the `disableDrag` grid option. This is a shortcut for:
+Enables/disables widget moving. `includeNewWidgets` will force new widgets to be draggable as per `doEnable`'s value by changing the `disableDrag` grid option (default: true). This is a shortcut for:
 
-```javascript
-grid.movable(this.container.children('.' + this.opts.itemClass), doEnable);
+```js
+grid.movable('.grid-stack-item', doEnable);
+grid.opts.disableDrag = !doEnable;
 ```
 
 ### enableResize(doEnable, includeNewWidgets)
 
-Enables/disables widget resizing. `includeNewWidgets` will force new widgets to be resizable as per `doEnable`'s value by changing the `disableResize` grid option.  This is a shortcut for:
+Enables/disables widget resizing. `includeNewWidgets` will force new widgets to be resizable as per `doEnable`'s value by changing the `disableResize` grid option  (default: true). This is a shortcut for:
 
-```javascript
-grid.resizable(this.container.children('.' + this.opts.itemClass), doEnable);
+```js
+grid.resizable('.grid-stack-item', doEnable);
+grid.opts.disableResize = !doEnable;
 ```
 
 ### float(val?)
@@ -360,11 +370,9 @@ Parameters:
 
 - `el` - element to convert to a widget
 
-```javascript
-$('.grid-stack').gridstack();
-
-$('.grid-stack').append('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="true"></div>')
-var grid = $('.grid-stack').data('gridstack');
+```js
+var grid = GridStack.init();
+grid.el.appendChild('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="true"></div>')
 grid.makeWidget('gsi-1');
 ```
 
@@ -451,16 +459,6 @@ Toggle the grid animation state.  Toggles the `grid-stack-animate` class.
 
 - `doAnimate` - if `true` the grid will animate.
 
-### setColumn(column, doNotPropagate)
-
-Modify number of columns in the grid. Will update existing widgets to conform to new number of columns,
-as well as cache the original layout so you can revert back to previous positions without loss.
-Requires `gridstack-extra.css` or `gridstack-extra.min.css` for [1-11],
-else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
-
-- `column` - Integer > 0 (default 12).
-- `doNotPropagate` - if true existing widgets will not be updated.
-
 ### setStatic(staticValue)
 
 Toggle the grid static state.  Also toggle the `grid-stack-static` class.
@@ -493,7 +491,7 @@ Parameters:
 Returns `true` if the `height` of the grid will be less the vertical constraint. Always returns `true` if grid doesn't
 have `height` constraint.
 
-```javascript
+```js
 if (grid.willItFit(newNode.x, newNode.y, newNode.width, newNode.height, true)) {
   grid.addWidget(newNode.el, newNode.x, newNode.y, newNode.width, newNode.height, true);
 }
@@ -505,7 +503,7 @@ else {
 
 ## Utils
 
-### GridStackUI.Utils.sort(nodes[, dir[, width]])
+### GridStack.Utils.sort(nodes[, dir[, width]])
 
 Sorts array of nodes
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'node_modules/jquery/dist/jquery.min.js',
+      'dist/jquery.min.js',
       'src/gridstack.js',
       'dist/jquery-ui.min.js',
       'src/gridstack.jQueryUI.js',

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
   "name": "gridstack",
-  "version": "0.6.4-dev",
-  "description": "gridstack.js for dashboard layout and creation, with many wrappers (React, Angular, Ember, knockout...)",
+  "version": "1.0.0-rc",
+  "description": "TypeScript/Javascript lib for dashboard layout and creation, no external dependencies, with many wrappers (React, Angular, Ember, knockout...)",
   "main": "dist/gridstack.js",
+  "typings": "dist/gridstack.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gridstack/gridstack.js.git"
   },
   "scripts": {
-    "build": "grunt && doctoc ./README.md && doctoc ./doc/README.md && doctoc ./doc/CHANGES.md",
+    "build": "rm dist/* && grunt && doctoc ./README.md && doctoc ./doc/README.md && doctoc ./doc/CHANGES.md",
     "test": "grunt lint && karma start karma.conf.js",
     "lint": "grunt lint",
     "reset": "rm -rf dist node_modules",
     "prepublishOnly": "yarn build"
   },
   "keywords": [
+    "Typescript",
     "gridstack.js",
     "grid",
     "gridster",
@@ -26,7 +28,7 @@
     "widgets",
     "Angular",
     "React",
-    "Typescript"
+    "JavaScript"
   ],
   "author": "Pavel Reznikov <pashka.reznikov@gmail.com>",
   "contributors": [
@@ -38,10 +40,10 @@
     "url": "https://github.com/gridstack/gridstack.js/issues"
   },
   "homepage": "http://gridstack.github.io/gridstack.js/",
-  "dependencies": {
-    "jquery": "^1.8 || 2 || 3"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@types/jquery": "^3.3.32",
+    "@types/jqueryui": "^1.12.10",
     "connect": "^3.6.6",
     "core-js": "^3.0.0",
     "coveralls": "^3.0.3",
@@ -64,7 +66,8 @@
     "karma-coveralls": "^2.1.0",
     "karma-jasmine": "^2.0.1",
     "puppeteer": "^1.13.0",
-    "serve-static": "^1.13.2"
+    "serve-static": "^1.13.2",
+    "typescript": "^3.8.2"
   },
   "resolutions": {
     "lodash": "^4.17.13",

--- a/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
+++ b/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
@@ -12,7 +12,7 @@
 
   <link rel="stylesheet" href="../../../demo/demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="../../../dist/jquery.min.js"></script>
   <script src="../../../dist/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
@@ -45,14 +45,12 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var options = {
-        cellHeight: 80,
-        verticalMargin: 10,
-        float: true
-      };
-      $('.grid-stack').gridstack(options);
-    });
+    var options = {
+      cellHeight: 80,
+      verticalMargin: 10,
+      float: true
+    };
+    GridStack.init(options);
   </script>
 </body>
 

--- a/spec/e2e/html/1142_change_event_missing.html
+++ b/spec/e2e/html/1142_change_event_missing.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>test demo</title>
+  <title>1142 demo</title>
 
   <link rel="stylesheet" href="../../../demo/demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="../../../dist/jquery.min.js"></script>
   <script src="../../../dist/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
@@ -22,27 +22,21 @@
   </div>
   
 <script type="text/javascript">
-  $(function () {
-    var $grid = $('.grid-stack').gridstack({float: false});
+  var grid = GridStack.init({float: false});
 
-  $grid.on('added', function(e, items) { log(' added ', items) });
-  $grid.on('removed', function(e, items) { log(' removed ', items) });
-  $grid.on('change', function(e, items) { log(' change ', items) });
-
+  grid.on('added', function(e, items) {log('added ', items)});
+  grid.on('removed', function(e, items) {log('removed ', items)});
+  grid.on('change', function(e, items) {log('change ', items)});
   function log(type, items) {
     var str = '';
-    for (let i = 0; items && i < items.length && items[i]; i++) {
-      str += ' (x,y)=' + items[i].x + ',' + items[i].y;
-    }
+    items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
     console.log(type + items.length + ' items.' + str);
   }
 
   $('.grid-stack .grid-stack-item').click(function(e) {
     var item = $(e.currentTarget).closest('.grid-stack-item');
-    var g = item.closest('.grid-stack').data('gridstack');
-    g.removeWidget(item);
+    grid.removeWidget(item);
   });
-});
 </script>
 </body>
 </html>

--- a/spec/e2e/html/1143_nested_acceptWidget_types.html
+++ b/spec/e2e/html/1143_nested_acceptWidget_types.html
@@ -9,8 +9,8 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
   <link rel="stylesheet" href="../../../demo/demo.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
-  <script src="../../../dist/jquery-ui.js"></script>
+  <script src="../../../dist/jquery.min.js"></script>
+  <script src="../../../dist/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
 
@@ -19,10 +19,10 @@
       opacity: 0.8;
       filter: blur(5px);
     }
-    #advanced-grid .grid-stack-item-content {
+    .outer .grid-stack-item-content {
       background-color: transparent;
     }
-    #advanced-grid .nested1 .grid-stack-item-content {
+    .outer .nested .grid-stack-item-content {
       background-color: #18bc9c;
     }
   </style>
@@ -37,12 +37,12 @@
       </div>
     </div>
     <div class="col-sm-12 col-md-10">
-      <div class="grid-stack" id="advanced-grid" data-gs-animate="yes">
+      <div class="grid-stack outer" data-gs-animate="yes">
         <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="12" data-gs-height="3">
           <div class="grid-stack-item-content">
             This nested grid accepts new widget with class "newWidget"<br/>
-            The parent grid also accepts new widget but with a differenent class 'otherWidgetType'<br/>&nbsp;
-          <div class="grid-stack nested1">
+            The parent grid also accepts new widget but with a different class 'otherWidgetType'<br/>&nbsp;
+          <div class="grid-stack nested">
             <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">1</div></div>
             <div class="grid-stack-item sub" data-gs-x="3" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">2</div></div>
             <div class="grid-stack-item sub" data-gs-x="6" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">3</div></div>
@@ -58,26 +58,23 @@
   </div>
 
   <script type="text/javascript">
-    $(function () {
-      var $grid = $('#advanced-grid');
-      $grid.gridstack({ acceptWidgets: '.otherWidgetType' });
-      $('.grid-stack.nested1').gridstack({ acceptWidgets: '.newWidget' });
-      
-      $grid.on('added', function(e, items) { log(' added ', items) });
-      $grid.on('removed', function(e, items) { log(' removed ', items) });
-      $grid.on('change', function(e, items) { log(' change ', items) });
-      function log(type, items) {
-        var str = '';
-        for (let i=0; items && i<items.length && items[i]; i++) { str += ' (x,y)=' + items[i].x + ',' + items[i].y; }
-        console.log(type + items.length + ' items.' + str );
-      }
+    var grid = GridStack.init({ acceptWidgets: '.otherWidgetType' }, '.grid-stack.outer');
+    var gridNest = GridStack.init({ acceptWidgets: '.newWidget' }, '.grid-stack.nested');
+    
+    grid.on('added', function(e, items) {log('added ', items)});
+    grid.on('removed', function(e, items) {log('removed ', items)});
+    grid.on('change', function(e, items) {log('change ', items)});
+    function log(type, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(type + items.length + ' items.' + str );
+    }
 
-      $('.newWidget').draggable({
-        revert: 'invalid',
-        scroll: false,
-        appendTo: 'body',
-        helper: 'clone'
-      });
+    $('.newWidget').draggable({
+      revert: 'invalid',
+      scroll: false,
+      appendTo: 'body',
+      helper: 'clone'
     });
   </script>
 </body>

--- a/spec/e2e/html/1155-max-row.html
+++ b/spec/e2e/html/1155-max-row.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>maxRow Test</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+
+  <script src="../../../dist/jquery.min.js"></script>
+  <script src="../../../dist/jquery-ui.min.js"></script>
+  <script src="../../../src/gridstack.js"></script>
+  <script src="../../../src/gridstack.jQueryUI.js"></script>
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>maxRow Test</h1>
+    <br/>
+    <div class="grid-stack"></div>
+  </div>
+
+  <script type="text/javascript">
+    var grid = GridStack.init({float: true, maxRow: 3});
+
+    var items = [
+      {x: 0, y: 1, width: 1, height: 2},
+      {x: 1, y: 3, width: 2, height: 1, text: 'Y=3 out of bound should align'}
+    ];
+    var count = 0;
+
+    grid.batchUpdate();
+    items.forEach(function (node) {
+      node.id = count++;
+      grid.addWidget('<div><div class="grid-stack-item-content">' + (node.text? node.text : node.id) +'</div></div>', node);
+    });
+    grid.commit();
+  </script>
+</body>
+</html>

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../../../demo/demo.css"/>
   <link rel="stylesheet" href="810-many-columns.css"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="../../../dist/jquery.min.js"></script>
   <script src="../../../dist/jquery-ui.min.js"></script>
   <script src="../../../src/gridstack.js"></script>
   <script src="../../../src/gridstack.jQueryUI.js"></script>
@@ -18,7 +18,7 @@
   <div class="container-fluid">
     <h1>Many Columns demo</h1>
     <div>
-      <a class="btn btn-primary" id="add-widget" href="#">Add Widget</a>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
     </div>
     <br><br>
     <div class="grid-stack"></div>
@@ -26,31 +26,23 @@
 
 
   <script type="text/javascript">
-    $(function () {
-      const COLUMNS = 30; // # of columns, also need to update CSS
-      var count = 0;
-      var options = {
-        column: COLUMNS,
-        cellHeight: 'auto',
-        float: false
-      };
-      $('.grid-stack').gridstack(options);
+    const COLUMNS = 30; // # of columns, also need to update CSS
+    var count = 0;
+    var options = {
+      column: COLUMNS,
+      cellHeight: 'auto',
+      float: false
+    };
+    var grid = GridStack.init(options);
 
-      new function () {
-        this.grid = $('.grid-stack').data('gridstack');
+    addNewWidget = function() {
+      grid.addWidget('<div><div class="grid-stack-item-content">' + count + '</div></div>', {id: count});
+      count++
+    };
 
-        this.addNewWidget = function(i) {
-          this.grid.addWidget($('<div><div class="grid-stack-item-content">' + i + '</div></div>'), {id: i});
-          return false;
-        }.bind(this);
-
-        for (; count < COLUMNS; count++) {
-          this.addNewWidget(count); 
-        }
-
-        $('#add-widget').click(this.addNewWidget(count++));
-      };
-    });
+    for (; count <= COLUMNS;) {
+      this.addNewWidget(); 
+    }
   </script>
 </body>
 </html>

--- a/spec/e2e/html/events.html
+++ b/spec/e2e/html/events.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Events test</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+
+  <script src="../../../dist/jquery.js"></script>
+  <script src="../../../dist/jquery-ui.js"></script>
+  <script src="../../../src/gridstack.js"></script>
+  <script src="../../../src/gridstack.jQueryUI.js"></script>
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Events test</h1>
+    <div><a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a></div>
+    <br>
+    <div class="grid-stack"></div>
+  </div>
+
+  <script type="text/javascript">
+    var grid = GridStack.init({float: true});
+    var count = 0;
+
+    function addWidget() {
+      grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content"><button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>'
+        + count++ + '</div></div>');
+    };
+
+    grid.on('added', function(e, items) {log('added ', items)});
+    grid.on('removed', function(e, items) {log('removed ', items)});
+    grid.on('change', function(e, items) {log('change ', items)});
+    function log(type, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y,wxh)=' + item.x + ',' + item.y + ' ' + item.width + 'x' + item.height; });
+      console.log(type + items.length + ' items.' + str );
+    }
+
+    grid.on('disable', function(event) {
+      var grid = event.target;
+      console.log('disable');
+    });
+
+    grid.on('dragstart', function(event, ui) {
+      var grid = this;
+      var el = event.target;
+      console.log('dragStart ' + el.textContent);
+    });
+
+    grid.on('dragstop', function(event, ui) {
+      var grid = this;
+      var el = event.target;
+      console.log('dragstop ' + el.textContent);
+    });
+
+    grid.on('dropped', function(event, previousWidget, newWidget) {
+      console.log('dropped - Removed widget that was dragged out of grid:', previousWidget);
+      console.log('dropped - Added widget in dropped grid:', newWidget);
+    });
+
+    grid.on('enable', function(event) {
+      var grid = event.target;
+      console.log('enable');
+    });
+
+    grid.on('resizestart', function(event, ui) {
+      var grid = this;
+      var el = event.target;
+      var w = el.getAttribute('data-gs-width');
+      var h = el.getAttribute('data-gs-height');
+      console.log('resizestart ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
+    });
+
+    grid.on('resizestop', function(event, ui) {
+      // HAPPENS BEFORE we get to update our attr - SKIP
+      var el = event.target;
+      var w = el.getAttribute('data-gs-width');
+      var h = el.getAttribute('data-gs-height');
+      console.log('JQ resizestop ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
+    });
+
+    grid.on('gsresizestop', function(event, el) {
+      var w = el.getAttribute('data-gs-width');
+      var h = el.getAttribute('data-gs-height');
+      console.log('gsresizestop ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
+    });
+
+    addWidget();
+
+    // jQuery-ui event on '.grid-stack-item' propagates up
+    grid.on('resize', function(event, ui) {
+      var el = event.target;
+      // console.log('resize size: (' + el.clientWidth + ' x ' + el.clientHeight + ')');
+    });
+
+  </script>
+</body>
+</html>

--- a/spec/gridstack-engine-spec.js
+++ b/spec/gridstack-engine-spec.js
@@ -6,14 +6,14 @@ describe('gridstack engine', function() {
 
   beforeEach(function() {
     w = window;
-    e = w.GridStackUI.Engine;
+    e = GridStack.Engine;
   });
 
   describe('test constructor', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12);
+      engine = new GridStack.Engine(12);
     });
 
     it('should be setup properly', function() {
@@ -28,7 +28,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12);
+      engine = new GridStack.Engine(12);
     });
 
     it('should prepare a node', function() {
@@ -53,7 +53,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12, null, true);
+      engine = new GridStack.Engine(12, null, true);
       engine.nodes = [
         engine._prepareNode({x: 3, y: 2, width: 3, height: 2})
       ];
@@ -74,7 +74,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12, null, true);
+      engine = new GridStack.Engine(12, null, true);
       engine.nodes = [
         engine._prepareNode({x: 0, y: 0, width: 1, height: 1, idx: 1, _dirty: true}),
         engine._prepareNode({x: 3, y: 2, width: 3, height: 2, idx: 2, _dirty: true}),
@@ -112,7 +112,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12);
+      engine = new GridStack.Engine(12);
     });
 
     it('should work on not float grids', function() {
@@ -140,7 +140,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12, null, true);
+      engine = new GridStack.Engine(12, null, true);
     });
 
     it('should work on float grids', function() {
@@ -164,7 +164,7 @@ describe('gridstack engine', function() {
       };
       spyOn(spy, 'callback');
 
-      engine = new GridStackUI.Engine(12, spy.callback, true);
+      engine = new GridStack.Engine(12, spy.callback, true);
 
       engine.nodes = [
         engine._prepareNode({x: 0, y: 0, width: 1, height: 1, idx: 1, _dirty: true}),
@@ -223,7 +223,7 @@ describe('gridstack engine', function() {
       };
 
       beforeEach(function() {
-        engine = new GridStackUI.Engine(12, null, false);
+        engine = new GridStack.Engine(12, null, false);
       });
 
       it('shouldn\'t pack one node with y coord eq 0', function() {
@@ -290,7 +290,7 @@ describe('gridstack engine', function() {
     var engine;
 
     beforeAll(function() {
-      engine = new GridStackUI.Engine(12);
+      engine = new GridStack.Engine(12);
     });
 
     it('should return true for changed x', function() {

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -26,7 +26,7 @@ describe('gridstack', function() {
 
   beforeEach(function() {
     w = window;
-    e = w.GridStackUI.Engine;
+    e = GridStack.Engine;
   });
 
   describe('setup of gridstack', function() {
@@ -114,7 +114,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       $('.grid-stack').removeClass('grid-stack-animate');
       grid.setAnimation(true);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(true);
@@ -124,7 +124,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       $('.grid-stack').addClass('grid-stack-animate');
       grid.setAnimation(false);
       expect($('.grid-stack').hasClass('grid-stack-animate')).toBe(false);
@@ -144,7 +144,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       $('.grid-stack').removeClass('grid-stack-static');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(true);
@@ -155,7 +155,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         staticGrid: false
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       $('.grid-stack').addClass('grid-stack-static');
       grid._setStaticClass();
       expect($('.grid-stack').hasClass('grid-stack-static')).toBe(false);
@@ -174,7 +174,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var container = $('.grid-stack');
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel);
@@ -186,7 +186,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, false);
       expect(cell.x).toBe(2);
@@ -197,7 +197,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var pixel = {top: 500, left: 200};
       var cell = grid.getCellFromPixel(pixel, true);
       expect(cell.x).toBe(2);
@@ -218,7 +218,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var res = Math.round($('.grid-stack').outerWidth() / 12);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -228,7 +228,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         column: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var res = Math.round($('.grid-stack').outerWidth() / 10);
       expect(grid.cellWidth()).toBe(res);
     });
@@ -249,10 +249,11 @@ describe('gridstack', function() {
         verticalMargin: verticalMargin,
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var container = $('.grid-stack');
-      var grid = container.data('gridstack');
-      var rows = container.attr('data-gs-current-height');
+      var rows = parseInt(container.attr('data-gs-current-row'));
+      
+      expect(grid.getRow()).toBe(rows);
 
       expect(grid.cellHeight()).toBe(cellHeight);
       expect(parseInt(container.css('height'))).toBe(rows * cellHeight + (rows-1) * verticalMargin);
@@ -273,7 +274,7 @@ describe('gridstack', function() {
     });
   });
 
-  describe('grid.setColumn', function() {
+  describe('grid.column', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
     });
@@ -281,29 +282,29 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should have no changes', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
-      expect(grid.opts.column).toBe(12);
-      grid.setColumn(12);
-      expect(grid.opts.column).toBe(12);
+      var grid = GridStack.init();
+      expect(grid.column()).toBe(12);
+      grid.column(12);
+      expect(grid.column()).toBe(12);
     });
     it('should SMALL change column number, no relayout', function() {
       var options = {
         column: 12
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
-      grid.setColumn(10, false);
-      expect(grid.opts.column).toBe(10);
+      grid.column(10, false);
+      expect(grid.column()).toBe(10);
       for (var j = 0; j < items.length; j++) {
         expect(parseInt($(items[j]).attr('data-gs-y'), 10)).toBe(0);
       }
-      grid.setColumn(9, true);
-      expect(grid.opts.column).toBe(9);
+      grid.column(9, true);
+      expect(grid.column()).toBe(9);
       for (var j = 0; j < items.length; j++) {
         expect(parseInt($(items[j]).attr('data-gs-y'), 10)).toBe(0);
       }
-      grid.setColumn(12);
-      expect(grid.opts.column).toBe(12);
+      grid.column(12);
+      expect(grid.column()).toBe(12);
       for (var j = 0; j < items.length; j++) {
         expect(parseInt($(items[j]).attr('data-gs-y'), 10)).toBe(0);
       }
@@ -313,7 +314,7 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var el1 = $('#item1')
       var el2 = $('#item2')
 
@@ -328,8 +329,8 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-width'))).toBe(4);
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
       // 1 column will have item1, item2
-      grid.setColumn(1);
-      expect(grid.opts.column).toBe(1);
+      grid.column(1);
+      expect(grid.column()).toBe(1);
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
@@ -341,7 +342,7 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
 
       // add default 1x1 item to the end (1 column)
-      var el3 = grid.addWidget(widgetHTML);
+      var el3 = $(grid.addWidget(widgetHTML));
       expect(el3).not.toBe(null);
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(6);
@@ -349,8 +350,8 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-height'))).toBe(1);
 
       // back to 12 column and initial layout (other than new item3)
-      grid.setColumn(12);
-      expect(grid.opts.column).toBe(12);
+      grid.column(12);
+      expect(grid.column()).toBe(12);
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-width'))).toBe(4);
@@ -367,8 +368,8 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-height'))).toBe(1);
 
       // back to 1 column, move item2 to beginning to [3][1][2] vertically
-      grid.setColumn(1);
-      expect(grid.opts.column).toBe(1);
+      grid.column(1);
+      expect(grid.column()).toBe(1);
       grid.move(el3, 0, 0);
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
@@ -386,8 +387,8 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
 
       // back to 12 column, el3 to be beginning still, but [1][2] to be in 1 columns still but wide 4x2 and 4x still
-      grid.setColumn(12);
-      expect(grid.opts.column).toBe(12);
+      grid.column(12);
+      expect(grid.column()).toBe(12);
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-width'))).toBe(1);
@@ -404,9 +405,9 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
 
       // 2 column will have item1, item2, item3 in 1 column still but half the width
-      grid.setColumn(1); // test convert from small, should use 12 layout still
-      grid.setColumn(2);
-      expect(grid.opts.column).toBe(2);
+      grid.column(1); // test convert from small, should use 12 layout still
+      grid.column(2);
+      expect(grid.column()).toBe(2);
 
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
@@ -437,10 +438,10 @@ describe('gridstack', function() {
         column: 12,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
-      var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
-      var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
-      var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
+      var grid = GridStack.init(options);
+      var el1 = $(grid.addWidget(widgetHTML, {width:1, height:1}));
+      var el2 = $(grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1}));
+      var el3 = $(grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2}));
 
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
@@ -459,7 +460,7 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
 
       // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
-      grid.setColumn(1);
+      grid.column(1);
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
@@ -481,10 +482,10 @@ describe('gridstack', function() {
         oneColumnModeDomSort: true,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
-      var el1 = grid.addWidget(widgetHTML, {width:1, height:1});
-      var el2 = grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1});
-      var el3 = grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2});
+      var grid = GridStack.init(options);
+      var el1 = $(grid.addWidget(widgetHTML, {width:1, height:1}));
+      var el2 = $(grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1}));
+      var el3 = $(grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2}));
 
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
@@ -503,7 +504,7 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(1);
 
       // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
-      grid.setColumn(1);
+      grid.column(1);
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-width'))).toBe(1);
@@ -533,7 +534,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minWidth(items[i], 2);
@@ -556,7 +557,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxWidth(items[i], 2);
@@ -579,7 +580,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.minHeight(items[i], 2);
@@ -602,7 +603,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.maxHeight(items[i], 2);
@@ -625,7 +626,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var shouldBeFalse = grid.isAreaEmpty(1, 1, 1, 1);
       expect(shouldBeFalse).toBe(false);
     });
@@ -634,7 +635,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var shouldBeTrue = grid.isAreaEmpty(5, 5, 1, 1);
       expect(shouldBeTrue).toBe(true);
     });
@@ -648,21 +649,21 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove all children by default', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       grid.removeAll();
-      expect(grid.grid.nodes).toEqual([]);
+      expect(grid.engine.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove all children', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       grid.removeAll(true);
-      expect(grid.grid.nodes).toEqual([]);
+      expect(grid.engine.nodes).toEqual([]);
       expect(document.getElementById('item1')).toBe(null);
     });
     it('should remove gridstack part, leave DOM behind', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       grid.removeAll(false);
-      expect(grid.grid.nodes).toEqual([]);
+      expect(grid.engine.nodes).toEqual([]);
       expect(document.getElementById('item1')).not.toBe(null);
     });
   });
@@ -675,25 +676,25 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should remove first item (default), then second (true), then third (false)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
-      expect(grid.grid.nodes.length).toEqual(2);
+      var grid = GridStack.init();
+      expect(grid.engine.nodes.length).toEqual(2);
 
       var el1 = document.getElementById('item1');
       expect(el1).not.toBe(null);
       grid.removeWidget(el1);
-      expect(grid.grid.nodes.length).toEqual(1);
+      expect(grid.engine.nodes.length).toEqual(1);
       expect(document.getElementById('item1')).toBe(null);
       expect(document.getElementById('item2')).not.toBe(null);
 
       var el2 = document.getElementById('item2');
       grid.removeWidget(el2, true);
-      expect(grid.grid.nodes.length).toEqual(0);
+      expect(grid.engine.nodes.length).toEqual(0);
       expect(document.getElementById('item2')).toBe(null);
 
       var el3 = grid.addWidget(widgetHTML);
       expect(el3).not.toBe(null);
       grid.removeWidget(el3, false);
-      expect(grid.grid.nodes.length).toEqual(0);
+      expect(grid.engine.nodes.length).toEqual(0);
       expect(document.getElementById('item3')).not.toBe(null);
     });
   });
@@ -711,7 +712,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -727,7 +728,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       var $el;
       var $oldEl;
@@ -751,7 +752,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should keep all widget options the same (autoPosition off', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');;
+      var grid = GridStack.init({float: true});;
       var widget = grid.addWidget(widgetHTML, 6, 7, 2, 3, false, 1, 4, 2, 5, 'coolWidget');
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(6);
@@ -804,7 +805,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should change x, y coordinates for widgets.', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = GridStack.init({float: true});
       var widget = grid.addWidget(widgetHTML, 9, 7, 2, 3, true);
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).not.toBe(9);
@@ -820,7 +821,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should autoPosition (missing X,Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -835,7 +836,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing X)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {y: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -850,7 +851,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {x: 9, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -865,7 +866,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (correct X, missing Y)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -880,7 +881,7 @@ describe('gridstack', function() {
       expect($widget.attr('data-gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (empty options)', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -904,7 +905,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should use default', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       var widget = grid.addWidget(widgetHTML, {x: 'foo', y: null, width: 'bar', height: ''});
       var $widget = $(widget);
       expect(parseInt($widget.attr('data-gs-x'), 10)).toBe(8);
@@ -922,7 +923,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should clear x position', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = GridStack.init({float: true});
       var widgetHTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
       var widget = grid.addWidget(widgetHTML, null, null, undefined);
       var $widget = $(widget);
@@ -939,7 +940,7 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should match true/false only', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = GridStack.init({float: true});
       expect(grid.float()).toBe(true);
       grid.float(0);
       expect(grid.float()).toBe(false);
@@ -964,21 +965,21 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       grid.destroy();
       expect($('.grid-stack').length).toBe(0);
-      expect(grid.grid).toBe(null);
+      expect(grid.engine).toBe(null);
     });
     it('should cleanup gridstack but leave elements', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       grid.destroy(false);
       expect($('.grid-stack').length).toBe(1);
       expect($('.grid-stack-item').length).toBe(2);
-      expect(grid.grid).toBe(null);
+      expect(grid.engine).toBe(null);
       grid.destroy();
     });
   });
@@ -995,7 +996,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.resize(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1016,7 +1017,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.move(items[0], 5, 5);
       expect(parseInt($(items[0]).attr('data-gs-x'), 10)).toBe(5);
@@ -1036,10 +1037,10 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid._updateElement(items[0], function(el, node) {
-        var newNode = grid.grid.moveNode(node);
+        var newNode = grid.engine.moveNode(node);
         expect(newNode).toBe(node);
       });
     });
@@ -1048,14 +1049,14 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.minWidth(items[0], 1);
       grid.maxWidth(items[0], 2);
       grid.minHeight(items[0], 1);
       grid.maxHeight(items[0], 2);
       grid._updateElement(items[0], function(el, node) {
-        var newNode = grid.grid.moveNode(node);
+        var newNode = grid.engine.moveNode(node);
         expect(newNode).toBe(node);
       });
     });
@@ -1074,7 +1075,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         float: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.update(items[0], 5, 5, 5 ,5);
       expect(parseInt($(items[0]).attr('data-gs-width'), 10)).toBe(5);
@@ -1096,7 +1097,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var vm = grid.verticalMargin();
       expect(vm).toBe(10);
     });
@@ -1105,7 +1106,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       grid.verticalMargin(11);
       expect(grid.verticalMargin()).toBe(11);
     });
@@ -1114,18 +1115,17 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10,
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       expect(grid.verticalMargin()).toBe(10);
       grid.verticalMargin(10);
       expect(grid.verticalMargin()).toBe(10);
-      // expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `height` is deprecated in v0.5.3 and has been replaced with `maxRow`. It will be **completely** removed in v1.0');
     });
     it('should not update styles', function() {
       var options = {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       spyOn(grid, '_updateStyles');
       grid.verticalMargin(11, true);
       expect(grid._updateStyles).not.toHaveBeenCalled();
@@ -1145,7 +1145,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         rtl: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(true);
     });
     it('should not add grid-stack-rtl class', function() {
@@ -1153,7 +1153,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       expect($('.grid-stack').hasClass('grid-stack-rtl')).toBe(false);
     });
   });
@@ -1172,7 +1172,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableDrag: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       expect(grid.opts.disableDrag).toBe(true);
       grid.enableMove(true, true);
@@ -1187,7 +1187,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.enableMove(false);
       for (var i = 0; i < items.length; i++) {
@@ -1211,7 +1211,7 @@ describe('gridstack', function() {
         minWidth: 1,
         disableResize: true
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       expect(grid.opts.disableResize).toBe(true);
       grid.enableResize(true, true);
@@ -1226,7 +1226,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       for (var i = 0; i < items.length; i++) {
@@ -1249,7 +1249,7 @@ describe('gridstack', function() {
         verticalMargin: 10,
         minWidth: 1
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       grid.enableResize(false);
       grid.enableMove(false);
@@ -1277,7 +1277,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], true);
@@ -1289,7 +1289,7 @@ describe('gridstack', function() {
         cellHeight: 80,
         verticalMargin: 10
       };
-      var grid = $('.grid-stack').gridstack(options).data('gridstack');
+      var grid = GridStack.init(options);
       var items = $('.grid-stack-item');
       for (var i = 0; i < items.length; i++) {
         grid.locked(items[i], false);
@@ -1343,9 +1343,9 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('should move all 3 items to top-left with no space', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = GridStack.init({float: true});
 
-      var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5});
+      var el3 = $(grid.addWidget(widgetHTML, {x: 3, y: 5}));
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
 
@@ -1354,9 +1354,9 @@ describe('gridstack', function() {
       expect(parseInt(el3.attr('data-gs-y'))).toBe(0);
     });
     it('not move locked item', function() {
-      var grid = $('.grid-stack').gridstack({float: true}).data('gridstack');
+      var grid = GridStack.init({float: true});
 
-      var el3 = grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true});
+      var el3 = $(grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true}));
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
 
@@ -1379,19 +1379,25 @@ describe('gridstack', function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
     it('warning if OLD setGridWidth is called', function() {
-      var grid = $('.grid-stack').gridstack().data('gridstack');
+      var grid = GridStack.init();
       grid.setGridWidth(11); // old 0.5.2 API
-      expect(grid.opts.column).toBe(11);
-      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Function `setGridWidth` is deprecated in v0.5.3 and has been replaced with `setColumn`. It will be **completely** removed in v1.0');
+      expect(grid.column()).toBe(11);
+      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Function `setGridWidth` is deprecated in v0.5.3 and has been replaced with `column`. It will be **completely** removed in v1.0');
+    });
+    it('warning if OLD setColumn is called', function() {
+      var grid = GridStack.init();
+      grid.setColumn(10); // old 0.6.4 API
+      expect(grid.column()).toBe(10);
+      expect(console.warn).toHaveBeenCalledWith('gridstack.js: Function `setColumn` is deprecated in v0.6.4 and has been replaced with `column`. It will be **completely** removed in v1.0');
     });
     it('warning if OLD grid height is set', function() {
-      var grid = $('.grid-stack').gridstack({height: 10}).data('gridstack'); // old 0.5.2 Opt now maxRow
+      var grid = GridStack.init({height: 10}); // old 0.5.2 Opt now maxRow
       expect(grid.opts.maxRow).toBe(10);
-      expect(grid.grid.maxRow).toBe(10);
+      expect(grid.engine.maxRow).toBe(10);
       expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `height` is deprecated in v0.5.3 and has been replaced with `maxRow`. It will be **completely** removed in v1.0');
     });
     it('warning if OLD oneColumnModeClass is set (no changes)', function() {
-      $('.grid-stack').gridstack({oneColumnModeClass: 'foo'}).data('gridstack'); // deleted 0.6.3 Opt
+      GridStack.init({oneColumnModeClass: 'foo'}); // deleted 0.6.3 Opt
       expect(console.warn).toHaveBeenCalledWith('gridstack.js: Option `oneColumnModeClass` is deprecated in v0.6.3. Use class `.grid-stack-1` instead');
     });
   });

--- a/spec/gridstack-tests.ts
+++ b/spec/gridstack-tests.ts
@@ -1,0 +1,24 @@
+import { GridStack, GridstackOptions, MousePosition } from '../src/gridstack';
+
+var options: GridstackOptions = {
+    float: true
+};
+
+var grid: GridStack = GridStack.init(options);
+var gsFromElement: GridStack = GridStack.get();
+var gsFromElement2: GridStack = ($('.grid-stack').get(0) as any).gridstack;
+
+if (gsFromElement !== grid) throw Error('These should match!');
+if (gsFromElement2 !== grid) throw Error('These should match!');
+
+var gridItem = '<div><div class="grid-stack-item-content"> Hello </div></div>'
+
+grid.addWidget(gridItem, {width: 2});
+grid.addWidget(gridItem, 1, 2, 3, 4, true);
+grid.makeWidget(document.createElement('div'));
+grid.batchUpdate();
+grid.cellHeight();;
+grid.cellHeight(2);
+grid.cellWidth();
+grid.getCellFromPixel(<MousePosition>{ left:20, top: 20 });
+grid.removeAll(false);

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -4,7 +4,7 @@ describe('gridstack utils', function() {
   var utils;
 
   beforeEach(function() {
-    utils = window.GridStackUI.Utils;
+    utils = GridStack.Utils;
   });
 
   describe('setup of utils', function() {

--- a/src/gridstack-dragdrop-plugin.ts
+++ b/src/gridstack-dragdrop-plugin.ts
@@ -1,0 +1,49 @@
+/** gridstack-dragdrop-plugin.ts 1.0.0-rc
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+ * @preserve
+*/
+
+import { GridStack } from './gridstack';
+import { GridStackElement } from './types';
+
+/** drag&drop options currently called from the main code, but others can be passed in grid options */
+export type DDOpts = 'enable' | 'disable' | 'option' | {} | any;
+export type DDKey = 'minWidth' | 'minHeight' | string;
+
+/**
+ * Base class for drag'n'drop plugin.
+ */
+export class GridStackDragDropPlugin {
+  protected grid: GridStack;
+  static registeredPlugins = [];
+  
+  static registerPlugin(pluginClass) {
+    GridStackDragDropPlugin.registeredPlugins.push(pluginClass);
+  };
+
+  public constructor(grid: GridStack) {
+    this.grid = grid;
+  }
+
+  public resizable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    return this;
+  };
+
+  public draggable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    return this;
+  };
+
+  public droppable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    return this;
+  };
+
+  public isDroppable(el: GridStackElement): boolean {
+    return false;
+  };
+
+  public on(el: GridStackElement, eventName: string, callback): GridStackDragDropPlugin {
+    return this;
+  };
+}

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -1,0 +1,553 @@
+/** gridstack-engine.ts 1.0.0-rc
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+ * @preserve
+*/
+
+import { Utils, obsolete } from './utils';
+import { GridStackNode } from './types';
+
+export type onChangeCB = (nodes: GridStackNode[], detachNode?: boolean) => void;
+
+/** @internal class to store per column layout bare minimal info (subset of GridstackWidget) */
+interface layout {
+  x: number;
+  y: number;
+  width: number;
+  _id: number; // so we can find full node back
+}
+
+/**
+ * Defines the GridStack engine that does most no DOM grid manipulation.
+ * See GridStack methods and vars for descriptions.
+ * 
+ * NOTE: values should not be modified directly - call the main GridStack API instead
+ */
+export class GridStackEngine {
+  public column: number;
+  public float: boolean;
+  public maxRow: number;
+  public nodes: GridStackNode[];
+  public onchange: onChangeCB;
+  public addedNodes: GridStackNode[] = [];
+  public removedNodes: GridStackNode[] = [];
+  public batchMode: boolean;
+  /** @internal */
+  private _prevFloat: boolean;
+  private _layouts?: layout[][]; // maps column # to array of values nodes
+  private _ignoreLayoutsNodeChange: boolean;
+  private static _idSeq = 1;
+
+  public constructor(column?: number, onchange?: onChangeCB, float?: boolean, maxRow?: number, nodes?: GridStackNode[]) {
+    this.column = column || 12;
+    this.float = float || false;
+    this.maxRow = maxRow || 0;
+    this.nodes = nodes || [];
+    this.onchange = onchange || function () {};
+  }
+
+  public batchUpdate() {
+    if (this.batchMode) return;
+    this.batchMode = true;
+    this._prevFloat = this.float;
+    this.float = true; // let things go anywhere for now... commit() will restore and possibly reposition
+  };
+
+  public commit() {
+    if (!this.batchMode) return;
+    this.batchMode = false;
+    this.float = this._prevFloat;
+    delete this._prevFloat;
+    this._packNodes();
+    this._notify();
+  };
+
+  public _fixCollisions(node: GridStackNode) {
+    this._sortNodes(-1);
+
+    var nn = node;
+    var hasLocked = Boolean(this.nodes.find(function(n) { return n.locked; }));
+    if (!this.float && !hasLocked) {
+      nn = {x: 0, y: node.y, width: this.column, height: node.height};
+    }
+    while (true) {
+      var collisionNode = this.nodes.find( n => n !== node && Utils.isIntercepted(n, nn), {node: node, nn: nn});
+      if (!collisionNode) { return; }
+      this.moveNode(collisionNode, collisionNode.x, node.y + node.height,
+        collisionNode.width, collisionNode.height, true);
+    }
+  };
+
+  public isAreaEmpty(x: number, y: number, width: number, height: number) {
+    var nn = {x: x || 0, y: y || 0, width: width || 1, height: height || 1};
+    var collisionNode = this.nodes.find(function(n) {
+      return Utils.isIntercepted(n, nn);
+    });
+    return !collisionNode;
+  };
+
+  public _sortNodes(dir?: number) {
+    this.nodes = Utils.sort(this.nodes, dir, this.column);
+  };
+
+  public _packNodes() {
+    this._sortNodes();
+
+    if (this.float) {
+      this.nodes.forEach((n, i) => {
+        if (n._updating || n._packY === undefined || n.y === n._packY) {
+          return;
+        }
+        var newY = n.y;
+        while (newY >= n._packY) {
+          var box = {x: n.x, y: newY, width: n.width, height: n.height};
+          var collisionNode = this.nodes
+            .slice(0, i)
+            .find(bn => Utils.isIntercepted(box, bn), {n: n, newY: newY});
+          if (!collisionNode) {
+            n._dirty = true;
+            n.y = newY;
+          }
+          --newY;
+        }
+      });
+    } else {
+      this.nodes.forEach((n, i) => {
+        if (n.locked) { return; }
+        while (n.y > 0) {
+          var newY = n.y - 1;
+          var canBeMoved = i === 0;
+          var box = {x: n.x, y: newY, width: n.width, height: n.height};
+          if (i > 0) {
+            var collisionNode = this.nodes
+              .slice(0, i)
+              .find(bn => Utils.isIntercepted(box, bn), {n: n, newY: newY});
+            canBeMoved = collisionNode === undefined;
+          }
+
+          if (!canBeMoved) { break; }
+          // Note: must be dirty (from last position) for GridStack::OnChange CB to update positions
+          // and move items back. The user 'change' CB should detect changes from the original
+          // starting position instead.
+          n._dirty = (n.y !== newY);
+          n.y = newY;
+        }
+      });
+    }
+  };
+
+  public _prepareNode(node: GridStackNode, resizing?: boolean) {
+    node = node || {};
+    // if we're missing position, have the grid position us automatically (before we set them to 0,0)
+    if (node.x === undefined || node.y === undefined || node.x === null || node.y === null) {
+      node.autoPosition = true;
+    }
+
+    // assign defaults for missing required fields
+    var defaults = {width: 1, height: 1, x: 0, y: 0};
+    node = Utils.defaults(node, defaults);
+
+    // convert any strings over
+    /* TODO: check
+    node.x = parseInt(node.x);
+    node.y = parseInt(node.y);
+    node.width = parseInt(node.width);
+    node.height = parseInt(node.height);
+    */
+    node.autoPosition = node.autoPosition || false;
+    node.noResize = node.noResize || false;
+    node.noMove = node.noMove || false;
+
+    // check for NaN (in case messed up strings were passed. can't do parseInt() || defaults.x above as 0 is valid #)
+    if (Number.isNaN(node.x))      { node.x = defaults.x; node.autoPosition = true; }
+    if (Number.isNaN(node.y))      { node.y = defaults.y; node.autoPosition = true; }
+    if (Number.isNaN(node.width))  { node.width = defaults.width; }
+    if (Number.isNaN(node.height)) { node.height = defaults.height; }
+
+    if (node.width > this.column) {
+      node.width = this.column;
+    } else if (node.width < 1) {
+      node.width = 1;
+    }
+
+    if (node.height < 1) {
+      node.height = 1;
+    }
+
+    if (node.x < 0) {
+      node.x = 0;
+    }
+
+    if (node.x + node.width > this.column) {
+      if (resizing) {
+        node.width = this.column - node.x;
+      } else {
+        node.x = this.column - node.width;
+      }
+    }
+
+    if (node.y < 0) {
+      node.y = 0;
+    }
+
+    return node;
+  };
+
+  public getDirtyNodes(verify?: boolean) {
+    // compare original X,Y,W,H (or entire node?) instead as _dirty can be a temporary state
+    if (verify) {
+      var dirtNodes = [];
+      this.nodes.forEach(function (n) {
+        if (n._dirty) {
+          if (n.y === n._origY && n.x === n._origX && n.width === n._origW && n.height === n._origH) {
+            delete n._dirty;
+          } else {
+            dirtNodes.push(n);
+          }
+        }
+      });
+      return dirtNodes;
+    }
+
+    return this.nodes.filter(function(n) { return n._dirty; });
+  };
+
+  public _notify(nodes?: GridStackNode | GridStackNode[], detachNode?: boolean) {
+    if (this.batchMode) { return; }
+    detachNode = (detachNode === undefined ? true : detachNode);
+    nodes = (nodes === undefined ? [] : (Array.isArray(nodes) ? nodes : [nodes]) );
+    var dirtyNodes = nodes.concat(this.getDirtyNodes());
+    this.onchange(dirtyNodes, detachNode);
+  };
+
+  public cleanNodes() {
+    if (this.batchMode) { return; }
+    this.nodes.forEach(function(n) { delete n._dirty; });
+  };
+
+  public addNode(node: GridStackNode, triggerAddEvent?: boolean) {
+    node = this._prepareNode(node);
+
+    if (node.maxWidth !== undefined) { node.width = Math.min(node.width, node.maxWidth); }
+    if (node.maxHeight !== undefined) { node.height = Math.min(node.height, node.maxHeight); }
+    if (node.minWidth !== undefined) { node.width = Math.max(node.width, node.minWidth); }
+    if (node.minHeight !== undefined) { node.height = Math.max(node.height, node.minHeight); }
+
+    node._id = node._id || GridStackEngine._idSeq++;
+
+    if (node.autoPosition) {
+      this._sortNodes();
+
+      for (var i = 0;; ++i) {
+        var x = i % this.column;
+        var y = Math.floor(i / this.column);
+        if (x + node.width > this.column) {
+          continue;
+        }
+        var box = {x: x, y: y, width: node.width, height: node.height};
+        if (!this.nodes.find(n => Utils.isIntercepted(box, n), {x: x, y: y, node: node})) {
+          node.x = x;
+          node.y = y;
+          delete node.autoPosition; // found our slot
+          break;
+        }
+      }
+    }
+
+    this.nodes.push(node);
+    if (triggerAddEvent) {
+      this.addedNodes.push(node);
+    }
+
+    this._fixCollisions(node);
+    this._packNodes();
+    this._notify();
+    return node;
+  };
+
+  public removeNode(node: GridStackNode, detachNode?: boolean) {
+    detachNode = (detachNode === undefined ? true : detachNode);
+    this.removedNodes.push(node);
+    node._id = null; // hint that node is being removed
+    this.nodes = Utils.without(this.nodes, node);
+    this._packNodes();
+    this._notify(node, detachNode);
+  };
+
+  public removeAll(detachNode?: boolean) {
+    delete this._layouts;
+    if (this.nodes.length === 0) { return; }
+    detachNode = (detachNode === undefined ? true : detachNode);
+    this.nodes.forEach(function(n) { n._id = null; }); // hint that node is being removed
+    this.removedNodes = this.nodes;
+    this.nodes = [];
+    this._notify(this.removedNodes, detachNode);
+  };
+
+  public canMoveNode(node: GridStackNode, x: number, y: number, width?: number, height?: number): boolean {
+    if (!this.isNodeChangedPosition(node, x, y, width, height)) {
+      return false;
+    }
+    var hasLocked = Boolean(this.nodes.find(function(n) { return n.locked; }));
+
+    if (!this.maxRow && !hasLocked) {
+      return true;
+    }
+
+    var clonedNode;
+    var clone = new GridStackEngine(
+      this.column,
+      null,
+      this.float,
+      0,
+      this.nodes.map(function(n) {
+        if (n === node) {
+          clonedNode = Utils.clone(n);
+          return clonedNode;
+        }
+        return Utils.clone(n);
+      }));
+
+    if (!clonedNode) {  return true;}
+
+    clone.moveNode(clonedNode, x, y, width, height);
+
+    var canMove = true;
+    if (hasLocked) {
+      canMove = canMove && !Boolean(clone.nodes.find(function(n) {
+        return n !== clonedNode && Boolean(n.locked) && Boolean(n._dirty);
+      }));
+    }
+    if (this.maxRow) {
+      canMove = canMove && (clone.getRow() <= this.maxRow);
+    }
+
+    return canMove;
+  };
+
+  public canBePlacedWithRespectToHeight(node: GridStackNode) {
+    if (!this.maxRow) {
+      return true;
+    }
+
+    var clone = new GridStackEngine(
+      this.column,
+      null,
+      this.float,
+      0,
+      this.nodes.map(function(n) { return Utils.clone(n) }));
+    clone.addNode(node);
+    return clone.getRow() <= this.maxRow;
+  };
+
+  public isNodeChangedPosition(node: GridStackNode, x: number, y: number, width: number, height: number) {
+    if (typeof x !== 'number') { x = node.x; }
+    if (typeof y !== 'number') { y = node.y; }
+    if (typeof width !== 'number') { width = node.width; }
+    if (typeof height !== 'number') { height = node.height; }
+
+    if (node.maxWidth !== undefined) { width = Math.min(width, node.maxWidth); }
+    if (node.maxHeight !== undefined) { height = Math.min(height, node.maxHeight); }
+    if (node.minWidth !== undefined) { width = Math.max(width, node.minWidth); }
+    if (node.minHeight !== undefined) { height = Math.max(height, node.minHeight); }
+
+    if (node.x === x && node.y === y && node.width === width && node.height === height) {
+      return false;
+    }
+    return true;
+  };
+
+  public moveNode(node: GridStackNode, x: number, y: number, width?: number, height?: number, noPack?: boolean): GridStackNode {
+    if (typeof x !== 'number') { x = node.x; }
+    if (typeof y !== 'number') { y = node.y; }
+    if (typeof width !== 'number') { width = node.width; }
+    if (typeof height !== 'number') { height = node.height; }
+
+    if (node.maxWidth !== undefined) { width = Math.min(width, node.maxWidth); }
+    if (node.maxHeight !== undefined) { height = Math.min(height, node.maxHeight); }
+    if (node.minWidth !== undefined) { width = Math.max(width, node.minWidth); }
+    if (node.minHeight !== undefined) { height = Math.max(height, node.minHeight); }
+
+    if (node.x === x && node.y === y && node.width === width && node.height === height) {
+      return node;
+    }
+
+    var resizing = node.width !== width;
+    node._dirty = true;
+
+    node.x = x;
+    node.y = y;
+    node.width = width;
+    node.height = height;
+
+    node._lastTriedX = x;
+    node._lastTriedY = y;
+    node._lastTriedWidth = width;
+    node._lastTriedHeight = height;
+
+    node = this._prepareNode(node, resizing);
+
+    this._fixCollisions(node);
+    if (!noPack) {
+      this._packNodes();
+      this._notify();
+    }
+    return node;
+  };
+
+  public getRow(): number {
+    return this.nodes.reduce(function(memo, n) { return Math.max(memo, n.y + n.height); }, 0);
+  };
+
+  public beginUpdate(node: GridStackNode) {
+    if (node._updating) return;
+    node._updating = true;
+    this.nodes.forEach(function(n) { n._packY = n.y; });
+  };
+
+  public endUpdate() {
+    var n = this.nodes.find(function(n) { return n._updating; });
+    if (n) {
+      n._updating = false;
+      this.nodes.forEach(function(n) { delete n._packY; });
+    }
+  };
+
+  /** called whenever a node is added or moved - updates the cached layouts */
+  public _layoutsNodesChange(nodes: GridStackNode[]) {
+    if (!this._layouts || this._ignoreLayoutsNodeChange) return;
+    // remove smaller layouts - we will re-generate those on the fly... larger ones need to update
+    this._layouts.forEach(function(layout, column) {
+      if (!layout || column === this.column) return;
+      if (column < this.column) {
+        this._layouts[column] = undefined;
+      }
+      else {
+        // we save the original x,y,w (h isn't cached) to see what actually changed to propagate better.
+        // Note: we don't need to check against out of bound scaling/moving as that will be done when using those cache values.
+        nodes.forEach(function(node) {
+          var n = layout.find(function(l) { return l._id === node._id });
+          if (!n) return; // no cache for new nodes. Will use those values.
+          var ratio = column / this.column;
+          // Y changed, push down same amount
+          // TODO: detect doing item 'swaps' will help instead of move (especially in 1 column mode)
+          if (node.y !== node._origY) {
+            n.y += (node.y - node._origY);
+          }
+          // X changed, scale from new position
+          if (node.x !== node._origX) {
+            n.x = Math.round(node.x * ratio);
+          }
+          // width changed, scale from new width
+          if (node.width !== node._origW) {
+            n.width = Math.round(node.width * ratio);
+          }
+          // ...height always carries over from cache
+        }, this);
+      }
+    }, this);
+  }
+
+  /**
+   * Called to scale the widget width & position up/down based on the column change.
+   * Note we store previous layouts (especially original ones) to make it possible to go
+   * from say 12 -> 1 -> 12 and get back to where we were.
+   *
+   * oldColumn: previous number of columns
+   * column:    new column number
+   * nodes?:    different sorted list (ex: DOM order) instead of current list
+   */
+  public _updateNodeWidths(oldColumn: number, column: number, nodes: GridStackNode[]) {
+    if (!this.nodes.length || oldColumn === column) { return; }
+
+    // cache the current layout in case they want to go back (like 12 -> 1 -> 12) as it requires original data
+    var copy: layout[] = [];
+    this.nodes.forEach(function(n, i) { copy[i] = {x: n.x, y: n.y, width: n.width, _id: n._id} }); // only thing we change is x,y,w and id to find it back
+    this._layouts = this._layouts || []; // use array to find larger quick
+    this._layouts[oldColumn] = copy;
+
+    // if we're going to 1 column and using DOM order rather than default sorting, then generate that layout
+    if (column === 1 && nodes && nodes.length) {
+      var top = 0;
+      nodes.forEach(function(n) {
+        n.x = 0;
+        n.width = 1;
+        n.y = Math.max(n.y, top);
+        top = n.y + n.height;
+      });
+    } else {
+      nodes = Utils.sort(this.nodes, -1, oldColumn); // current column reverse sorting so we can insert last to front (limit collision)
+    }
+
+    // see if we have cached previous layout.
+    var cacheNodes = this._layouts[column] || [];
+    // if not AND we are going up in size start with the largest layout as down-scaling is more accurate
+    var lastIndex = this._layouts.length - 1;
+    if (cacheNodes.length === 0 && column > oldColumn && column < lastIndex) {
+      cacheNodes = this._layouts[lastIndex] || [];
+      if (cacheNodes.length) {
+        // pretend we came from that larger column by assigning those values as starting point
+        oldColumn = lastIndex;
+        cacheNodes.forEach(function(cacheNode) {
+          var j = nodes.findIndex(function(n) {return n && n._id === cacheNode._id});
+          if (j !== -1) {
+            // still current, use cache info positions
+            nodes[j].x = cacheNode.x;
+            nodes[j].y = cacheNode.y;
+            nodes[j].width = cacheNode.width;
+          }
+        });
+        cacheNodes = []; // we still don't have new column cached data... will generate from larger one.
+      }
+    }
+
+    // if we found cache re-use those nodes that are still current
+    var newNodes = [];
+    cacheNodes.forEach(function(cacheNode) {
+      var j = nodes.findIndex(function(n) {return n && n._id === cacheNode._id});
+      if (j !== -1) {
+        // still current, use cache info positions
+        nodes[j].x = cacheNode.x;
+        nodes[j].y = cacheNode.y;
+        nodes[j].width = cacheNode.width;
+        newNodes.push(nodes[j]);
+        nodes[j] = null; // erase it so we know what's left
+      }
+    });
+    // ...and add any extra non-cached ones
+    var ratio = column / oldColumn;
+    nodes.forEach(function(node) {
+      if (!node) return;
+      node.x = (column === 1 ? 0 : Math.round(node.x * ratio));
+      node.width = ((column === 1 || oldColumn === 1) ? 1 : (Math.round(node.width * ratio) || 1));
+      newNodes.push(node);
+    });
+
+    // finally relayout them in reverse order (to get correct placement)
+    newNodes = Utils.sort(newNodes, -1, column);
+    this._ignoreLayoutsNodeChange = true;
+    this.batchUpdate();
+    this.nodes = []; // pretend we have no nodes to start with (we use same structures) to simplify layout
+    newNodes.forEach(function(node) {
+      this.addNode(node, false); // 'false' for add event trigger
+      node._dirty = true; // force attr update
+    }, this);
+    this.commit();
+    delete this._ignoreLayoutsNodeChange;
+  }
+
+  /** called to save initial position/size */
+  public _saveInitial() {
+    this.nodes.forEach(function(n) {
+      n._origX = n.x;
+      n._origY = n.y;
+      n._origW = n.width;
+      n._origH = n.height;
+      delete n._dirty;
+    });
+  }
+
+  // legacy method renames
+  private getGridHeight = obsolete(GridStackEngine.prototype.getRow, 'getGridHeight', 'getRow', 'v1.0.0');
+}

--- a/src/gridstack-extra.scss
+++ b/src/gridstack-extra.scss
@@ -1,5 +1,5 @@
 /*!
- * gridstack 0.6.4-dev extra CSS for [2-11] columns (non default)
+ * gridstack 1.0.0-rc extra CSS for [2-11] columns (non default)
  * https://gridstackjs.com/
  * (c) 2014-2020  Alain Dumesny, Dylan Weiss, Pavel Reznikov
  * gridstack.js may be freely distributed under the MIT license.

--- a/src/gridstack-poly.js
+++ b/src/gridstack-poly.js
@@ -1,4 +1,4 @@
-/** gridstack.js 0.6.4-dev - IE and older browsers Polyfills for this library @preserve*/
+/** gridstack.js 1.0.0-rc - IE and older browsers Polyfills for this library @preserve*/
 /**
  * https://gridstackjs.com/
  * (c) 2019-2020 Alain Dumesny

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -1,5 +1,5 @@
 /*!
- * required gridstack 0.6.4-dev CSS for default 12 and 1 columnMode size. Use gridstack-extra.css for others
+ * required gridstack 1.0.0-rc CSS for default 12 and 1 columnMode size. Use gridstack-extra.css for others
  * https://gridstackjs.com/
  * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
  * gridstack.js may be freely distributed under the MIT license.

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1,0 +1,1591 @@
+/** gridstack.ts 1.0.0-rc
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+ * @preserve
+*/
+
+import { GridStackEngine } from './gridstack-engine'
+import { obsoleteOpts, obsoleteOptsDel, obsoleteAttr, obsolete, Utils } from './utils';
+import { GridStackElement, GridItemHTMLElement, GridstackWidget, GridStackNode, GridstackOptions, numberOrString } from './types';
+import { GridStackDragDropPlugin } from './gridstack-dragdrop-plugin';
+
+// TODO: TEMPORARY until we remove all jquery calls
+// also see https://stackoverflow.com/questions/35345760/importing-jqueryui-with-typescript-and-requirejs
+import $ from './jquery.js';
+
+export interface GridHTMLElement extends HTMLElement {
+  gridstack?: GridStack; // grid's parent DOM element points back to grid class
+}
+export type GridStackEvent =
+'added' | 'change' | 'disable' | 'dragstart' | 'dragstop' | 'dropped' | 'enable' | 'removed' | 'resize' | 'resizestart' | 'gsresizestop';
+
+/** Defines the coordinates of an object */
+export interface MousePosition {
+  top: number;
+  left: number;
+}
+
+/** Defines the position of a cell inside the grid*/
+export interface CellPosition {
+  x: number;
+  y: number;
+}
+
+interface GridCSSStyleSheet extends CSSStyleSheet {
+  _max?: number; // internal tracker of the max # of rows we created
+}
+
+/**
+ * Main gridstack class - you will need to call `GridStack.init()` first to initialize your grid.
+ * Note: your grid elements MUST have the following classes for the CSS layout to work:
+ * @example
+ * <div class="grid-stack">
+ *   <div class="grid-stack-item">
+ *     <div class="grid-stack-item-content">Item 1</div>
+ *   </div>
+ * </div>
+ */
+export class GridStack {
+
+  /**
+   * initializing the HTML element, or selector string, into a grid will return the grid. Calling it again will
+   * simply return the existing instance (ignore any passed options). There is also an initAll() version that support
+   * multiple grids initialization at once.
+   * @param options grid options (optional)
+   * @param elOrString element to convert to a grid (default to '.grid-stack' class selector)
+   * 
+   * @example
+   * var grid = GridStack.init();
+   * // Note: the HTMLElement (of type GridHTMLElement) will store a `gridstack: GridStack` value that can be retrieve later
+   * var grid = document.querySelector('.grid-stack').gridstack;
+   */
+  public static init(options?: GridstackOptions, elOrString?: GridStackElement): GridStack {
+    var el: GridHTMLElement;
+    if (!elOrString) { elOrString = '.grid-stack' }
+    if (typeof elOrString === 'string') {
+      el = document.querySelector(elOrString);
+    } else {
+      el = elOrString;
+    }
+    if (!el) return;
+    if (!el.gridstack) {
+      el.gridstack = new GridStack(el, options);
+    }
+    return el.gridstack
+  }
+
+  /**
+   * Will initialize a list of elements (given a selector) and return an array of grids.
+   * @param options grid options (optional)
+   * @param selector element to convert to grids (default to '.grid-stack' class selector)
+   * 
+   * @example
+   * var grids = GridStack.initAll();
+   * grids.forEach(...)
+   */
+  public static initAll(options?: GridstackOptions, selector?: string): GridStack[] {
+    if (!selector) { selector = '.grid-stack' }
+    var grids: GridStack[] = [];
+    document.querySelectorAll(selector).forEach((el: GridHTMLElement) => {
+      if (!el.gridstack) {
+        el.gridstack = new GridStack(el, options);
+      }
+      grids.push(el.gridstack);
+    });
+    return grids;
+  }
+
+  /** the HTML element tied to this grid after it's been initialized */
+  public el: GridHTMLElement;
+
+  /** engine used to implement non DOM grid functionality */
+  public engine: GridStackEngine;
+
+  /** grid options - public for classes to access, but use methods to modify! */
+  public opts: GridstackOptions;
+
+  /** @internal */
+  private $el: JQuery; // TODO: legacy code
+  private $placeholder: JQuery;
+  private oneColumnMode: boolean;
+  private dd: GridStackDragDropPlugin;
+  private _prevColumn: number;
+  private _stylesId: string;
+  private _gsEventHandler: {};
+  private _styles: GridCSSStyleSheet;
+  private isAutoCellHeight: boolean;
+
+  /**
+   * Construct a grid item from the given element and options
+   * @param el
+   * @param opts
+   */
+  public constructor(el: GridStackElement, opts: GridstackOptions) {
+    opts = opts || {};
+
+    this.$el = $(el); // legacy code
+    this.el = this.el; // exposed HTML element to the user
+
+    obsoleteOpts(opts, 'width', 'column', 'v0.5.3');
+    obsoleteOpts(opts, 'height', 'maxRow', 'v0.5.3');
+    obsoleteOptsDel(opts, 'oneColumnModeClass', 'v0.6.3', '. Use class `.grid-stack-1` instead');
+
+    // container attributes
+    obsoleteAttr(this.el, 'data-gs-width', 'data-gs-column', 'v0.5.3');
+    obsoleteAttr(this.el, 'data-gs-height', 'data-gs-max-row', 'v0.5.3');
+    obsoleteAttr(this.el, 'data-gs-current-height', 'data-gs-current-row', 'v1.0.0');
+
+    opts.itemClass = opts.itemClass || 'grid-stack-item';
+
+    var defaults: GridstackOptions = {
+      column: parseInt(this.$el.attr('data-gs-column')) || 12,
+      maxRow: parseInt(this.$el.attr('data-gs-max-row')) || 0,
+      itemClass: 'grid-stack-item',
+      placeholderClass: 'grid-stack-placeholder',
+      placeholderText: '',
+      handle: '.grid-stack-item-content',
+      handleClass: null,
+      cellHeight: 60,
+      verticalMargin: 20,
+      auto: true,
+      minWidth: 768,
+      float: false,
+      staticGrid: false,
+      _class: 'grid-stack-instance-' + (Math.random() * 10000).toFixed(0),
+      animate: Boolean(this.$el.attr('data-gs-animate')) || false,
+      alwaysShowResizeHandle: opts.alwaysShowResizeHandle || false,
+      resizable: Utils.defaults(opts.resizable || {}, {
+        autoHide: !(opts.alwaysShowResizeHandle || false),
+        handles: 'se'
+      }),
+      draggable: Utils.defaults(opts.draggable || {}, {
+        handle: (opts.handleClass ? '.' + opts.handleClass : (opts.handle ? opts.handle : '')) ||
+          '.grid-stack-item-content',
+        scroll: false,
+        appendTo: 'body'
+      }),
+      disableDrag: opts.disableDrag || false,
+      disableResize: opts.disableResize || false,
+      rtl: 'auto',
+      removable: false,
+      removableOptions: Utils.defaults(opts.removableOptions || {}, {
+        accept: '.' + opts.itemClass
+      }),
+      removeTimeout: 2000,
+      verticalMarginUnit: 'px',
+      cellHeightUnit: 'px',
+      disableOneColumnMode: opts.disableOneColumnMode || false,
+      oneColumnModeDomSort: opts.oneColumnModeDomSort,
+      ddPlugin: null
+    };
+    this.opts = Utils.defaults(opts, defaults);
+
+    if (this.opts.ddPlugin === false) {
+      this.opts.ddPlugin = GridStackDragDropPlugin;
+    } else if (this.opts.ddPlugin === null) {
+      this.opts.ddPlugin = GridStackDragDropPlugin.registeredPlugins[0] || GridStackDragDropPlugin;
+    }
+
+    this.dd = new this.opts.ddPlugin(this);
+
+    if (this.opts.rtl === 'auto') {
+      this.opts.rtl = this.$el.css('direction') === 'rtl';
+    }
+
+    if (this.opts.rtl) {
+      this.$el.addClass('grid-stack-rtl');
+    }
+
+    this.opts._isNested = this.$el.closest('.' + opts.itemClass).length > 0;
+    if (this.opts._isNested) {
+      this.$el.addClass('grid-stack-nested');
+    }
+
+    this.isAutoCellHeight = (this.opts.cellHeight === 'auto');
+    if (this.isAutoCellHeight) {
+      // make the cell square initially
+      this.cellHeight(this.cellWidth(), true);
+    } else {
+      this.cellHeight(this.opts.cellHeight, true);
+    }
+    this.verticalMargin(this.opts.verticalMargin, true);
+
+    this.$el.addClass(this.opts._class);
+
+    this._setStaticClass();
+
+    this._initStyles();
+
+    this.engine = new GridStackEngine(this.opts.column, (cbNodes, detachNode) => {
+      detachNode = (detachNode === undefined ? true : detachNode);
+      var maxHeight = 0;
+      this.engine.nodes.forEach(n => { maxHeight = Math.max(maxHeight, n.y + n.height) });
+      cbNodes.forEach(n => {
+        if (detachNode && n._id === null) {
+          if (n.el) { $(n.el).remove() }
+        } else {
+          $(n.el)
+            .attr('data-gs-x', n.x)
+            .attr('data-gs-y', n.y)
+            .attr('data-gs-width', n.width)
+            .attr('data-gs-height', n.height);
+          }
+        });
+        this._updateStyles(maxHeight + 10);
+      },
+      this.opts.float,
+      this.opts.maxRow);
+
+    if (this.opts.auto) {
+      var elements = [];
+      var _this = this;
+      this.$el.children('.' + this.opts.itemClass + ':not(.' + this.opts.placeholderClass + ')')
+        .each((index, el) => {
+          var x = parseInt(el.getAttribute('data-gs-x'));
+          var y = parseInt(el.getAttribute('data-gs-y'));
+          elements.push({
+            el: el,
+            // if x,y are missing (autoPosition) add them to end of list - but keep their respective DOM order
+            i: (Number.isNaN(x) ? 1000 : x) + (Number.isNaN(y) ? 1000 : y) * _this.opts.column
+          });
+        });
+      Utils.sortBy(elements, x => x.i).forEach( item => { this._prepareElement(item.el) });
+    }
+    this.engine._saveInitial(); // initial start of items
+
+    this.setAnimation(this.opts.animate);
+
+    this.$placeholder = $(
+      '<div class="' + this.opts.placeholderClass + ' ' + this.opts.itemClass + '">' +
+      '<div class="placeholder-content">' + this.opts.placeholderText + '</div></div>').hide();
+
+    this._updateContainerHeight();
+
+    $(window).resize(this.onResizeHandler);
+    this.onResizeHandler();
+
+    if (!this.opts.staticGrid && typeof this.opts.removable === 'string') {
+      var trashZone = $(this.opts.removable);
+      if (!this.dd.isDroppable(trashZone)) {
+        this.dd.droppable(trashZone, this.opts.removableOptions);
+      }
+      this.dd
+        .on(trashZone, 'dropover', (event, ui) => {
+          var el = $(ui.draggable);
+          var node = el.get(0).gridstackNode;
+          if (!node || node._grid !== this) {
+            return;
+          }
+          el.data('inTrashZone', true);
+          this._setupRemovingTimeout(el);
+        })
+        .on(trashZone, 'dropout', (event, ui) => {
+          var el = $(ui.draggable);
+          var node = el.get(0).gridstackNode;
+          if (!node || node._grid !== this) {
+            return;
+          }
+          el.data('inTrashZone', false);
+          this._clearRemovingTimeout(el);
+        });
+    }
+
+    this.setupAcceptWidget();
+  };
+
+
+  /**
+   * Creates new widget and returns it.
+   *
+   * Widget will be always placed even if result height is more than actual grid height.
+   * You need to use willItFit method before calling addWidget for additional check.
+   * See also `makeWidget()`.
+   *
+   * @example
+   * var grid = GridStack.init();
+   * grid.addWidget(el, {width: 3, autoPosition: true});
+   *
+   * @param el widget to add
+   * @param options widget position/size options (optional)
+   */
+  public addWidget(el: GridStackElement, options? : GridstackWidget): HTMLElement;
+
+  /**
+   * Creates new widget and returns it. 
+   * Legacy: Spelled out version of the widgets options, recommend use new version instead.
+   *
+   * @example
+   * var grid = GridStack.init();
+   * grid.addWidget(el, 0, 0, 3, 2, true);
+   *
+   * @param el widget to add
+   * @param x widget position x (optional)
+   * @param y widget position y (optional)
+   * @param width  widget dimension width (optional)
+   * @param height widget dimension height (optional)
+   * @param autoPosition if true then x, y parameters will be ignored and widget will be places on the first available position (optional)
+   * @param minWidth minimum width allowed during resize/creation (optional)
+   * @param maxWidth maximum width allowed during resize/creation (optional)
+   * @param minHeight minimum height allowed during resize/creation (optional)
+   * @param maxHeight maximum height allowed during resize/creation (optional)
+   * @param id value for `data-gs-id` (optional)
+   */
+  public addWidget(el: GridStackElement, x? : number | GridstackWidget, y?: number, width?: number, height?: number, autoPosition?: boolean,
+    minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: numberOrString): HTMLElement {
+      // new way of calling with an object - make sure all items have been properly initialized
+      if (x === undefined || typeof x === 'object') {
+        // Tempting to initialize the passed in opt with default and valid values, but this break knockout demos
+        // as the actual value are filled in when _prepareElement() calls el.attr('data-gs-xyz) before adding the node.
+        // opt = this.engine._prepareNode(opt);
+        x = x || {};
+      } else {
+        // old legacy way of calling with items spelled out - call us back with single object instead (so we can properly initialized values)
+        return this.addWidget(el, {x: x, y: y, width: width, height: height, autoPosition: autoPosition,
+          minWidth: minWidth, maxWidth: maxWidth, minHeight: minHeight, maxHeight: maxHeight, id: id});
+      }
+
+      var $el = $(el);
+      this._writeAttr(el, x);
+      this.$el.append(el);
+      return this.makeWidget(el);
+    }
+
+  /**
+   * Initializes batch updates. You will see no changes until `commit()` method is called.
+   */
+  public batchUpdate() {
+    this.engine.batchUpdate();
+  }
+
+  /**
+   * Gets current cell height.
+   */
+  public getCellHeight(): number {
+    if (this.opts.cellHeight && this.opts.cellHeight !== 'auto') {
+      return this.opts.cellHeight as number;
+    }
+    // compute the height taking margin into account (each row has margin other than last one)
+    var o = this.$el.children('.' + this.opts.itemClass).first();
+    var height = parseInt(o.attr('data-gs-height'));
+    var verticalMargin = this.opts.verticalMargin as number;
+    return Math.round((o.outerHeight() - (height - 1) * verticalMargin) / height);
+  }
+
+  /**
+   * Update current cell height - see `GridstackOptions.cellHeight` for format.
+   * This method rebuilds an internal CSS style sheet.
+   * Note: You can expect performance issues if call this method too often.
+   *
+   * @param val the cell height
+   * @param noUpdate (Optional) if true, styles will not be updated
+   *
+   * @example
+   * grid.cellHeight(grid.cellWidth() * 1.2);
+   */
+  public cellHeight(val: numberOrString, noUpdate?: boolean) {
+    var heightData = Utils.parseHeight(val);
+    if (this.opts.cellHeightUnit === heightData.unit && this.opts.cellHeight === heightData.height) {
+      return ;
+    }
+    this.opts.cellHeightUnit = heightData.unit;
+    this.opts.cellHeight = heightData.height;
+
+    if (!noUpdate) {
+      this._updateStyles();
+    }
+  }
+
+  /**
+   * Gets current cell width.
+   */
+  public cellWidth(): number {
+    // TODO: take margin into account ($horizontal_padding in .scss) to make cellHeight='auto' square ? (see 810-many-columns.html)
+    return Math.round(this.$el.outerWidth() / this.opts.column);
+  }
+
+  /**
+   * Finishes batch updates. Updates DOM nodes. You must call it after batchUpdate.
+   */
+  public commit() {
+    this.engine.commit();
+    this._triggerRemoveEvent();
+    this._triggerAddEvent();
+    this._triggerChangeEvent();
+  };
+
+  /**
+   * re-layout grid items to reclaim any empty space
+   */
+  public compact() {
+    if (this.engine.nodes.length === 0) { return; }
+    this.batchUpdate();
+    this.engine._sortNodes();
+    var nodes = this.engine.nodes;
+    this.engine.nodes = []; // pretend we have no nodes to conflict layout to start with...
+    nodes.forEach(node => {
+      if (!node.noMove && !node.locked) {
+        node.autoPosition = true;
+      }
+      this.engine.addNode(node, false); // 'false' for add event trigger
+      node._dirty = true; // force attr update
+    });
+    this.commit();
+  }
+
+  /**
+   * set the number of columns in the grid. Will update existing widgets to conform to new number of columns,
+   * as well as cache the original layout so you can revert back to previous positions without loss.
+   * Requires `gridstack-extra.css` or `gridstack-extra.min.css` for [1-11],
+   * else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
+   * @param column - Integer > 0 (default 12).
+   * @param doNotPropagate if true existing widgets will not be updated (optional) 
+   */
+  public column(column: number, doNotPropagate?: boolean) {
+    if (this.opts.column === column) { return; }
+    var oldColumn = this.opts.column;
+
+    // if we go into 1 column mode (which happens if we're sized less than minWidth unless disableOneColumnMode is on)
+    // then remember the original columns so we can restore.
+    if (column === 1) {
+      this._prevColumn = oldColumn;
+    } else {
+      delete this._prevColumn;
+    }
+
+    this.$el.removeClass('grid-stack-' + oldColumn);
+    this.$el.addClass('grid-stack-' + column);
+    this.opts.column = this.engine.column = column;
+
+    if (doNotPropagate === true) { return; }
+
+    // update the items now - see if the dom order nodes should be passed instead (else default to current list)
+    var domNodes;
+    if (this.opts.oneColumnModeDomSort && column === 1) {
+      domNodes = [];
+      this.$el.children('.' + this.opts.itemClass).each((index, el: GridItemHTMLElement) => {
+        var node = el.gridstackNode;
+        if (node) { domNodes.push(node); }
+      });
+      if (!domNodes.length) { domNodes = undefined; }
+    }
+    this.engine._updateNodeWidths(oldColumn, column, domNodes);
+
+    // and trigger our event last...
+    this._triggerChangeEvent(true); // skip layout update
+  }
+
+  /**
+   * get the number of columns in the grid (default 12)
+   */
+  public getColumn(): number {
+    return this.opts.column;
+  }
+
+  /**
+   * Destroys a grid instance.
+   * @param detachGrid if false nodes and grid will not be removed from the DOM (Optional. Default true).
+   */
+  public destroy(detachGrid?: boolean) {
+    $(window).off('resize', this.onResizeHandler);
+    this.disable();
+    if (detachGrid !== undefined && !detachGrid) {
+      this.removeAll(false);
+      delete this.el.gridstack;
+    } else {
+      this.$el.remove();
+    }
+    Utils.removeStylesheet(this._stylesId);
+    if (this.engine) {
+      this.engine = null;
+    }
+  }
+
+  /**
+   * Disables widgets moving/resizing. This is a shortcut for:
+   * @example
+   *  grid.enableMove(false);
+   *  grid.enableResize(false);
+   */
+  public disable() {
+    this.enableMove(false);
+    this.enableResize(false);
+    this.$el.trigger('disable');
+  }
+
+  /**
+   * Enables widgets moving/resizing. This is a shortcut for:
+   * @example
+   *  grid.enableMove(true);
+   *  grid.enableResize(true);
+   */
+  public enable() {
+    this.enableMove(true);
+    this.enableResize(true);
+    this.$el.trigger('enable');
+  }
+
+  /**
+   * Enables/disables widget moving.
+   *
+   * @param doEnable
+   * @param includeNewWidgets will force new widgets to be draggable as per
+   * doEnable`s value by changing the disableDrag grid option (default: true).
+   */
+  public enableMove(doEnable: boolean, includeNewWidgets = true) {
+    this.$el.children('.' + this.opts.itemClass).each((index, el) => {
+      this.movable(el, doEnable);
+    })
+    if (includeNewWidgets) {
+      this.opts.disableDrag = !doEnable;
+    }
+  }
+
+  /**
+   * Enables/disables widget resizing
+   * @param doEnable
+   * @param includeNewWidgets will force new widgets to be draggable as per
+   * doEnable`s value by changing the disableResize grid option (default: true).
+   */
+  public enableResize(doEnable: boolean, includeNewWidgets = true) {
+    this.$el.children('.' + this.opts.itemClass).each((index, el) => {
+      this.resizable(el, doEnable);
+    })
+    if (includeNewWidgets) {
+      this.opts.disableResize = !doEnable;
+    }
+  }
+
+  /**
+   * enable/disable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
+   * @param mode 
+   */
+  public float(val: boolean) {
+    if (this.opts.float === val) { return; }
+    this.opts.float = this.engine.float = val || false;
+    if (!val) {
+      this.engine._packNodes();
+      this.engine._notify();
+      this._triggerChangeEvent();
+    }
+  }
+  
+  /**
+   * get the current float mode
+   */
+  public getFloat(): boolean {
+    return this.opts.float || false;
+  }
+
+  /**
+   * Get the position of the cell under a pixel on screen.
+   * @param position the position of the pixel to resolve in
+   * absolute coordinates, as an object with top and left properties
+   * @param useOffset if true, value will be based on offset vs position (Optional. Default false).
+   * Useful when grid is within `position: relative` element
+   *
+   * Returns an object with properties `x` and `y` i.e. the column and row in the grid.
+   */
+  public getCellFromPixel(position: MousePosition, useOffset?: boolean): CellPosition {
+    var containerPos = (useOffset !== undefined && useOffset) ?
+      this.$el.offset() : this.$el.position();
+    var relativeLeft = position.left - containerPos.left;
+    var relativeTop = position.top - containerPos.top;
+
+    var columnWidth = Math.floor(this.$el.width() / this.opts.column);
+    var rowHeight = Math.floor(this.$el.height() / parseInt(this.$el.attr('data-gs-current-row')));
+
+    return {x: Math.floor(relativeLeft / columnWidth), y: Math.floor(relativeTop / rowHeight)};
+  }
+
+  /** returns the current number of rows */
+  public getRow(): number {
+    return this.engine.getRow();
+  }
+
+  /**
+   * Checks if specified area is empty.
+   * @param x the position x.
+   * @param y the position y.
+   * @param width the width of to check
+   * @param height the height of to check
+   */
+  public isAreaEmpty(x: number, y: number, width: number, height: number): boolean {
+    return this.engine.isAreaEmpty(x, y, width, height);
+  }
+
+  /**
+   * Locks/unlocks widget.
+   * @param el element or selector to modify.
+   * @param val if true widget will be locked.
+   */
+  public locked(els: GridStackElement, val: boolean): GridStack {
+    $(els).each((index, el) => {
+      var node = el.gridstackNode;
+      if (node!) return;
+      node.locked = (val || false);
+      if (node.locked) {
+        el.setAttribute('data-gs-locked', 'yes');
+      } else {
+        el.removeAttribute('data-gs-locked');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * If you add elements to your grid by hand, you have to tell gridstack afterwards to make them widgets.
+   * If you want gridstack to add the elements for you, use addWidget instead.
+   * Makes the given element a widget and returns it.
+   * @param el widget to convert.
+   *
+   * @example
+   * var grid = GridStack.init();
+   * grid.el.appendChild('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2"
+   *                     data-gs-auto-position="true"></div>')
+   * grid.makeWidget('gsi-1');
+   */
+  public makeWidget(el: GridStackElement): HTMLElement {
+    this._prepareElement(el, true);
+    this._updateContainerHeight();
+    this._triggerAddEvent();
+    this._triggerChangeEvent();
+    return $(el).get(0);
+  }
+
+  /**
+   * Set the maxWidth for a widget.
+   * @param el widget to modify.
+   * @param val A numeric value of the number of columns
+   */
+  public maxWidth(els: GridStackElement, val: number): GridStack {
+    if (isNaN(val)) return;
+    $(els).each((index, el) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      node.maxWidth = (val || undefined);
+      if (node.maxWidth) {
+        el.setAttribute('data-gs-max-width', val);
+      } else {
+        el.removeAttribute('data-gs-max-width');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Set the minWidth for a widget.
+   * @param el widget to modify.
+   * @param val A numeric value of the number of columns
+   */
+  public minWidth(els: GridStackElement, val: number): GridStack {
+    if (isNaN(val)) return;
+    $(els).each((index, el) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      if (node.minWidth) {
+        el.setAttribute('data-gs-min-width', val);
+      } else {
+        el.removeAttribute('data-gs-min-width');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Set the maxHeight for a widget.
+   * @param el widget to modify.
+   * @param val A numeric value of the number of rows
+   */
+  public maxHeight(els: GridStackElement, val: number): GridStack {
+    if (isNaN(val)) return;
+    $(els).each((index, el) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      if (node.maxHeight) {
+        el.setAttribute('data-gs-max-height', val);
+      } else {
+        el.removeAttribute('data-gs-max-height');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Set the minHeight for a widget.
+   * @param el widget to modify.
+   * @param val A numeric value of the number of rows
+   */
+  public minHeight(els: GridStackElement, val: number): GridStack {
+    if (isNaN(val)) return;
+    $(els).each((index, el) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      if (node.minHeight) {
+        el.setAttribute('data-gs-min-height', val);
+      } else {
+        el.removeAttribute('data-gs-min-height');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Enables/Disables moving.
+   * @param el widget to modify.
+   * @param val if true widget will be draggable.
+   */
+  public movable(els: GridStackElement, val: boolean): GridStack {
+    $(els).each((index, el: GridItemHTMLElement) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      node.noMove = !(val || false);
+      if (node.noMove) {
+        this.dd.draggable(el, 'disable');
+        el.classList.remove('ui-draggable-handle');
+      } else {
+        this.dd.draggable(el, 'enable');
+        el.classList.remove('ui-draggable-handle');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Changes widget position
+   * @param el  widget to modify
+   * @param x new position x. If value is null or undefined it will be ignored.
+   * @param y new position y. If value is null or undefined it will be ignored.
+   */
+  public move(el: GridStackElement, x: number, y: number) {
+    this._updateElement(el, (el, node) => {
+      x = (x !== null && x !== undefined) ? x : node.x;
+      y = (y !== null && y !== undefined) ? y : node.y;
+
+      this.engine.moveNode(node, x, y, node.width, node.height);
+    });
+  }
+
+  /**
+   * unsubscribe from the 'on' event below
+   * @param eventName of the event (see possible values)
+   */
+  public off(eventName: GridStackEvent) {
+    if (eventName === 'change' || eventName === 'added' || eventName === 'removed' || eventName === 'enable' || eventName === 'disable') {
+      // remove native CustomEvent handlers
+      if (this._gsEventHandler && this._gsEventHandler[eventName]) {
+        this.el.removeEventListener(eventName, this._gsEventHandler[eventName]);
+        delete this._gsEventHandler[eventName];
+      }
+    } else {
+      // still JQuery events
+      this.$el.off(eventName);
+    }
+  }
+
+  /**
+   * Event handler that extracts our CustomEvent data out automatically for receiving custom
+   * notifications (see doc for supported events)
+   * @param eventName of the event (see possible values)
+   * @param callback function called with event and optional second/third param
+   * (see README documentation for each signature).
+   * 
+   * @example
+   * grid.on('added', function(e, items) { log('added ', items)} );
+   * 
+   * Note: in some cases it is the same as calling native handler and parsing the event.
+   * grid.el.addEventListener('added', function(event) { log('added ', event.detail)} );
+   */
+  public on(eventName: GridStackEvent, callback: (event: CustomEvent, arg2?: GridStackNode[] | Object, arg3?: Object) => void) {
+    if (eventName === 'change' || eventName === 'added' || eventName === 'removed' || eventName === 'enable' || eventName === 'disable') {
+      // native CustomEvent handlers - cash the generic handlers so we can remove
+      var noData = (eventName === 'enable' || eventName === 'disable');
+      this._gsEventHandler = this._gsEventHandler || {};
+      if (noData) {
+        this._gsEventHandler[eventName] = (event) => callback(event);
+      } else {
+        this._gsEventHandler[eventName] = (event) => callback(event, event.detail);
+      }
+      this.el.addEventListener(eventName, this._gsEventHandler[eventName]);
+    } else {
+      // still JQuery events
+      this.$el.on(eventName as any, callback);
+    }
+  }
+
+  /**
+   * Removes widget from the grid.
+   * @param el  widget to modify
+   * @param detachNode if false DOM node won't be removed from the tree (Default? true).
+   */
+  public removeWidget(el: GridStackElement, detachNode?: boolean) {
+    var elItem = $(el).get(0) as GridItemHTMLElement;
+    detachNode = (detachNode === undefined ? true : detachNode);
+    var node = elItem.gridstackNode;
+    // For Meteor support: https://github.com/gridstack/gridstack.js/pull/272
+    if (!node) {
+      node = this.engine.nodes.find(n => el === n.el);
+    }
+    if (!node) return;
+
+    delete elItem.gridstackNode;
+    this.engine.removeNode(node, detachNode);
+    this._triggerRemoveEvent();
+    this._triggerChangeEvent();
+  }
+
+  /**
+   * Removes all widgets from the grid.
+   * @param detachNode if false DOM nodes won't be removed from the tree (Default? true).
+   */
+  public removeAll(detachNode?: boolean) {
+    if (detachNode !== false) {
+      // remove our data structure before list gets emptied and DOM elements stay behind
+      this.engine.nodes.forEach(n => delete n.el.gridstackNode);
+    }
+    this.engine.removeAll(detachNode);
+    this._triggerRemoveEvent();
+  }
+
+  /**
+   * Changes widget size
+   * @param el  widget to modify
+   * @param width new dimensions width. If value is null or undefined it will be ignored.
+   * @param height  new dimensions height. If value is null or undefined it will be ignored.
+   */
+  public resize(el: GridStackElement, width: number, height: number) {
+    this._updateElement(el, (el, node) => {
+      width = (width !== null && width !== undefined) ? width : node.width;
+      height = (height !== null && height !== undefined) ? height : node.height;
+
+      this.engine.moveNode(node, node.x, node.y, width, height);
+    });
+  }
+
+  /**
+   * Enables/Disables resizing.
+   * @param el  widget to modify
+   * @param val  if true widget will be resizable.
+   */
+  public resizable(els: GridStackElement, val: boolean): GridStack {
+    $(els).each((index, el: GridItemHTMLElement) => {
+      var node = el.gridstackNode;
+      if (!node) { return; }
+      node.noResize = !(val || false);
+      if (node.noResize) {
+        this.dd.resizable(el, 'disable');
+      } else {
+        this.dd.resizable(el, 'enable');
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Toggle the grid animation state.  Toggles the `grid-stack-animate` class.
+   * @param doAnimate if true the grid will animate.
+   */
+  public setAnimation(doAnimate: boolean) {
+    if (doAnimate) {
+      this.$el.addClass('grid-stack-animate');
+    } else {
+      this.$el.removeClass('grid-stack-animate');
+    }
+  }
+
+  /**
+   * Toggle the grid static state. Also toggle the grid-stack-static class.
+   * @param staticValue if true the grid become static.
+   */
+  public setStatic(staticValue: boolean) {
+    this.opts.staticGrid = (staticValue === true);
+    this.enableMove(!staticValue);
+    this.enableResize(!staticValue);
+    this._setStaticClass();
+  }
+
+  /**
+   * Updates widget position/size.
+   * @param el widget to modify
+   * @param x new position x. If value is null or undefined it will be ignored.
+   * @param y new position y. If value is null or undefined it will be ignored.
+   * @param width new dimensions width. If value is null or undefined it will be ignored.
+   * @param height  new dimensions height. If value is null or undefined it will be ignored.
+   */
+  public update(el: GridStackElement, x: number, y: number, width: number, height: number) {
+    this._updateElement(el, (el, node) => {
+      x = (x !== null && x !== undefined) ? x : node.x;
+      y = (y !== null && y !== undefined) ? y : node.y;
+      width = (width !== null && width !== undefined) ? width : node.width;
+      height = (height !== null && height !== undefined) ? height : node.height;
+
+      this.engine.moveNode(node, x, y, width, height);
+    });
+  }
+
+  /**
+   * Updates the vertical margin - see `GridstackOptions.verticalMargin` for format options.
+   *
+   * @param value new vertical margin value
+   * @param noUpdate (optional) if true, styles will not be updated
+   */
+  public verticalMargin(value: numberOrString, noUpdate?: boolean) {
+    var heightData = Utils.parseHeight(value);
+
+    if (this.opts.verticalMarginUnit === heightData.unit && this.opts.maxRow === heightData.height) {
+      return ;
+    }
+    this.opts.verticalMarginUnit = heightData.unit;
+    this.opts.verticalMargin = heightData.height;
+
+    if (!noUpdate) {
+      this._updateStyles();
+    }
+  }
+
+  /**
+   * returns current vertical margin value
+   */
+  public getVerticalMargin(): number { return this.opts.verticalMargin as number; }
+
+  /**
+   * Returns true if the height of the grid will be less the vertical
+   * constraint. Always returns true if grid doesn't have height constraint.
+   * @param x new position x. If value is null or undefined it will be ignored.
+   * @param y new position y. If value is null or undefined it will be ignored.
+   * @param width new dimensions width. If value is null or undefined it will be ignored.
+   * @param height new dimensions height. If value is null or undefined it will be ignored.
+   * @param autoPosition if true then x, y parameters will be ignored and widget
+   * will be places on the first available position
+   *
+   * @example
+   * if (grid.willItFit(newNode.x, newNode.y, newNode.width, newNode.height, true)) {
+   *   grid.addWidget(newNode.el, newNode.x, newNode.y, newNode.width, newNode.height, true);
+   * } else {
+   *   alert('Not enough free space to place the widget');
+   * }
+   */
+  public willItFit(x: number, y: number, width: number, height: number, autoPosition: boolean): boolean {
+    var node = {x: x, y: y, width: width, height: height, autoPosition: autoPosition};
+    return this.engine.canBePlacedWithRespectToHeight(node);
+  }
+
+  private _triggerChangeEvent(skipLayoutChange?: boolean) {
+    if (this.engine.batchMode) { return; }
+    var elements = this.engine.getDirtyNodes(true); // verify they really changed
+    if (elements && elements.length) {
+      if (!skipLayoutChange) {
+        this.engine._layoutsNodesChange(elements);
+      }
+      this._triggerEvent('change', elements);
+    }
+    this.engine._saveInitial(); // we called, now reset initial values & dirty flags
+  }
+
+  private _triggerAddEvent() {
+    if (this.engine.batchMode) { return; }
+    if (this.engine.addedNodes && this.engine.addedNodes.length > 0) {
+      this.engine._layoutsNodesChange(this.engine.addedNodes);
+      // prevent added nodes from also triggering 'change' event (which is called next)
+      this.engine.addedNodes.forEach(n => { delete n._dirty; });
+      this._triggerEvent('added', this.engine.addedNodes);
+      this.engine.addedNodes = [];
+    }
+  }
+
+  private _triggerRemoveEvent() {
+    if (this.engine.batchMode) { return; }
+    if (this.engine.removedNodes && this.engine.removedNodes.length > 0) {
+      this._triggerEvent('removed', this.engine.removedNodes);
+      this.engine.removedNodes = [];
+    }
+  }
+
+  private _triggerEvent(name: string, data?: any) {
+    var event = data ? new CustomEvent(name, {bubbles: false, detail: data}) : new Event(name);
+    this.el.dispatchEvent(event);
+  }
+
+  private _initStyles() {
+    if (this._stylesId) {
+      Utils.removeStylesheet(this._stylesId);
+    }
+    this._stylesId = 'gridstack-style-' + (Math.random() * 100000).toFixed();
+    // insert style to parent (instead of 'head') to support WebComponent
+    var parent = this.el.parentNode as HTMLElement;
+    this._styles = Utils.createStylesheet(this._stylesId, parent);
+    if (this._styles !== null) {
+      this._styles._max = 0;
+    }
+  }
+
+  private _updateStyles(maxHeight?: number) {
+    if (this._styles === null || this._styles === undefined) {
+      return;
+    }
+
+    var prefix = '.' + this.opts._class + ' .' + this.opts.itemClass;
+    var getHeight;
+
+    if (maxHeight === undefined) {
+      maxHeight = this._styles._max;
+    }
+
+    this._initStyles();
+    this._updateContainerHeight();
+    if (!this.opts.cellHeight) { // The rest will be handled by CSS
+      return ;
+    }
+    if (this._styles._max !== 0 && maxHeight <= this._styles._max) { // Keep it increasing
+      return ;
+    }
+    var height = this.opts.cellHeight as number;
+    var margin = this.opts.verticalMargin as number;
+
+    if (!this.opts.verticalMargin || this.opts.cellHeightUnit === this.opts.verticalMarginUnit) {
+      getHeight = (nbRows, nbMargins) => {
+        return (height * nbRows + margin * nbMargins) + this.opts.cellHeightUnit;
+      }
+    } else {
+      getHeight = (nbRows, nbMargins) => {
+        if (!nbRows || !nbMargins) {
+          return (height * nbRows + margin * nbMargins) + this.opts.cellHeightUnit;
+        }
+        return 'calc(' + ((height * nbRows) + this.opts.cellHeightUnit) + ' + ' +
+          ((margin * nbMargins) + this.opts.verticalMarginUnit) + ')';
+      }
+    }
+
+    if (this._styles._max === 0) {
+      Utils.insertCSSRule(this._styles, prefix, 'min-height: ' + getHeight(1, 0) + ';', 0);
+    }
+
+    if (maxHeight > this._styles._max) {
+      for (var i = this._styles._max; i < maxHeight; ++i) {
+        Utils.insertCSSRule(this._styles,
+          prefix + '[data-gs-height="' + (i + 1) + '"]',
+          'height: ' + getHeight(i + 1, i) + ';',
+          i
+        );
+        Utils.insertCSSRule(this._styles,
+          prefix + '[data-gs-min-height="' + (i + 1) + '"]',
+          'min-height: ' + getHeight(i + 1, i) + ';',
+          i
+        );
+        Utils.insertCSSRule(this._styles,
+          prefix + '[data-gs-max-height="' + (i + 1) + '"]',
+          'max-height: ' + getHeight(i + 1, i) + ';',
+          i
+        );
+        Utils.insertCSSRule(this._styles,
+          prefix + '[data-gs-y="' + i + '"]',
+          'top: ' + getHeight(i, i) + ';',
+          i
+        );
+      }
+      this._styles._max = maxHeight;
+    }
+  }
+
+  private _updateContainerHeight() {
+    if (this.engine.batchMode) { return; }
+    var row = this.engine.getRow();
+    // check for css min height. Each row is cellHeight + verticalMargin, until last one which has no margin below
+    var cssMinHeight = parseInt(this.$el.css('min-height'));
+    if (cssMinHeight > 0) {
+      var verticalMargin = this.opts.verticalMargin as number;
+      var minRow =  Math.round((cssMinHeight + verticalMargin) / (this.getCellHeight() + verticalMargin));
+      if (row < minRow) {
+        row = minRow;
+      }
+    }
+    this.$el.attr('data-gs-current-row', row);
+    if (!this.opts.cellHeight) {
+      return ;
+    }
+    if (!this.opts.verticalMargin) {
+      this.$el.css('height', (row * (this.opts.cellHeight as number)) + this.opts.cellHeightUnit);
+    } else if (this.opts.cellHeightUnit === this.opts.verticalMarginUnit) {
+      this.$el.css('height', (row * ((this.opts.cellHeight as number) + (this.opts.verticalMargin as number)) -
+        (this.opts.verticalMargin as number)) + this.opts.cellHeightUnit);
+    } else {
+      this.$el.css('height', 'calc(' + ((row * (this.opts.cellHeight as number)) + this.opts.cellHeightUnit) +
+        ' + ' + ((row * ((this.opts.verticalMargin as number) - 1)) + this.opts.verticalMarginUnit) + ')');
+    }
+  }
+
+  private _setupRemovingTimeout(el) {
+    var node = $(el).get(0).gridstackNode;
+    if (node._removeTimeout || !this.opts.removable) { return; }
+    node._removeTimeout = setTimeout(() => {
+      el.addClass('grid-stack-item-removing');
+      node._isAboutToRemove = true;
+    }, this.opts.removeTimeout);
+  }
+
+  private _clearRemovingTimeout(el) {
+    var node = $(el).get(0).gridstackNode;
+
+    if (!node._removeTimeout) {
+      return;
+    }
+    clearTimeout(node._removeTimeout);
+    node._removeTimeout = null;
+    el.removeClass('grid-stack-item-removing');
+    node._isAboutToRemove = false;
+  }
+
+  /**
+   * prepares the element for drag&drop
+   **/
+  private _prepareElementsByNode(el, node) {
+    el = $(el)
+
+    // variables used/cashed between the 3 start/move/end methods, in addition to node passed above
+    var cellWidth;
+    var cellHeight;
+    var self = this;
+
+    /** called when item starts moving/resizing */
+    var onStartMoving = function(event, ui) {
+      self.$el.append(self.$placeholder);
+      self.engine.cleanNodes();
+      self.engine.beginUpdate(node);
+      cellWidth = self.cellWidth();
+      var strictCellHeight = self.getCellHeight();
+      // TODO: cellHeight = getCellHeight() causes issue (i.e. remove strictCellHeight above) otherwise
+      // when sizing up we jump almost right away to next size instead of half way there. Not sure
+      // why as we don't use ceil() in many places but round() instead.
+      cellHeight = self.$el.height() / parseInt(self.$el.attr('data-gs-current-row'));
+      var o = $(this);
+      self.$placeholder
+        .attr('data-gs-x', o.attr('data-gs-x'))
+        .attr('data-gs-y', o.attr('data-gs-y'))
+        .attr('data-gs-width', o.attr('data-gs-width'))
+        .attr('data-gs-height', o.attr('data-gs-height'))
+        .show();
+      node.el = self.$placeholder.get(0);
+      node._beforeDragX = node.x;
+      node._beforeDragY = node.y;
+      node._prevYPix = ui.position.top;
+      var minHeight = (node.minHeight || 1);
+      var verticalMargin = self.opts.verticalMargin as number;
+
+      // mineHeight - Each row is cellHeight + verticalMargin, until last one which has no margin below
+      self.dd.resizable(el, 'option', 'minWidth', cellWidth * (node.minWidth || 1));
+      self.dd.resizable(el, 'option', 'minHeight', (strictCellHeight * minHeight) + (minHeight - 1) * verticalMargin);
+
+      if (event.type === 'resizestart') {
+        o.find('.grid-stack-item').trigger('resizestart');
+      }
+    }
+
+    /** called when item is being dragged/resized */
+    var dragOrResize = function(event, ui) {
+      var x = Math.round(ui.position.left / cellWidth);
+      var y = Math.floor((ui.position.top + cellHeight / 2) / cellHeight);
+      var width;
+      var height;
+
+      if (event.type !== 'drag') {
+        width = Math.round(ui.size.width / cellWidth);
+        height = Math.round(ui.size.height / cellHeight);
+      }
+
+      if (event.type === 'drag') {
+        var distance = ui.position.top - node._prevYPix;
+        node._prevYPix = ui.position.top;
+        Utils.updateScrollPosition(el[0], ui, distance);
+        if (el.data('inTrashZone') || x < 0 || x >= self.engine.column || y < 0 ||
+          (!self.engine.float && y > self.engine.getRow())) {
+          if (!node._temporaryRemoved) {
+            if (self.opts.removable === true) {
+              self._setupRemovingTimeout(el);
+            }
+
+            x = node._beforeDragX;
+            y = node._beforeDragY;
+
+            self.$placeholder.detach();
+            self.$placeholder.hide();
+            self.engine.removeNode(node);
+            self._updateContainerHeight();
+
+            node._temporaryRemoved = true;
+          } else {
+            return;
+          }
+        } else {
+          self._clearRemovingTimeout(el);
+
+          if (node._temporaryRemoved) {
+            self.engine.addNode(node);
+            self.$placeholder
+              .attr('data-gs-x', x)
+              .attr('data-gs-y', y)
+              .attr('data-gs-width', width)
+              .attr('data-gs-height', height)
+              .show();
+            self.$el.append(self.$placeholder);
+            node.el = self.$placeholder.get(0);
+            node._temporaryRemoved = false;
+          }
+        }
+      } else if (event.type === 'resize')  {
+        if (x < 0) {
+          return;
+        }
+      }
+      // width and height are undefined if not resizing
+      var _lastTriedWidth = width !== undefined ? width : node._lastTriedWidth;
+      var _lastTriedHeight = height !== undefined ? height : node._lastTriedHeight;
+      if (!self.engine.canMoveNode(node, x, y, width, height) ||
+        (node._lastTriedX === x && node._lastTriedY === y &&
+        node._lastTriedWidth === _lastTriedWidth && node._lastTriedHeight === _lastTriedHeight)) {
+        return;
+      }
+      node._lastTriedX = x;
+      node._lastTriedY = y;
+      node._lastTriedWidth = width;
+      node._lastTriedHeight = height;
+      self.engine.moveNode(node, x, y, width, height);
+      self._updateContainerHeight();
+
+      if (event.type === 'resize')  {
+        $(event.target).trigger('gsresize', node);
+      }
+    }
+
+    /** called when the item stops moving/resizing */
+    var onEndMoving = function(event, ui) {
+      var o = $(this);
+      if (!o.get(0).gridstackNode) {
+        return;
+      }
+
+      // var forceNotify = false; what is the point of calling 'change' event with no data, when the 'removed' event is already called ?
+      self.$placeholder.detach();
+      node.el = o.get(0);
+      self.$placeholder.hide();
+
+      if (node._isAboutToRemove) {
+        // forceNotify = true;
+        var gridToNotify = el.get(0).gridstackNode._grid;
+        gridToNotify._triggerRemoveEvent();
+        delete el.get(0).gridstackNode;
+        el.remove();
+      } else {
+        self._clearRemovingTimeout(el);
+        if (!node._temporaryRemoved) {
+          Utils.removePositioningStyles(o);
+          o
+            .attr('data-gs-x', node.x)
+            .attr('data-gs-y', node.y)
+            .attr('data-gs-width', node.width)
+            .attr('data-gs-height', node.height);
+        } else {
+          Utils.removePositioningStyles(o);
+          o
+            .attr('data-gs-x', node._beforeDragX)
+            .attr('data-gs-y', node._beforeDragY)
+            .attr('data-gs-width', node.width)
+            .attr('data-gs-height', node.height);
+          node.x = node._beforeDragX;
+          node.y = node._beforeDragY;
+          node._temporaryRemoved = false;
+          self.engine.addNode(node);
+        }
+      }
+      self._updateContainerHeight();
+      self._triggerChangeEvent();
+
+      self.engine.endUpdate();
+
+      var nestedGrids = o.find('.grid-stack');
+      if (nestedGrids.length && event.type === 'resizestop') {
+        nestedGrids.each((index, el) => {
+          el.gridstack.onResizeHandler();
+        });
+        o.find('.grid-stack-item').trigger('resizestop');
+        o.find('.grid-stack-item').trigger('gsresizestop');
+      }
+      if (event.type === 'resizestop') {
+        self.$el.trigger('gsresizestop', o);
+      }
+    }
+
+    this.dd
+      .draggable(el, {
+        start: onStartMoving,
+        stop: onEndMoving,
+        drag: dragOrResize
+      })
+      .resizable(el, {
+        start: onStartMoving,
+        stop: onEndMoving,
+        resize: dragOrResize
+      });
+
+    if (node.noMove || this.opts.disableDrag || this.opts.staticGrid) {
+      this.dd.draggable(el, 'disable');
+    }
+    if (node.noResize || this.opts.disableResize || this.opts.staticGrid) {
+      this.dd.resizable(el, 'disable');
+    }
+    this._writeAttr(el, node);
+  }
+
+  private _prepareElement(el, triggerAddEvent?: boolean) {
+    triggerAddEvent = triggerAddEvent !== undefined ? triggerAddEvent : false;
+    el = $(el);
+
+    el.addClass(this.opts.itemClass);
+    var node = this._readAttr(el, {el: el.get(0), _grid: this});
+    node = this.engine.addNode(node, triggerAddEvent);
+    el.get(0).gridstackNode = node;
+
+    this._prepareElementsByNode(el, node);
+  }
+
+  /** call to write any default attributes back to element */
+  private _writeAttr(el, node) {
+    var $el = $(el);
+    node = node || {}
+    // Note: passing null removes the attr in jquery
+    if (node.x !== undefined) { el.attr('data-gs-x', node.x); }
+    if (node.y !== undefined) { el.attr('data-gs-y', node.y); }
+    if (node.width !== undefined) { el.attr('data-gs-width', node.width); }
+    if (node.height !== undefined) { el.attr('data-gs-height', node.height); }
+    if (node.autoPosition !== undefined) { el.attr('data-gs-auto-position', node.autoPosition ? true : null); }
+    if (node.minWidth !== undefined) { el.attr('data-gs-min-width', node.minWidth); }
+    if (node.maxWidth !== undefined) { el.attr('data-gs-max-width', node.maxWidth); }
+    if (node.minHeight !== undefined) { el.attr('data-gs-min-height', node.minHeight); }
+    if (node.maxHeight !== undefined) { el.attr('data-gs-max-height', node.maxHeight); }
+    if (node.noResize !== undefined) { el.attr('data-gs-no-resize', node.noResize ? true : null); }
+    if (node.noMove !== undefined) { el.attr('data-gs-no-move', node.noMove ? true : null); }
+    if (node.locked !== undefined) { el.attr('data-gs-locked', node.locked ? true : null); }
+    if (node.resizeHandles !== undefined) { el.attr('data-gs-resize-handles', node.resizeHandles); }
+    if (node.id !== undefined) { el.attr('data-gs-id', node.id); }
+  }
+
+  /** call to write any default attributes back to element */
+  private _readAttr(el, node) {
+    var $el = $(el);
+    node = node || {};
+    node.x = el.attr('data-gs-x');
+    node.y = el.attr('data-gs-y');
+    node.width = el.attr('data-gs-width');
+    node.height = el.attr('data-gs-height');
+    node.autoPosition = Utils.toBool(el.attr('data-gs-auto-position'));
+    node.maxWidth = el.attr('data-gs-max-width');
+    node.minWidth = el.attr('data-gs-min-width');
+    node.maxHeight = el.attr('data-gs-max-height');
+    node.minHeight = el.attr('data-gs-min-height');
+    node.noResize = Utils.toBool(el.attr('data-gs-no-resize'));
+    node.noMove = Utils.toBool(el.attr('data-gs-no-move'));
+    node.locked = Utils.toBool(el.attr('data-gs-locked'));
+    node.resizeHandles = el.attr('data-gs-resize-handles');
+    node.id = el.attr('data-gs-id');
+    return node;
+  }
+
+  private _updateElement(el, callback) {
+    el = $(el).first();
+    var node = el.gridstackNode;
+    if (!node) { return; }
+
+    this.engine.cleanNodes();
+    this.engine.beginUpdate(node);
+
+    callback.call(this, el, node);
+
+    this._updateContainerHeight();
+    this._triggerChangeEvent();
+
+    this.engine.endUpdate();
+  }
+
+  private _setStaticClass() {
+    var staticClassName = 'grid-stack-static';
+
+    if (this.opts.staticGrid === true) {
+      this.$el.addClass(staticClassName);
+    } else {
+      this.$el.removeClass(staticClassName);
+    }
+  }
+
+  /**
+   * called when we are being resized - check if the one Column Mode needs to be turned on/off
+   * and remember the prev columns we used.
+   */
+  private onResizeHandler() {
+    if (this.isAutoCellHeight) {
+      Utils.throttle(() => { this.cellHeight(this.cellWidth(), false)}, 100);
+    }
+
+    if (this.opts.staticGrid) { return; }
+
+    if (!this.opts.disableOneColumnMode &&
+      (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= this.opts.minWidth) {
+      if (this.oneColumnMode) {  return; }
+      this.oneColumnMode = true;
+      this.column(1);
+    } else {
+      if (!this.oneColumnMode) { return; }
+      this.oneColumnMode = false;
+      this.column(this._prevColumn);
+    }
+  }
+
+  /** called to add drag over support to support widgets*/
+  private setupAcceptWidget() {
+    if (this.opts.staticGrid || !this.opts.acceptWidgets) return;
+
+    // vars used by the function callback
+    var draggingElement = null;
+    var self = this;
+
+    var onDrag = function(event, ui) {
+      var el = draggingElement;
+      var node = el.get(0).gridstackNode;
+      var pos = this.getCellFromPixel({left: event.pageX, top: event.pageY}, true);
+      var x = Math.max(0, pos.x);
+      var y = Math.max(0, pos.y);
+      if (!node._added) {
+        node._added = true;
+
+        node.el = el.get(0);
+        node.autoPosition = true;
+        node.x = x;
+        node.y = y;
+        this.engine.cleanNodes();
+        this.engine.beginUpdate(node);
+        this.engine.addNode(node);
+
+        this.$el.append(self.$placeholder);
+        self.$placeholder
+          .attr('data-gs-x', node.x)
+          .attr('data-gs-y', node.y)
+          .attr('data-gs-width', node.width)
+          .attr('data-gs-height', node.height)
+          .show();
+        node.el = self.$placeholder.get(0);
+        node._beforeDragX = node.x;
+        node._beforeDragY = node.y;
+
+        self._updateContainerHeight();
+      }
+      if (!self.engine.canMoveNode(node, x, y)) {
+        return;
+      }
+      self.engine.moveNode(node, x, y);
+      self._updateContainerHeight();
+    };
+
+    this.dd
+      .droppable(this.el, {
+        accept: el => {
+          el = $(el);
+          var node = el.get(0).gridstackNode;
+          if (node && node._grid === this) {
+            return false;
+          }
+          return el.is(this.opts.acceptWidgets === true ? '.grid-stack-item' : this.opts.acceptWidgets);
+        }
+      })
+      .on(this.el, 'dropover', (event, ui) => {
+        var el = $(ui.draggable);
+        var width, height;
+
+        // see if we already have a node with widget/height and check for attributes
+        var origNode = el.get(0).gridstackNode;
+        if (!origNode || !origNode.width || !origNode.height) {
+          var w = parseInt(el.attr('data-gs-width'));
+          if (w > 0) { origNode = origNode || {}; origNode.width = w; }
+          var h = parseInt(el.attr('data-gs-height'));
+          if (h > 0) { origNode = origNode || {}; origNode.height = h; }
+        }
+
+        // if not calculate the grid size based on element outer size
+        // height: Each row is cellHeight + verticalMargin, until last one which has no margin below
+        var cellWidth = this.cellWidth();
+        var cellHeight = this.getCellHeight();
+        var verticalMargin = this.opts.verticalMargin as number;
+        width = origNode && origNode.width ? origNode.width : Math.ceil(el.outerWidth() / cellWidth);
+        height = origNode && origNode.height ? origNode.height : Math.round((el.outerHeight() + verticalMargin) / (cellHeight + verticalMargin));
+
+        draggingElement = el;
+
+        var node = this.engine._prepareNode({width: width, height: height, _added: false, _temporary: true});
+        node._isOutOfGrid = true;
+        el.get(0).gridstackNode = node;
+        el.get(0)._gridstackNodeOrig = origNode;
+
+        el.on('drag', onDrag);
+        return false; // prevent parent from receiving msg (which may be grid as well)
+      })
+      .on(this.el, 'dropout', (event, ui) => {
+        // jquery-ui bug. Must verify widget is being dropped out
+        // check node variable that gets set when widget is out of grid
+        var el = $(ui.draggable);
+        var node = el.get(0).gridstackNode;
+        if (!node || !node._isOutOfGrid) {
+          return;
+        }
+        el.unbind('drag', onDrag);
+        node.el = null;
+        this.engine.removeNode(node);
+        this.$placeholder.detach();
+        this._updateContainerHeight();
+        el.get(0).gridstackNode = el.get(0)._gridstackNodeOrig;
+        return false; // prevent parent from receiving msg (which may be grid as well)
+      })
+      .on(this.el, 'drop', (event, ui) => {
+        this.$placeholder.detach();
+
+        var node = $(ui.draggable).get(0).gridstackNode;
+        delete node._isOutOfGrid;
+        node._grid = this;
+        var el = $(ui.draggable).clone(false);
+        el.get(0).gridstackNode = node;
+        var originalNode = $(ui.draggable).get(0)._gridstackNodeOrig;
+        if (originalNode !== undefined && originalNode._grid !== undefined) {
+          originalNode._grid._triggerRemoveEvent();
+        }
+        $(ui.helper).remove();
+        node.el = el.get(0);
+        this.$placeholder.hide();
+        Utils.removePositioningStyles(el);
+        el.find('div.ui-resizable-handle').remove();
+
+        el
+          .attr('data-gs-x', node.x)
+          .attr('data-gs-y', node.y)
+          .attr('data-gs-width', node.width)
+          .attr('data-gs-height', node.height)
+          .addClass(this.opts.itemClass)
+          .enableSelection()
+          .removeData('draggable')
+          .removeClass('ui-draggable ui-draggable-dragging ui-draggable-disabled')
+          .unbind('drag', onDrag);
+        this.$el.append(el);
+        this._prepareElementsByNode(el, node);
+        this._updateContainerHeight();
+        this.engine.addedNodes.push(node);
+        this._triggerAddEvent();
+        this._triggerChangeEvent();
+
+        this.engine.endUpdate();
+        $(ui.draggable).unbind('drag', onDrag);
+        delete $(ui.draggable).get(0).gridstackNode;
+        delete $(ui.draggable).get(0)._gridstackNodeOrig;
+        this.$el.trigger('dropped', [originalNode, node]);
+        return false; // prevent parent from receiving msg (which may be grid as well)
+      });
+  }
+
+  // legacy method renames
+  private setGridWidth = obsolete(GridStack.prototype.column, 'setGridWidth', 'column', 'v0.5.3');
+  private setColumn = obsolete(GridStack.prototype.column, 'setColumn', 'column', 'v0.6.4');
+}

--- a/src/jquery-ui.js
+++ b/src/jquery-ui.js
@@ -4,11 +4,12 @@
 * Copyright jQuery Foundation and other contributors; Licensed MIT @preserve*/
 
 (function( factory ) {
+  /* [alain] we compile this in so no need to load with AMD
   if ( typeof define === "function" && define.amd ) {
 
     // AMD. Register as an anonymous module.
     define([ "jquery" ], factory );
-  } else {
+  } else */{
 
     // Browser globals
     factory( jQuery );

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -1,0 +1,10598 @@
+/*!
+ * jQuery JavaScript Library v3.4.1
+ * https://jquery.com/
+ *
+ * Includes Sizzle.js
+ * https://sizzlejs.com/
+ *
+ * Copyright JS Foundation and other contributors
+ * Released under the MIT license
+ * https://jquery.org/license
+ *
+ * Date: 2019-05-01T21:04Z
+ */
+( function( global, factory ) {
+
+	"use strict";
+
+	if ( typeof module === "object" && typeof module.exports === "object" ) {
+
+		// For CommonJS and CommonJS-like environments where a proper `window`
+		// is present, execute the factory and get jQuery.
+		// For environments that do not have a `window` with a `document`
+		// (such as Node.js), expose a factory as module.exports.
+		// This accentuates the need for the creation of a real `window`.
+		// e.g. var jQuery = require("jquery")(window);
+		// See ticket #14549 for more info.
+		module.exports = global.document ?
+			factory( global, true ) :
+			function( w ) {
+				if ( !w.document ) {
+					throw new Error( "jQuery requires a window with a document" );
+				}
+				return factory( w );
+			};
+	} else {
+		factory( global );
+	}
+
+// Pass this if window is not defined yet
+} )( typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
+
+// Edge <= 12 - 13+, Firefox <=18 - 45+, IE 10 - 11, Safari 5.1 - 9+, iOS 6 - 9.1
+// throw exceptions when non-strict code (e.g., ASP.NET 4.5) accesses strict mode
+// arguments.callee.caller (trac-13335). But as of jQuery 3.0 (2016), strict mode should be common
+// enough that all such attempts are guarded in a try block.
+"use strict";
+
+var arr = [];
+
+var document = window.document;
+
+var getProto = Object.getPrototypeOf;
+
+var slice = arr.slice;
+
+var concat = arr.concat;
+
+var push = arr.push;
+
+var indexOf = arr.indexOf;
+
+var class2type = {};
+
+var toString = class2type.toString;
+
+var hasOwn = class2type.hasOwnProperty;
+
+var fnToString = hasOwn.toString;
+
+var ObjectFunctionString = fnToString.call( Object );
+
+var support = {};
+
+var isFunction = function isFunction( obj ) {
+
+      // Support: Chrome <=57, Firefox <=52
+      // In some browsers, typeof returns "function" for HTML <object> elements
+      // (i.e., `typeof document.createElement( "object" ) === "function"`).
+      // We don't want to classify *any* DOM node as a function.
+      return typeof obj === "function" && typeof obj.nodeType !== "number";
+  };
+
+
+var isWindow = function isWindow( obj ) {
+		return obj != null && obj === obj.window;
+	};
+
+
+
+
+	var preservedScriptAttributes = {
+		type: true,
+		src: true,
+		nonce: true,
+		noModule: true
+	};
+
+	function DOMEval( code, node, doc ) {
+		doc = doc || document;
+
+		var i, val,
+			script = doc.createElement( "script" );
+
+		script.text = code;
+		if ( node ) {
+			for ( i in preservedScriptAttributes ) {
+
+				// Support: Firefox 64+, Edge 18+
+				// Some browsers don't support the "nonce" property on scripts.
+				// On the other hand, just using `getAttribute` is not enough as
+				// the `nonce` attribute is reset to an empty string whenever it
+				// becomes browsing-context connected.
+				// See https://github.com/whatwg/html/issues/2369
+				// See https://html.spec.whatwg.org/#nonce-attributes
+				// The `node.getAttribute` check was added for the sake of
+				// `jQuery.globalEval` so that it can fake a nonce-containing node
+				// via an object.
+				val = node[ i ] || node.getAttribute && node.getAttribute( i );
+				if ( val ) {
+					script.setAttribute( i, val );
+				}
+			}
+		}
+		doc.head.appendChild( script ).parentNode.removeChild( script );
+	}
+
+
+function toType( obj ) {
+	if ( obj == null ) {
+		return obj + "";
+	}
+
+	// Support: Android <=2.3 only (functionish RegExp)
+	return typeof obj === "object" || typeof obj === "function" ?
+		class2type[ toString.call( obj ) ] || "object" :
+		typeof obj;
+}
+/* global Symbol */
+// Defining this global in .eslintrc.json would create a danger of using the global
+// unguarded in another place, it seems safer to define global only for this module
+
+
+
+var
+	version = "3.4.1",
+
+	// Define a local copy of jQuery
+	jQuery = function( selector, context ) {
+
+		// The jQuery object is actually just the init constructor 'enhanced'
+		// Need init if jQuery is called (just allow error to be thrown if not included)
+		return new jQuery.fn.init( selector, context );
+	},
+
+	// Support: Android <=4.0 only
+	// Make sure we trim BOM and NBSP
+	rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
+
+jQuery.fn = jQuery.prototype = {
+
+	// The current version of jQuery being used
+	jquery: version,
+
+	constructor: jQuery,
+
+	// The default length of a jQuery object is 0
+	length: 0,
+
+	toArray: function() {
+		return slice.call( this );
+	},
+
+	// Get the Nth element in the matched element set OR
+	// Get the whole matched element set as a clean array
+	get: function( num ) {
+
+		// Return all the elements in a clean array
+		if ( num == null ) {
+			return slice.call( this );
+		}
+
+		// Return just the one element from the set
+		return num < 0 ? this[ num + this.length ] : this[ num ];
+	},
+
+	// Take an array of elements and push it onto the stack
+	// (returning the new matched element set)
+	pushStack: function( elems ) {
+
+		// Build a new jQuery matched element set
+		var ret = jQuery.merge( this.constructor(), elems );
+
+		// Add the old object onto the stack (as a reference)
+		ret.prevObject = this;
+
+		// Return the newly-formed element set
+		return ret;
+	},
+
+	// Execute a callback for every element in the matched set.
+	each: function( callback ) {
+		return jQuery.each( this, callback );
+	},
+
+	map: function( callback ) {
+		return this.pushStack( jQuery.map( this, function( elem, i ) {
+			return callback.call( elem, i, elem );
+		} ) );
+	},
+
+	slice: function() {
+		return this.pushStack( slice.apply( this, arguments ) );
+	},
+
+	first: function() {
+		return this.eq( 0 );
+	},
+
+	last: function() {
+		return this.eq( -1 );
+	},
+
+	eq: function( i ) {
+		var len = this.length,
+			j = +i + ( i < 0 ? len : 0 );
+		return this.pushStack( j >= 0 && j < len ? [ this[ j ] ] : [] );
+	},
+
+	end: function() {
+		return this.prevObject || this.constructor();
+	},
+
+	// For internal use only.
+	// Behaves like an Array's method, not like a jQuery method.
+	push: push,
+	sort: arr.sort,
+	splice: arr.splice
+};
+
+jQuery.extend = jQuery.fn.extend = function() {
+	var options, name, src, copy, copyIsArray, clone,
+		target = arguments[ 0 ] || {},
+		i = 1,
+		length = arguments.length,
+		deep = false;
+
+	// Handle a deep copy situation
+	if ( typeof target === "boolean" ) {
+		deep = target;
+
+		// Skip the boolean and the target
+		target = arguments[ i ] || {};
+		i++;
+	}
+
+	// Handle case when target is a string or something (possible in deep copy)
+	if ( typeof target !== "object" && !isFunction( target ) ) {
+		target = {};
+	}
+
+	// Extend jQuery itself if only one argument is passed
+	if ( i === length ) {
+		target = this;
+		i--;
+	}
+
+	for ( ; i < length; i++ ) {
+
+		// Only deal with non-null/undefined values
+		if ( ( options = arguments[ i ] ) != null ) {
+
+			// Extend the base object
+			for ( name in options ) {
+				copy = options[ name ];
+
+				// Prevent Object.prototype pollution
+				// Prevent never-ending loop
+				if ( name === "__proto__" || target === copy ) {
+					continue;
+				}
+
+				// Recurse if we're merging plain objects or arrays
+				if ( deep && copy && ( jQuery.isPlainObject( copy ) ||
+					( copyIsArray = Array.isArray( copy ) ) ) ) {
+					src = target[ name ];
+
+					// Ensure proper type for the source value
+					if ( copyIsArray && !Array.isArray( src ) ) {
+						clone = [];
+					} else if ( !copyIsArray && !jQuery.isPlainObject( src ) ) {
+						clone = {};
+					} else {
+						clone = src;
+					}
+					copyIsArray = false;
+
+					// Never move original objects, clone them
+					target[ name ] = jQuery.extend( deep, clone, copy );
+
+				// Don't bring in undefined values
+				} else if ( copy !== undefined ) {
+					target[ name ] = copy;
+				}
+			}
+		}
+	}
+
+	// Return the modified object
+	return target;
+};
+
+jQuery.extend( {
+
+	// Unique for each copy of jQuery on the page
+	expando: "jQuery" + ( version + Math.random() ).replace( /\D/g, "" ),
+
+	// Assume jQuery is ready without the ready module
+	isReady: true,
+
+	error: function( msg ) {
+		throw new Error( msg );
+	},
+
+	noop: function() {},
+
+	isPlainObject: function( obj ) {
+		var proto, Ctor;
+
+		// Detect obvious negatives
+		// Use toString instead of jQuery.type to catch host objects
+		if ( !obj || toString.call( obj ) !== "[object Object]" ) {
+			return false;
+		}
+
+		proto = getProto( obj );
+
+		// Objects with no prototype (e.g., `Object.create( null )`) are plain
+		if ( !proto ) {
+			return true;
+		}
+
+		// Objects with prototype are plain iff they were constructed by a global Object function
+		Ctor = hasOwn.call( proto, "constructor" ) && proto.constructor;
+		return typeof Ctor === "function" && fnToString.call( Ctor ) === ObjectFunctionString;
+	},
+
+	isEmptyObject: function( obj ) {
+		var name;
+
+		for ( name in obj ) {
+			return false;
+		}
+		return true;
+	},
+
+	// Evaluates a script in a global context
+	globalEval: function( code, options ) {
+		DOMEval( code, { nonce: options && options.nonce } );
+	},
+
+	each: function( obj, callback ) {
+		var length, i = 0;
+
+		if ( isArrayLike( obj ) ) {
+			length = obj.length;
+			for ( ; i < length; i++ ) {
+				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
+					break;
+				}
+			}
+		} else {
+			for ( i in obj ) {
+				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
+					break;
+				}
+			}
+		}
+
+		return obj;
+	},
+
+	// Support: Android <=4.0 only
+	trim: function( text ) {
+		return text == null ?
+			"" :
+			( text + "" ).replace( rtrim, "" );
+	},
+
+	// results is for internal usage only
+	makeArray: function( arr, results ) {
+		var ret = results || [];
+
+		if ( arr != null ) {
+			if ( isArrayLike( Object( arr ) ) ) {
+				jQuery.merge( ret,
+					typeof arr === "string" ?
+					[ arr ] : arr
+				);
+			} else {
+				push.call( ret, arr );
+			}
+		}
+
+		return ret;
+	},
+
+	inArray: function( elem, arr, i ) {
+		return arr == null ? -1 : indexOf.call( arr, elem, i );
+	},
+
+	// Support: Android <=4.0 only, PhantomJS 1 only
+	// push.apply(_, arraylike) throws on ancient WebKit
+	merge: function( first, second ) {
+		var len = +second.length,
+			j = 0,
+			i = first.length;
+
+		for ( ; j < len; j++ ) {
+			first[ i++ ] = second[ j ];
+		}
+
+		first.length = i;
+
+		return first;
+	},
+
+	grep: function( elems, callback, invert ) {
+		var callbackInverse,
+			matches = [],
+			i = 0,
+			length = elems.length,
+			callbackExpect = !invert;
+
+		// Go through the array, only saving the items
+		// that pass the validator function
+		for ( ; i < length; i++ ) {
+			callbackInverse = !callback( elems[ i ], i );
+			if ( callbackInverse !== callbackExpect ) {
+				matches.push( elems[ i ] );
+			}
+		}
+
+		return matches;
+	},
+
+	// arg is for internal usage only
+	map: function( elems, callback, arg ) {
+		var length, value,
+			i = 0,
+			ret = [];
+
+		// Go through the array, translating each of the items to their new values
+		if ( isArrayLike( elems ) ) {
+			length = elems.length;
+			for ( ; i < length; i++ ) {
+				value = callback( elems[ i ], i, arg );
+
+				if ( value != null ) {
+					ret.push( value );
+				}
+			}
+
+		// Go through every key on the object,
+		} else {
+			for ( i in elems ) {
+				value = callback( elems[ i ], i, arg );
+
+				if ( value != null ) {
+					ret.push( value );
+				}
+			}
+		}
+
+		// Flatten any nested arrays
+		return concat.apply( [], ret );
+	},
+
+	// A global GUID counter for objects
+	guid: 1,
+
+	// jQuery.support is not used in Core but other projects attach their
+	// properties to it so it needs to exist.
+	support: support
+} );
+
+if ( typeof Symbol === "function" ) {
+	jQuery.fn[ Symbol.iterator ] = arr[ Symbol.iterator ];
+}
+
+// Populate the class2type map
+jQuery.each( "Boolean Number String Function Array Date RegExp Object Error Symbol".split( " " ),
+function( i, name ) {
+	class2type[ "[object " + name + "]" ] = name.toLowerCase();
+} );
+
+function isArrayLike( obj ) {
+
+	// Support: real iOS 8.2 only (not reproducible in simulator)
+	// `in` check used to prevent JIT error (gh-2145)
+	// hasOwn isn't used here due to false negatives
+	// regarding Nodelist length in IE
+	var length = !!obj && "length" in obj && obj.length,
+		type = toType( obj );
+
+	if ( isFunction( obj ) || isWindow( obj ) ) {
+		return false;
+	}
+
+	return type === "array" || length === 0 ||
+		typeof length === "number" && length > 0 && ( length - 1 ) in obj;
+}
+var Sizzle =
+/*!
+ * Sizzle CSS Selector Engine v2.3.4
+ * https://sizzlejs.com/
+ *
+ * Copyright JS Foundation and other contributors
+ * Released under the MIT license
+ * https://js.foundation/
+ *
+ * Date: 2019-04-08
+ */
+(function( window ) {
+
+var i,
+	support,
+	Expr,
+	getText,
+	isXML,
+	tokenize,
+	compile,
+	select,
+	outermostContext,
+	sortInput,
+	hasDuplicate,
+
+	// Local document vars
+	setDocument,
+	document,
+	docElem,
+	documentIsHTML,
+	rbuggyQSA,
+	rbuggyMatches,
+	matches,
+	contains,
+
+	// Instance-specific data
+	expando = "sizzle" + 1 * new Date(),
+	preferredDoc = window.document,
+	dirruns = 0,
+	done = 0,
+	classCache = createCache(),
+	tokenCache = createCache(),
+	compilerCache = createCache(),
+	nonnativeSelectorCache = createCache(),
+	sortOrder = function( a, b ) {
+		if ( a === b ) {
+			hasDuplicate = true;
+		}
+		return 0;
+	},
+
+	// Instance methods
+	hasOwn = ({}).hasOwnProperty,
+	arr = [],
+	pop = arr.pop,
+	push_native = arr.push,
+	push = arr.push,
+	slice = arr.slice,
+	// Use a stripped-down indexOf as it's faster than native
+	// https://jsperf.com/thor-indexof-vs-for/5
+	indexOf = function( list, elem ) {
+		var i = 0,
+			len = list.length;
+		for ( ; i < len; i++ ) {
+			if ( list[i] === elem ) {
+				return i;
+			}
+		}
+		return -1;
+	},
+
+	booleans = "checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",
+
+	// Regular expressions
+
+	// http://www.w3.org/TR/css3-selectors/#whitespace
+	whitespace = "[\\x20\\t\\r\\n\\f]",
+
+	// http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+	identifier = "(?:\\\\.|[\\w-]|[^\0-\\xa0])+",
+
+	// Attribute selectors: http://www.w3.org/TR/selectors/#attribute-selectors
+	attributes = "\\[" + whitespace + "*(" + identifier + ")(?:" + whitespace +
+		// Operator (capture 2)
+		"*([*^$|!~]?=)" + whitespace +
+		// "Attribute values must be CSS identifiers [capture 5] or strings [capture 3 or capture 4]"
+		"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|(" + identifier + "))|)" + whitespace +
+		"*\\]",
+
+	pseudos = ":(" + identifier + ")(?:\\((" +
+		// To reduce the number of selectors needing tokenize in the preFilter, prefer arguments:
+		// 1. quoted (capture 3; capture 4 or capture 5)
+		"('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|" +
+		// 2. simple (capture 6)
+		"((?:\\\\.|[^\\\\()[\\]]|" + attributes + ")*)|" +
+		// 3. anything else (capture 2)
+		".*" +
+		")\\)|)",
+
+	// Leading and non-escaped trailing whitespace, capturing some non-whitespace characters preceding the latter
+	rwhitespace = new RegExp( whitespace + "+", "g" ),
+	rtrim = new RegExp( "^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$", "g" ),
+
+	rcomma = new RegExp( "^" + whitespace + "*," + whitespace + "*" ),
+	rcombinators = new RegExp( "^" + whitespace + "*([>+~]|" + whitespace + ")" + whitespace + "*" ),
+	rdescend = new RegExp( whitespace + "|>" ),
+
+	rpseudo = new RegExp( pseudos ),
+	ridentifier = new RegExp( "^" + identifier + "$" ),
+
+	matchExpr = {
+		"ID": new RegExp( "^#(" + identifier + ")" ),
+		"CLASS": new RegExp( "^\\.(" + identifier + ")" ),
+		"TAG": new RegExp( "^(" + identifier + "|[*])" ),
+		"ATTR": new RegExp( "^" + attributes ),
+		"PSEUDO": new RegExp( "^" + pseudos ),
+		"CHILD": new RegExp( "^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\(" + whitespace +
+			"*(even|odd|(([+-]|)(\\d*)n|)" + whitespace + "*(?:([+-]|)" + whitespace +
+			"*(\\d+)|))" + whitespace + "*\\)|)", "i" ),
+		"bool": new RegExp( "^(?:" + booleans + ")$", "i" ),
+		// For use in libraries implementing .is()
+		// We use this for POS matching in `select`
+		"needsContext": new RegExp( "^" + whitespace + "*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\(" +
+			whitespace + "*((?:-\\d)?\\d*)" + whitespace + "*\\)|)(?=[^-]|$)", "i" )
+	},
+
+	rhtml = /HTML$/i,
+	rinputs = /^(?:input|select|textarea|button)$/i,
+	rheader = /^h\d$/i,
+
+	rnative = /^[^{]+\{\s*\[native \w/,
+
+	// Easily-parseable/retrievable ID or TAG or CLASS selectors
+	rquickExpr = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,
+
+	rsibling = /[+~]/,
+
+	// CSS escapes
+	// http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
+	runescape = new RegExp( "\\\\([\\da-f]{1,6}" + whitespace + "?|(" + whitespace + ")|.)", "ig" ),
+	funescape = function( _, escaped, escapedWhitespace ) {
+		var high = "0x" + escaped - 0x10000;
+		// NaN means non-codepoint
+		// Support: Firefox<24
+		// Workaround erroneous numeric interpretation of +"0x"
+		return high !== high || escapedWhitespace ?
+			escaped :
+			high < 0 ?
+				// BMP codepoint
+				String.fromCharCode( high + 0x10000 ) :
+				// Supplemental Plane codepoint (surrogate pair)
+				String.fromCharCode( high >> 10 | 0xD800, high & 0x3FF | 0xDC00 );
+	},
+
+	// CSS string/identifier serialization
+	// https://drafts.csswg.org/cssom/#common-serializing-idioms
+	rcssescape = /([\0-\x1f\x7f]|^-?\d)|^-$|[^\0-\x1f\x7f-\uFFFF\w-]/g,
+	fcssescape = function( ch, asCodePoint ) {
+		if ( asCodePoint ) {
+
+			// U+0000 NULL becomes U+FFFD REPLACEMENT CHARACTER
+			if ( ch === "\0" ) {
+				return "\uFFFD";
+			}
+
+			// Control characters and (dependent upon position) numbers get escaped as code points
+			return ch.slice( 0, -1 ) + "\\" + ch.charCodeAt( ch.length - 1 ).toString( 16 ) + " ";
+		}
+
+		// Other potentially-special ASCII characters get backslash-escaped
+		return "\\" + ch;
+	},
+
+	// Used for iframes
+	// See setDocument()
+	// Removing the function wrapper causes a "Permission Denied"
+	// error in IE
+	unloadHandler = function() {
+		setDocument();
+	},
+
+	inDisabledFieldset = addCombinator(
+		function( elem ) {
+			return elem.disabled === true && elem.nodeName.toLowerCase() === "fieldset";
+		},
+		{ dir: "parentNode", next: "legend" }
+	);
+
+// Optimize for push.apply( _, NodeList )
+try {
+	push.apply(
+		(arr = slice.call( preferredDoc.childNodes )),
+		preferredDoc.childNodes
+	);
+	// Support: Android<4.0
+	// Detect silently failing push.apply
+	arr[ preferredDoc.childNodes.length ].nodeType;
+} catch ( e ) {
+	push = { apply: arr.length ?
+
+		// Leverage slice if possible
+		function( target, els ) {
+			push_native.apply( target, slice.call(els) );
+		} :
+
+		// Support: IE<9
+		// Otherwise append directly
+		function( target, els ) {
+			var j = target.length,
+				i = 0;
+			// Can't trust NodeList.length
+			while ( (target[j++] = els[i++]) ) {}
+			target.length = j - 1;
+		}
+	};
+}
+
+function Sizzle( selector, context, results, seed ) {
+	var m, i, elem, nid, match, groups, newSelector,
+		newContext = context && context.ownerDocument,
+
+		// nodeType defaults to 9, since context defaults to document
+		nodeType = context ? context.nodeType : 9;
+
+	results = results || [];
+
+	// Return early from calls with invalid selector or context
+	if ( typeof selector !== "string" || !selector ||
+		nodeType !== 1 && nodeType !== 9 && nodeType !== 11 ) {
+
+		return results;
+	}
+
+	// Try to shortcut find operations (as opposed to filters) in HTML documents
+	if ( !seed ) {
+
+		if ( ( context ? context.ownerDocument || context : preferredDoc ) !== document ) {
+			setDocument( context );
+		}
+		context = context || document;
+
+		if ( documentIsHTML ) {
+
+			// If the selector is sufficiently simple, try using a "get*By*" DOM method
+			// (excepting DocumentFragment context, where the methods don't exist)
+			if ( nodeType !== 11 && (match = rquickExpr.exec( selector )) ) {
+
+				// ID selector
+				if ( (m = match[1]) ) {
+
+					// Document context
+					if ( nodeType === 9 ) {
+						if ( (elem = context.getElementById( m )) ) {
+
+							// Support: IE, Opera, Webkit
+							// TODO: identify versions
+							// getElementById can match elements by name instead of ID
+							if ( elem.id === m ) {
+								results.push( elem );
+								return results;
+							}
+						} else {
+							return results;
+						}
+
+					// Element context
+					} else {
+
+						// Support: IE, Opera, Webkit
+						// TODO: identify versions
+						// getElementById can match elements by name instead of ID
+						if ( newContext && (elem = newContext.getElementById( m )) &&
+							contains( context, elem ) &&
+							elem.id === m ) {
+
+							results.push( elem );
+							return results;
+						}
+					}
+
+				// Type selector
+				} else if ( match[2] ) {
+					push.apply( results, context.getElementsByTagName( selector ) );
+					return results;
+
+				// Class selector
+				} else if ( (m = match[3]) && support.getElementsByClassName &&
+					context.getElementsByClassName ) {
+
+					push.apply( results, context.getElementsByClassName( m ) );
+					return results;
+				}
+			}
+
+			// Take advantage of querySelectorAll
+			if ( support.qsa &&
+				!nonnativeSelectorCache[ selector + " " ] &&
+				(!rbuggyQSA || !rbuggyQSA.test( selector )) &&
+
+				// Support: IE 8 only
+				// Exclude object elements
+				(nodeType !== 1 || context.nodeName.toLowerCase() !== "object") ) {
+
+				newSelector = selector;
+				newContext = context;
+
+				// qSA considers elements outside a scoping root when evaluating child or
+				// descendant combinators, which is not what we want.
+				// In such cases, we work around the behavior by prefixing every selector in the
+				// list with an ID selector referencing the scope context.
+				// Thanks to Andrew Dupont for this technique.
+				if ( nodeType === 1 && rdescend.test( selector ) ) {
+
+					// Capture the context ID, setting it first if necessary
+					if ( (nid = context.getAttribute( "id" )) ) {
+						nid = nid.replace( rcssescape, fcssescape );
+					} else {
+						context.setAttribute( "id", (nid = expando) );
+					}
+
+					// Prefix every selector in the list
+					groups = tokenize( selector );
+					i = groups.length;
+					while ( i-- ) {
+						groups[i] = "#" + nid + " " + toSelector( groups[i] );
+					}
+					newSelector = groups.join( "," );
+
+					// Expand context for sibling selectors
+					newContext = rsibling.test( selector ) && testContext( context.parentNode ) ||
+						context;
+				}
+
+				try {
+					push.apply( results,
+						newContext.querySelectorAll( newSelector )
+					);
+					return results;
+				} catch ( qsaError ) {
+					nonnativeSelectorCache( selector, true );
+				} finally {
+					if ( nid === expando ) {
+						context.removeAttribute( "id" );
+					}
+				}
+			}
+		}
+	}
+
+	// All others
+	return select( selector.replace( rtrim, "$1" ), context, results, seed );
+}
+
+/**
+ * Create key-value caches of limited size
+ * @returns {function(string, object)} Returns the Object data after storing it on itself with
+ *	property name the (space-suffixed) string and (if the cache is larger than Expr.cacheLength)
+ *	deleting the oldest entry
+ */
+function createCache() {
+	var keys = [];
+
+	function cache( key, value ) {
+		// Use (key + " ") to avoid collision with native prototype properties (see Issue #157)
+		if ( keys.push( key + " " ) > Expr.cacheLength ) {
+			// Only keep the most recent entries
+			delete cache[ keys.shift() ];
+		}
+		return (cache[ key + " " ] = value);
+	}
+	return cache;
+}
+
+/**
+ * Mark a function for special use by Sizzle
+ * @param {Function} fn The function to mark
+ */
+function markFunction( fn ) {
+	fn[ expando ] = true;
+	return fn;
+}
+
+/**
+ * Support testing using an element
+ * @param {Function} fn Passed the created element and returns a boolean result
+ */
+function assert( fn ) {
+	var el = document.createElement("fieldset");
+
+	try {
+		return !!fn( el );
+	} catch (e) {
+		return false;
+	} finally {
+		// Remove from its parent by default
+		if ( el.parentNode ) {
+			el.parentNode.removeChild( el );
+		}
+		// release memory in IE
+		el = null;
+	}
+}
+
+/**
+ * Adds the same handler for all of the specified attrs
+ * @param {String} attrs Pipe-separated list of attributes
+ * @param {Function} handler The method that will be applied
+ */
+function addHandle( attrs, handler ) {
+	var arr = attrs.split("|"),
+		i = arr.length;
+
+	while ( i-- ) {
+		Expr.attrHandle[ arr[i] ] = handler;
+	}
+}
+
+/**
+ * Checks document order of two siblings
+ * @param {Element} a
+ * @param {Element} b
+ * @returns {Number} Returns less than 0 if a precedes b, greater than 0 if a follows b
+ */
+function siblingCheck( a, b ) {
+	var cur = b && a,
+		diff = cur && a.nodeType === 1 && b.nodeType === 1 &&
+			a.sourceIndex - b.sourceIndex;
+
+	// Use IE sourceIndex if available on both nodes
+	if ( diff ) {
+		return diff;
+	}
+
+	// Check if b follows a
+	if ( cur ) {
+		while ( (cur = cur.nextSibling) ) {
+			if ( cur === b ) {
+				return -1;
+			}
+		}
+	}
+
+	return a ? 1 : -1;
+}
+
+/**
+ * Returns a function to use in pseudos for input types
+ * @param {String} type
+ */
+function createInputPseudo( type ) {
+	return function( elem ) {
+		var name = elem.nodeName.toLowerCase();
+		return name === "input" && elem.type === type;
+	};
+}
+
+/**
+ * Returns a function to use in pseudos for buttons
+ * @param {String} type
+ */
+function createButtonPseudo( type ) {
+	return function( elem ) {
+		var name = elem.nodeName.toLowerCase();
+		return (name === "input" || name === "button") && elem.type === type;
+	};
+}
+
+/**
+ * Returns a function to use in pseudos for :enabled/:disabled
+ * @param {Boolean} disabled true for :disabled; false for :enabled
+ */
+function createDisabledPseudo( disabled ) {
+
+	// Known :disabled false positives: fieldset[disabled] > legend:nth-of-type(n+2) :can-disable
+	return function( elem ) {
+
+		// Only certain elements can match :enabled or :disabled
+		// https://html.spec.whatwg.org/multipage/scripting.html#selector-enabled
+		// https://html.spec.whatwg.org/multipage/scripting.html#selector-disabled
+		if ( "form" in elem ) {
+
+			// Check for inherited disabledness on relevant non-disabled elements:
+			// * listed form-associated elements in a disabled fieldset
+			//   https://html.spec.whatwg.org/multipage/forms.html#category-listed
+			//   https://html.spec.whatwg.org/multipage/forms.html#concept-fe-disabled
+			// * option elements in a disabled optgroup
+			//   https://html.spec.whatwg.org/multipage/forms.html#concept-option-disabled
+			// All such elements have a "form" property.
+			if ( elem.parentNode && elem.disabled === false ) {
+
+				// Option elements defer to a parent optgroup if present
+				if ( "label" in elem ) {
+					if ( "label" in elem.parentNode ) {
+						return elem.parentNode.disabled === disabled;
+					} else {
+						return elem.disabled === disabled;
+					}
+				}
+
+				// Support: IE 6 - 11
+				// Use the isDisabled shortcut property to check for disabled fieldset ancestors
+				return elem.isDisabled === disabled ||
+
+					// Where there is no isDisabled, check manually
+					/* jshint -W018 */
+					elem.isDisabled !== !disabled &&
+						inDisabledFieldset( elem ) === disabled;
+			}
+
+			return elem.disabled === disabled;
+
+		// Try to winnow out elements that can't be disabled before trusting the disabled property.
+		// Some victims get caught in our net (label, legend, menu, track), but it shouldn't
+		// even exist on them, let alone have a boolean value.
+		} else if ( "label" in elem ) {
+			return elem.disabled === disabled;
+		}
+
+		// Remaining elements are neither :enabled nor :disabled
+		return false;
+	};
+}
+
+/**
+ * Returns a function to use in pseudos for positionals
+ * @param {Function} fn
+ */
+function createPositionalPseudo( fn ) {
+	return markFunction(function( argument ) {
+		argument = +argument;
+		return markFunction(function( seed, matches ) {
+			var j,
+				matchIndexes = fn( [], seed.length, argument ),
+				i = matchIndexes.length;
+
+			// Match elements found at the specified indexes
+			while ( i-- ) {
+				if ( seed[ (j = matchIndexes[i]) ] ) {
+					seed[j] = !(matches[j] = seed[j]);
+				}
+			}
+		});
+	});
+}
+
+/**
+ * Checks a node for validity as a Sizzle context
+ * @param {Element|Object=} context
+ * @returns {Element|Object|Boolean} The input node if acceptable, otherwise a falsy value
+ */
+function testContext( context ) {
+	return context && typeof context.getElementsByTagName !== "undefined" && context;
+}
+
+// Expose support vars for convenience
+support = Sizzle.support = {};
+
+/**
+ * Detects XML nodes
+ * @param {Element|Object} elem An element or a document
+ * @returns {Boolean} True iff elem is a non-HTML XML node
+ */
+isXML = Sizzle.isXML = function( elem ) {
+	var namespace = elem.namespaceURI,
+		docElem = (elem.ownerDocument || elem).documentElement;
+
+	// Support: IE <=8
+	// Assume HTML when documentElement doesn't yet exist, such as inside loading iframes
+	// https://bugs.jquery.com/ticket/4833
+	return !rhtml.test( namespace || docElem && docElem.nodeName || "HTML" );
+};
+
+/**
+ * Sets document-related variables once based on the current document
+ * @param {Element|Object} [doc] An element or document object to use to set the document
+ * @returns {Object} Returns the current document
+ */
+setDocument = Sizzle.setDocument = function( node ) {
+	var hasCompare, subWindow,
+		doc = node ? node.ownerDocument || node : preferredDoc;
+
+	// Return early if doc is invalid or already selected
+	if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
+		return document;
+	}
+
+	// Update global variables
+	document = doc;
+	docElem = document.documentElement;
+	documentIsHTML = !isXML( document );
+
+	// Support: IE 9-11, Edge
+	// Accessing iframe documents after unload throws "permission denied" errors (jQuery #13936)
+	if ( preferredDoc !== document &&
+		(subWindow = document.defaultView) && subWindow.top !== subWindow ) {
+
+		// Support: IE 11, Edge
+		if ( subWindow.addEventListener ) {
+			subWindow.addEventListener( "unload", unloadHandler, false );
+
+		// Support: IE 9 - 10 only
+		} else if ( subWindow.attachEvent ) {
+			subWindow.attachEvent( "onunload", unloadHandler );
+		}
+	}
+
+	/* Attributes
+	---------------------------------------------------------------------- */
+
+	// Support: IE<8
+	// Verify that getAttribute really returns attributes and not properties
+	// (excepting IE8 booleans)
+	support.attributes = assert(function( el ) {
+		el.className = "i";
+		return !el.getAttribute("className");
+	});
+
+	/* getElement(s)By*
+	---------------------------------------------------------------------- */
+
+	// Check if getElementsByTagName("*") returns only elements
+	support.getElementsByTagName = assert(function( el ) {
+		el.appendChild( document.createComment("") );
+		return !el.getElementsByTagName("*").length;
+	});
+
+	// Support: IE<9
+	support.getElementsByClassName = rnative.test( document.getElementsByClassName );
+
+	// Support: IE<10
+	// Check if getElementById returns elements by name
+	// The broken getElementById methods don't pick up programmatically-set names,
+	// so use a roundabout getElementsByName test
+	support.getById = assert(function( el ) {
+		docElem.appendChild( el ).id = expando;
+		return !document.getElementsByName || !document.getElementsByName( expando ).length;
+	});
+
+	// ID filter and find
+	if ( support.getById ) {
+		Expr.filter["ID"] = function( id ) {
+			var attrId = id.replace( runescape, funescape );
+			return function( elem ) {
+				return elem.getAttribute("id") === attrId;
+			};
+		};
+		Expr.find["ID"] = function( id, context ) {
+			if ( typeof context.getElementById !== "undefined" && documentIsHTML ) {
+				var elem = context.getElementById( id );
+				return elem ? [ elem ] : [];
+			}
+		};
+	} else {
+		Expr.filter["ID"] =  function( id ) {
+			var attrId = id.replace( runescape, funescape );
+			return function( elem ) {
+				var node = typeof elem.getAttributeNode !== "undefined" &&
+					elem.getAttributeNode("id");
+				return node && node.value === attrId;
+			};
+		};
+
+		// Support: IE 6 - 7 only
+		// getElementById is not reliable as a find shortcut
+		Expr.find["ID"] = function( id, context ) {
+			if ( typeof context.getElementById !== "undefined" && documentIsHTML ) {
+				var node, i, elems,
+					elem = context.getElementById( id );
+
+				if ( elem ) {
+
+					// Verify the id attribute
+					node = elem.getAttributeNode("id");
+					if ( node && node.value === id ) {
+						return [ elem ];
+					}
+
+					// Fall back on getElementsByName
+					elems = context.getElementsByName( id );
+					i = 0;
+					while ( (elem = elems[i++]) ) {
+						node = elem.getAttributeNode("id");
+						if ( node && node.value === id ) {
+							return [ elem ];
+						}
+					}
+				}
+
+				return [];
+			}
+		};
+	}
+
+	// Tag
+	Expr.find["TAG"] = support.getElementsByTagName ?
+		function( tag, context ) {
+			if ( typeof context.getElementsByTagName !== "undefined" ) {
+				return context.getElementsByTagName( tag );
+
+			// DocumentFragment nodes don't have gEBTN
+			} else if ( support.qsa ) {
+				return context.querySelectorAll( tag );
+			}
+		} :
+
+		function( tag, context ) {
+			var elem,
+				tmp = [],
+				i = 0,
+				// By happy coincidence, a (broken) gEBTN appears on DocumentFragment nodes too
+				results = context.getElementsByTagName( tag );
+
+			// Filter out possible comments
+			if ( tag === "*" ) {
+				while ( (elem = results[i++]) ) {
+					if ( elem.nodeType === 1 ) {
+						tmp.push( elem );
+					}
+				}
+
+				return tmp;
+			}
+			return results;
+		};
+
+	// Class
+	Expr.find["CLASS"] = support.getElementsByClassName && function( className, context ) {
+		if ( typeof context.getElementsByClassName !== "undefined" && documentIsHTML ) {
+			return context.getElementsByClassName( className );
+		}
+	};
+
+	/* QSA/matchesSelector
+	---------------------------------------------------------------------- */
+
+	// QSA and matchesSelector support
+
+	// matchesSelector(:active) reports false when true (IE9/Opera 11.5)
+	rbuggyMatches = [];
+
+	// qSa(:focus) reports false when true (Chrome 21)
+	// We allow this because of a bug in IE8/9 that throws an error
+	// whenever `document.activeElement` is accessed on an iframe
+	// So, we allow :focus to pass through QSA all the time to avoid the IE error
+	// See https://bugs.jquery.com/ticket/13378
+	rbuggyQSA = [];
+
+	if ( (support.qsa = rnative.test( document.querySelectorAll )) ) {
+		// Build QSA regex
+		// Regex strategy adopted from Diego Perini
+		assert(function( el ) {
+			// Select is set to empty string on purpose
+			// This is to test IE's treatment of not explicitly
+			// setting a boolean content attribute,
+			// since its presence should be enough
+			// https://bugs.jquery.com/ticket/12359
+			docElem.appendChild( el ).innerHTML = "<a id='" + expando + "'></a>" +
+				"<select id='" + expando + "-\r\\' msallowcapture=''>" +
+				"<option selected=''></option></select>";
+
+			// Support: IE8, Opera 11-12.16
+			// Nothing should be selected when empty strings follow ^= or $= or *=
+			// The test attribute must be unknown in Opera but "safe" for WinRT
+			// https://msdn.microsoft.com/en-us/library/ie/hh465388.aspx#attribute_section
+			if ( el.querySelectorAll("[msallowcapture^='']").length ) {
+				rbuggyQSA.push( "[*^$]=" + whitespace + "*(?:''|\"\")" );
+			}
+
+			// Support: IE8
+			// Boolean attributes and "value" are not treated correctly
+			if ( !el.querySelectorAll("[selected]").length ) {
+				rbuggyQSA.push( "\\[" + whitespace + "*(?:value|" + booleans + ")" );
+			}
+
+			// Support: Chrome<29, Android<4.4, Safari<7.0+, iOS<7.0+, PhantomJS<1.9.8+
+			if ( !el.querySelectorAll( "[id~=" + expando + "-]" ).length ) {
+				rbuggyQSA.push("~=");
+			}
+
+			// Webkit/Opera - :checked should return selected option elements
+			// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+			// IE8 throws error here and will not see later tests
+			if ( !el.querySelectorAll(":checked").length ) {
+				rbuggyQSA.push(":checked");
+			}
+
+			// Support: Safari 8+, iOS 8+
+			// https://bugs.webkit.org/show_bug.cgi?id=136851
+			// In-page `selector#id sibling-combinator selector` fails
+			if ( !el.querySelectorAll( "a#" + expando + "+*" ).length ) {
+				rbuggyQSA.push(".#.+[+~]");
+			}
+		});
+
+		assert(function( el ) {
+			el.innerHTML = "<a href='' disabled='disabled'></a>" +
+				"<select disabled='disabled'><option/></select>";
+
+			// Support: Windows 8 Native Apps
+			// The type and name attributes are restricted during .innerHTML assignment
+			var input = document.createElement("input");
+			input.setAttribute( "type", "hidden" );
+			el.appendChild( input ).setAttribute( "name", "D" );
+
+			// Support: IE8
+			// Enforce case-sensitivity of name attribute
+			if ( el.querySelectorAll("[name=d]").length ) {
+				rbuggyQSA.push( "name" + whitespace + "*[*^$|!~]?=" );
+			}
+
+			// FF 3.5 - :enabled/:disabled and hidden elements (hidden elements are still enabled)
+			// IE8 throws error here and will not see later tests
+			if ( el.querySelectorAll(":enabled").length !== 2 ) {
+				rbuggyQSA.push( ":enabled", ":disabled" );
+			}
+
+			// Support: IE9-11+
+			// IE's :disabled selector does not pick up the children of disabled fieldsets
+			docElem.appendChild( el ).disabled = true;
+			if ( el.querySelectorAll(":disabled").length !== 2 ) {
+				rbuggyQSA.push( ":enabled", ":disabled" );
+			}
+
+			// Opera 10-11 does not throw on post-comma invalid pseudos
+			el.querySelectorAll("*,:x");
+			rbuggyQSA.push(",.*:");
+		});
+	}
+
+	if ( (support.matchesSelector = rnative.test( (matches = docElem.matches ||
+		docElem.webkitMatchesSelector ||
+		docElem.mozMatchesSelector ||
+		docElem.oMatchesSelector ||
+		docElem.msMatchesSelector) )) ) {
+
+		assert(function( el ) {
+			// Check to see if it's possible to do matchesSelector
+			// on a disconnected node (IE 9)
+			support.disconnectedMatch = matches.call( el, "*" );
+
+			// This should fail with an exception
+			// Gecko does not error, returns false instead
+			matches.call( el, "[s!='']:x" );
+			rbuggyMatches.push( "!=", pseudos );
+		});
+	}
+
+	rbuggyQSA = rbuggyQSA.length && new RegExp( rbuggyQSA.join("|") );
+	rbuggyMatches = rbuggyMatches.length && new RegExp( rbuggyMatches.join("|") );
+
+	/* Contains
+	---------------------------------------------------------------------- */
+	hasCompare = rnative.test( docElem.compareDocumentPosition );
+
+	// Element contains another
+	// Purposefully self-exclusive
+	// As in, an element does not contain itself
+	contains = hasCompare || rnative.test( docElem.contains ) ?
+		function( a, b ) {
+			var adown = a.nodeType === 9 ? a.documentElement : a,
+				bup = b && b.parentNode;
+			return a === bup || !!( bup && bup.nodeType === 1 && (
+				adown.contains ?
+					adown.contains( bup ) :
+					a.compareDocumentPosition && a.compareDocumentPosition( bup ) & 16
+			));
+		} :
+		function( a, b ) {
+			if ( b ) {
+				while ( (b = b.parentNode) ) {
+					if ( b === a ) {
+						return true;
+					}
+				}
+			}
+			return false;
+		};
+
+	/* Sorting
+	---------------------------------------------------------------------- */
+
+	// Document order sorting
+	sortOrder = hasCompare ?
+	function( a, b ) {
+
+		// Flag for duplicate removal
+		if ( a === b ) {
+			hasDuplicate = true;
+			return 0;
+		}
+
+		// Sort on method existence if only one input has compareDocumentPosition
+		var compare = !a.compareDocumentPosition - !b.compareDocumentPosition;
+		if ( compare ) {
+			return compare;
+		}
+
+		// Calculate position if both inputs belong to the same document
+		compare = ( a.ownerDocument || a ) === ( b.ownerDocument || b ) ?
+			a.compareDocumentPosition( b ) :
+
+			// Otherwise we know they are disconnected
+			1;
+
+		// Disconnected nodes
+		if ( compare & 1 ||
+			(!support.sortDetached && b.compareDocumentPosition( a ) === compare) ) {
+
+			// Choose the first element that is related to our preferred document
+			if ( a === document || a.ownerDocument === preferredDoc && contains(preferredDoc, a) ) {
+				return -1;
+			}
+			if ( b === document || b.ownerDocument === preferredDoc && contains(preferredDoc, b) ) {
+				return 1;
+			}
+
+			// Maintain original order
+			return sortInput ?
+				( indexOf( sortInput, a ) - indexOf( sortInput, b ) ) :
+				0;
+		}
+
+		return compare & 4 ? -1 : 1;
+	} :
+	function( a, b ) {
+		// Exit early if the nodes are identical
+		if ( a === b ) {
+			hasDuplicate = true;
+			return 0;
+		}
+
+		var cur,
+			i = 0,
+			aup = a.parentNode,
+			bup = b.parentNode,
+			ap = [ a ],
+			bp = [ b ];
+
+		// Parentless nodes are either documents or disconnected
+		if ( !aup || !bup ) {
+			return a === document ? -1 :
+				b === document ? 1 :
+				aup ? -1 :
+				bup ? 1 :
+				sortInput ?
+				( indexOf( sortInput, a ) - indexOf( sortInput, b ) ) :
+				0;
+
+		// If the nodes are siblings, we can do a quick check
+		} else if ( aup === bup ) {
+			return siblingCheck( a, b );
+		}
+
+		// Otherwise we need full lists of their ancestors for comparison
+		cur = a;
+		while ( (cur = cur.parentNode) ) {
+			ap.unshift( cur );
+		}
+		cur = b;
+		while ( (cur = cur.parentNode) ) {
+			bp.unshift( cur );
+		}
+
+		// Walk down the tree looking for a discrepancy
+		while ( ap[i] === bp[i] ) {
+			i++;
+		}
+
+		return i ?
+			// Do a sibling check if the nodes have a common ancestor
+			siblingCheck( ap[i], bp[i] ) :
+
+			// Otherwise nodes in our document sort first
+			ap[i] === preferredDoc ? -1 :
+			bp[i] === preferredDoc ? 1 :
+			0;
+	};
+
+	return document;
+};
+
+Sizzle.matches = function( expr, elements ) {
+	return Sizzle( expr, null, null, elements );
+};
+
+Sizzle.matchesSelector = function( elem, expr ) {
+	// Set document vars if needed
+	if ( ( elem.ownerDocument || elem ) !== document ) {
+		setDocument( elem );
+	}
+
+	if ( support.matchesSelector && documentIsHTML &&
+		!nonnativeSelectorCache[ expr + " " ] &&
+		( !rbuggyMatches || !rbuggyMatches.test( expr ) ) &&
+		( !rbuggyQSA     || !rbuggyQSA.test( expr ) ) ) {
+
+		try {
+			var ret = matches.call( elem, expr );
+
+			// IE 9's matchesSelector returns false on disconnected nodes
+			if ( ret || support.disconnectedMatch ||
+					// As well, disconnected nodes are said to be in a document
+					// fragment in IE 9
+					elem.document && elem.document.nodeType !== 11 ) {
+				return ret;
+			}
+		} catch (e) {
+			nonnativeSelectorCache( expr, true );
+		}
+	}
+
+	return Sizzle( expr, document, null, [ elem ] ).length > 0;
+};
+
+Sizzle.contains = function( context, elem ) {
+	// Set document vars if needed
+	if ( ( context.ownerDocument || context ) !== document ) {
+		setDocument( context );
+	}
+	return contains( context, elem );
+};
+
+Sizzle.attr = function( elem, name ) {
+	// Set document vars if needed
+	if ( ( elem.ownerDocument || elem ) !== document ) {
+		setDocument( elem );
+	}
+
+	var fn = Expr.attrHandle[ name.toLowerCase() ],
+		// Don't get fooled by Object.prototype properties (jQuery #13807)
+		val = fn && hasOwn.call( Expr.attrHandle, name.toLowerCase() ) ?
+			fn( elem, name, !documentIsHTML ) :
+			undefined;
+
+	return val !== undefined ?
+		val :
+		support.attributes || !documentIsHTML ?
+			elem.getAttribute( name ) :
+			(val = elem.getAttributeNode(name)) && val.specified ?
+				val.value :
+				null;
+};
+
+Sizzle.escape = function( sel ) {
+	return (sel + "").replace( rcssescape, fcssescape );
+};
+
+Sizzle.error = function( msg ) {
+	throw new Error( "Syntax error, unrecognized expression: " + msg );
+};
+
+/**
+ * Document sorting and removing duplicates
+ * @param {ArrayLike} results
+ */
+Sizzle.uniqueSort = function( results ) {
+	var elem,
+		duplicates = [],
+		j = 0,
+		i = 0;
+
+	// Unless we *know* we can detect duplicates, assume their presence
+	hasDuplicate = !support.detectDuplicates;
+	sortInput = !support.sortStable && results.slice( 0 );
+	results.sort( sortOrder );
+
+	if ( hasDuplicate ) {
+		while ( (elem = results[i++]) ) {
+			if ( elem === results[ i ] ) {
+				j = duplicates.push( i );
+			}
+		}
+		while ( j-- ) {
+			results.splice( duplicates[ j ], 1 );
+		}
+	}
+
+	// Clear input after sorting to release objects
+	// See https://github.com/jquery/sizzle/pull/225
+	sortInput = null;
+
+	return results;
+};
+
+/**
+ * Utility function for retrieving the text value of an array of DOM nodes
+ * @param {Array|Element} elem
+ */
+getText = Sizzle.getText = function( elem ) {
+	var node,
+		ret = "",
+		i = 0,
+		nodeType = elem.nodeType;
+
+	if ( !nodeType ) {
+		// If no nodeType, this is expected to be an array
+		while ( (node = elem[i++]) ) {
+			// Do not traverse comment nodes
+			ret += getText( node );
+		}
+	} else if ( nodeType === 1 || nodeType === 9 || nodeType === 11 ) {
+		// Use textContent for elements
+		// innerText usage removed for consistency of new lines (jQuery #11153)
+		if ( typeof elem.textContent === "string" ) {
+			return elem.textContent;
+		} else {
+			// Traverse its children
+			for ( elem = elem.firstChild; elem; elem = elem.nextSibling ) {
+				ret += getText( elem );
+			}
+		}
+	} else if ( nodeType === 3 || nodeType === 4 ) {
+		return elem.nodeValue;
+	}
+	// Do not include comment or processing instruction nodes
+
+	return ret;
+};
+
+Expr = Sizzle.selectors = {
+
+	// Can be adjusted by the user
+	cacheLength: 50,
+
+	createPseudo: markFunction,
+
+	match: matchExpr,
+
+	attrHandle: {},
+
+	find: {},
+
+	relative: {
+		">": { dir: "parentNode", first: true },
+		" ": { dir: "parentNode" },
+		"+": { dir: "previousSibling", first: true },
+		"~": { dir: "previousSibling" }
+	},
+
+	preFilter: {
+		"ATTR": function( match ) {
+			match[1] = match[1].replace( runescape, funescape );
+
+			// Move the given value to match[3] whether quoted or unquoted
+			match[3] = ( match[3] || match[4] || match[5] || "" ).replace( runescape, funescape );
+
+			if ( match[2] === "~=" ) {
+				match[3] = " " + match[3] + " ";
+			}
+
+			return match.slice( 0, 4 );
+		},
+
+		"CHILD": function( match ) {
+			/* matches from matchExpr["CHILD"]
+				1 type (only|nth|...)
+				2 what (child|of-type)
+				3 argument (even|odd|\d*|\d*n([+-]\d+)?|...)
+				4 xn-component of xn+y argument ([+-]?\d*n|)
+				5 sign of xn-component
+				6 x of xn-component
+				7 sign of y-component
+				8 y of y-component
+			*/
+			match[1] = match[1].toLowerCase();
+
+			if ( match[1].slice( 0, 3 ) === "nth" ) {
+				// nth-* requires argument
+				if ( !match[3] ) {
+					Sizzle.error( match[0] );
+				}
+
+				// numeric x and y parameters for Expr.filter.CHILD
+				// remember that false/true cast respectively to 0/1
+				match[4] = +( match[4] ? match[5] + (match[6] || 1) : 2 * ( match[3] === "even" || match[3] === "odd" ) );
+				match[5] = +( ( match[7] + match[8] ) || match[3] === "odd" );
+
+			// other types prohibit arguments
+			} else if ( match[3] ) {
+				Sizzle.error( match[0] );
+			}
+
+			return match;
+		},
+
+		"PSEUDO": function( match ) {
+			var excess,
+				unquoted = !match[6] && match[2];
+
+			if ( matchExpr["CHILD"].test( match[0] ) ) {
+				return null;
+			}
+
+			// Accept quoted arguments as-is
+			if ( match[3] ) {
+				match[2] = match[4] || match[5] || "";
+
+			// Strip excess characters from unquoted arguments
+			} else if ( unquoted && rpseudo.test( unquoted ) &&
+				// Get excess from tokenize (recursively)
+				(excess = tokenize( unquoted, true )) &&
+				// advance to the next closing parenthesis
+				(excess = unquoted.indexOf( ")", unquoted.length - excess ) - unquoted.length) ) {
+
+				// excess is a negative index
+				match[0] = match[0].slice( 0, excess );
+				match[2] = unquoted.slice( 0, excess );
+			}
+
+			// Return only captures needed by the pseudo filter method (type and argument)
+			return match.slice( 0, 3 );
+		}
+	},
+
+	filter: {
+
+		"TAG": function( nodeNameSelector ) {
+			var nodeName = nodeNameSelector.replace( runescape, funescape ).toLowerCase();
+			return nodeNameSelector === "*" ?
+				function() { return true; } :
+				function( elem ) {
+					return elem.nodeName && elem.nodeName.toLowerCase() === nodeName;
+				};
+		},
+
+		"CLASS": function( className ) {
+			var pattern = classCache[ className + " " ];
+
+			return pattern ||
+				(pattern = new RegExp( "(^|" + whitespace + ")" + className + "(" + whitespace + "|$)" )) &&
+				classCache( className, function( elem ) {
+					return pattern.test( typeof elem.className === "string" && elem.className || typeof elem.getAttribute !== "undefined" && elem.getAttribute("class") || "" );
+				});
+		},
+
+		"ATTR": function( name, operator, check ) {
+			return function( elem ) {
+				var result = Sizzle.attr( elem, name );
+
+				if ( result == null ) {
+					return operator === "!=";
+				}
+				if ( !operator ) {
+					return true;
+				}
+
+				result += "";
+
+				return operator === "=" ? result === check :
+					operator === "!=" ? result !== check :
+					operator === "^=" ? check && result.indexOf( check ) === 0 :
+					operator === "*=" ? check && result.indexOf( check ) > -1 :
+					operator === "$=" ? check && result.slice( -check.length ) === check :
+					operator === "~=" ? ( " " + result.replace( rwhitespace, " " ) + " " ).indexOf( check ) > -1 :
+					operator === "|=" ? result === check || result.slice( 0, check.length + 1 ) === check + "-" :
+					false;
+			};
+		},
+
+		"CHILD": function( type, what, argument, first, last ) {
+			var simple = type.slice( 0, 3 ) !== "nth",
+				forward = type.slice( -4 ) !== "last",
+				ofType = what === "of-type";
+
+			return first === 1 && last === 0 ?
+
+				// Shortcut for :nth-*(n)
+				function( elem ) {
+					return !!elem.parentNode;
+				} :
+
+				function( elem, context, xml ) {
+					var cache, uniqueCache, outerCache, node, nodeIndex, start,
+						dir = simple !== forward ? "nextSibling" : "previousSibling",
+						parent = elem.parentNode,
+						name = ofType && elem.nodeName.toLowerCase(),
+						useCache = !xml && !ofType,
+						diff = false;
+
+					if ( parent ) {
+
+						// :(first|last|only)-(child|of-type)
+						if ( simple ) {
+							while ( dir ) {
+								node = elem;
+								while ( (node = node[ dir ]) ) {
+									if ( ofType ?
+										node.nodeName.toLowerCase() === name :
+										node.nodeType === 1 ) {
+
+										return false;
+									}
+								}
+								// Reverse direction for :only-* (if we haven't yet done so)
+								start = dir = type === "only" && !start && "nextSibling";
+							}
+							return true;
+						}
+
+						start = [ forward ? parent.firstChild : parent.lastChild ];
+
+						// non-xml :nth-child(...) stores cache data on `parent`
+						if ( forward && useCache ) {
+
+							// Seek `elem` from a previously-cached index
+
+							// ...in a gzip-friendly way
+							node = parent;
+							outerCache = node[ expando ] || (node[ expando ] = {});
+
+							// Support: IE <9 only
+							// Defend against cloned attroperties (jQuery gh-1709)
+							uniqueCache = outerCache[ node.uniqueID ] ||
+								(outerCache[ node.uniqueID ] = {});
+
+							cache = uniqueCache[ type ] || [];
+							nodeIndex = cache[ 0 ] === dirruns && cache[ 1 ];
+							diff = nodeIndex && cache[ 2 ];
+							node = nodeIndex && parent.childNodes[ nodeIndex ];
+
+							while ( (node = ++nodeIndex && node && node[ dir ] ||
+
+								// Fallback to seeking `elem` from the start
+								(diff = nodeIndex = 0) || start.pop()) ) {
+
+								// When found, cache indexes on `parent` and break
+								if ( node.nodeType === 1 && ++diff && node === elem ) {
+									uniqueCache[ type ] = [ dirruns, nodeIndex, diff ];
+									break;
+								}
+							}
+
+						} else {
+							// Use previously-cached element index if available
+							if ( useCache ) {
+								// ...in a gzip-friendly way
+								node = elem;
+								outerCache = node[ expando ] || (node[ expando ] = {});
+
+								// Support: IE <9 only
+								// Defend against cloned attroperties (jQuery gh-1709)
+								uniqueCache = outerCache[ node.uniqueID ] ||
+									(outerCache[ node.uniqueID ] = {});
+
+								cache = uniqueCache[ type ] || [];
+								nodeIndex = cache[ 0 ] === dirruns && cache[ 1 ];
+								diff = nodeIndex;
+							}
+
+							// xml :nth-child(...)
+							// or :nth-last-child(...) or :nth(-last)?-of-type(...)
+							if ( diff === false ) {
+								// Use the same loop as above to seek `elem` from the start
+								while ( (node = ++nodeIndex && node && node[ dir ] ||
+									(diff = nodeIndex = 0) || start.pop()) ) {
+
+									if ( ( ofType ?
+										node.nodeName.toLowerCase() === name :
+										node.nodeType === 1 ) &&
+										++diff ) {
+
+										// Cache the index of each encountered element
+										if ( useCache ) {
+											outerCache = node[ expando ] || (node[ expando ] = {});
+
+											// Support: IE <9 only
+											// Defend against cloned attroperties (jQuery gh-1709)
+											uniqueCache = outerCache[ node.uniqueID ] ||
+												(outerCache[ node.uniqueID ] = {});
+
+											uniqueCache[ type ] = [ dirruns, diff ];
+										}
+
+										if ( node === elem ) {
+											break;
+										}
+									}
+								}
+							}
+						}
+
+						// Incorporate the offset, then check against cycle size
+						diff -= last;
+						return diff === first || ( diff % first === 0 && diff / first >= 0 );
+					}
+				};
+		},
+
+		"PSEUDO": function( pseudo, argument ) {
+			// pseudo-class names are case-insensitive
+			// http://www.w3.org/TR/selectors/#pseudo-classes
+			// Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
+			// Remember that setFilters inherits from pseudos
+			var args,
+				fn = Expr.pseudos[ pseudo ] || Expr.setFilters[ pseudo.toLowerCase() ] ||
+					Sizzle.error( "unsupported pseudo: " + pseudo );
+
+			// The user may use createPseudo to indicate that
+			// arguments are needed to create the filter function
+			// just as Sizzle does
+			if ( fn[ expando ] ) {
+				return fn( argument );
+			}
+
+			// But maintain support for old signatures
+			if ( fn.length > 1 ) {
+				args = [ pseudo, pseudo, "", argument ];
+				return Expr.setFilters.hasOwnProperty( pseudo.toLowerCase() ) ?
+					markFunction(function( seed, matches ) {
+						var idx,
+							matched = fn( seed, argument ),
+							i = matched.length;
+						while ( i-- ) {
+							idx = indexOf( seed, matched[i] );
+							seed[ idx ] = !( matches[ idx ] = matched[i] );
+						}
+					}) :
+					function( elem ) {
+						return fn( elem, 0, args );
+					};
+			}
+
+			return fn;
+		}
+	},
+
+	pseudos: {
+		// Potentially complex pseudos
+		"not": markFunction(function( selector ) {
+			// Trim the selector passed to compile
+			// to avoid treating leading and trailing
+			// spaces as combinators
+			var input = [],
+				results = [],
+				matcher = compile( selector.replace( rtrim, "$1" ) );
+
+			return matcher[ expando ] ?
+				markFunction(function( seed, matches, context, xml ) {
+					var elem,
+						unmatched = matcher( seed, null, xml, [] ),
+						i = seed.length;
+
+					// Match elements unmatched by `matcher`
+					while ( i-- ) {
+						if ( (elem = unmatched[i]) ) {
+							seed[i] = !(matches[i] = elem);
+						}
+					}
+				}) :
+				function( elem, context, xml ) {
+					input[0] = elem;
+					matcher( input, null, xml, results );
+					// Don't keep the element (issue #299)
+					input[0] = null;
+					return !results.pop();
+				};
+		}),
+
+		"has": markFunction(function( selector ) {
+			return function( elem ) {
+				return Sizzle( selector, elem ).length > 0;
+			};
+		}),
+
+		"contains": markFunction(function( text ) {
+			text = text.replace( runescape, funescape );
+			return function( elem ) {
+				return ( elem.textContent || getText( elem ) ).indexOf( text ) > -1;
+			};
+		}),
+
+		// "Whether an element is represented by a :lang() selector
+		// is based solely on the element's language value
+		// being equal to the identifier C,
+		// or beginning with the identifier C immediately followed by "-".
+		// The matching of C against the element's language value is performed case-insensitively.
+		// The identifier C does not have to be a valid language name."
+		// http://www.w3.org/TR/selectors/#lang-pseudo
+		"lang": markFunction( function( lang ) {
+			// lang value must be a valid identifier
+			if ( !ridentifier.test(lang || "") ) {
+				Sizzle.error( "unsupported lang: " + lang );
+			}
+			lang = lang.replace( runescape, funescape ).toLowerCase();
+			return function( elem ) {
+				var elemLang;
+				do {
+					if ( (elemLang = documentIsHTML ?
+						elem.lang :
+						elem.getAttribute("xml:lang") || elem.getAttribute("lang")) ) {
+
+						elemLang = elemLang.toLowerCase();
+						return elemLang === lang || elemLang.indexOf( lang + "-" ) === 0;
+					}
+				} while ( (elem = elem.parentNode) && elem.nodeType === 1 );
+				return false;
+			};
+		}),
+
+		// Miscellaneous
+		"target": function( elem ) {
+			var hash = window.location && window.location.hash;
+			return hash && hash.slice( 1 ) === elem.id;
+		},
+
+		"root": function( elem ) {
+			return elem === docElem;
+		},
+
+		"focus": function( elem ) {
+			return elem === document.activeElement && (!document.hasFocus || document.hasFocus()) && !!(elem.type || elem.href || ~elem.tabIndex);
+		},
+
+		// Boolean properties
+		"enabled": createDisabledPseudo( false ),
+		"disabled": createDisabledPseudo( true ),
+
+		"checked": function( elem ) {
+			// In CSS3, :checked should return both checked and selected elements
+			// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+			var nodeName = elem.nodeName.toLowerCase();
+			return (nodeName === "input" && !!elem.checked) || (nodeName === "option" && !!elem.selected);
+		},
+
+		"selected": function( elem ) {
+			// Accessing this property makes selected-by-default
+			// options in Safari work properly
+			if ( elem.parentNode ) {
+				elem.parentNode.selectedIndex;
+			}
+
+			return elem.selected === true;
+		},
+
+		// Contents
+		"empty": function( elem ) {
+			// http://www.w3.org/TR/selectors/#empty-pseudo
+			// :empty is negated by element (1) or content nodes (text: 3; cdata: 4; entity ref: 5),
+			//   but not by others (comment: 8; processing instruction: 7; etc.)
+			// nodeType < 6 works because attributes (2) do not appear as children
+			for ( elem = elem.firstChild; elem; elem = elem.nextSibling ) {
+				if ( elem.nodeType < 6 ) {
+					return false;
+				}
+			}
+			return true;
+		},
+
+		"parent": function( elem ) {
+			return !Expr.pseudos["empty"]( elem );
+		},
+
+		// Element/input types
+		"header": function( elem ) {
+			return rheader.test( elem.nodeName );
+		},
+
+		"input": function( elem ) {
+			return rinputs.test( elem.nodeName );
+		},
+
+		"button": function( elem ) {
+			var name = elem.nodeName.toLowerCase();
+			return name === "input" && elem.type === "button" || name === "button";
+		},
+
+		"text": function( elem ) {
+			var attr;
+			return elem.nodeName.toLowerCase() === "input" &&
+				elem.type === "text" &&
+
+				// Support: IE<8
+				// New HTML5 attribute values (e.g., "search") appear with elem.type === "text"
+				( (attr = elem.getAttribute("type")) == null || attr.toLowerCase() === "text" );
+		},
+
+		// Position-in-collection
+		"first": createPositionalPseudo(function() {
+			return [ 0 ];
+		}),
+
+		"last": createPositionalPseudo(function( matchIndexes, length ) {
+			return [ length - 1 ];
+		}),
+
+		"eq": createPositionalPseudo(function( matchIndexes, length, argument ) {
+			return [ argument < 0 ? argument + length : argument ];
+		}),
+
+		"even": createPositionalPseudo(function( matchIndexes, length ) {
+			var i = 0;
+			for ( ; i < length; i += 2 ) {
+				matchIndexes.push( i );
+			}
+			return matchIndexes;
+		}),
+
+		"odd": createPositionalPseudo(function( matchIndexes, length ) {
+			var i = 1;
+			for ( ; i < length; i += 2 ) {
+				matchIndexes.push( i );
+			}
+			return matchIndexes;
+		}),
+
+		"lt": createPositionalPseudo(function( matchIndexes, length, argument ) {
+			var i = argument < 0 ?
+				argument + length :
+				argument > length ?
+					length :
+					argument;
+			for ( ; --i >= 0; ) {
+				matchIndexes.push( i );
+			}
+			return matchIndexes;
+		}),
+
+		"gt": createPositionalPseudo(function( matchIndexes, length, argument ) {
+			var i = argument < 0 ? argument + length : argument;
+			for ( ; ++i < length; ) {
+				matchIndexes.push( i );
+			}
+			return matchIndexes;
+		})
+	}
+};
+
+Expr.pseudos["nth"] = Expr.pseudos["eq"];
+
+// Add button/input type pseudos
+for ( i in { radio: true, checkbox: true, file: true, password: true, image: true } ) {
+	Expr.pseudos[ i ] = createInputPseudo( i );
+}
+for ( i in { submit: true, reset: true } ) {
+	Expr.pseudos[ i ] = createButtonPseudo( i );
+}
+
+// Easy API for creating new setFilters
+function setFilters() {}
+setFilters.prototype = Expr.filters = Expr.pseudos;
+Expr.setFilters = new setFilters();
+
+tokenize = Sizzle.tokenize = function( selector, parseOnly ) {
+	var matched, match, tokens, type,
+		soFar, groups, preFilters,
+		cached = tokenCache[ selector + " " ];
+
+	if ( cached ) {
+		return parseOnly ? 0 : cached.slice( 0 );
+	}
+
+	soFar = selector;
+	groups = [];
+	preFilters = Expr.preFilter;
+
+	while ( soFar ) {
+
+		// Comma and first run
+		if ( !matched || (match = rcomma.exec( soFar )) ) {
+			if ( match ) {
+				// Don't consume trailing commas as valid
+				soFar = soFar.slice( match[0].length ) || soFar;
+			}
+			groups.push( (tokens = []) );
+		}
+
+		matched = false;
+
+		// Combinators
+		if ( (match = rcombinators.exec( soFar )) ) {
+			matched = match.shift();
+			tokens.push({
+				value: matched,
+				// Cast descendant combinators to space
+				type: match[0].replace( rtrim, " " )
+			});
+			soFar = soFar.slice( matched.length );
+		}
+
+		// Filters
+		for ( type in Expr.filter ) {
+			if ( (match = matchExpr[ type ].exec( soFar )) && (!preFilters[ type ] ||
+				(match = preFilters[ type ]( match ))) ) {
+				matched = match.shift();
+				tokens.push({
+					value: matched,
+					type: type,
+					matches: match
+				});
+				soFar = soFar.slice( matched.length );
+			}
+		}
+
+		if ( !matched ) {
+			break;
+		}
+	}
+
+	// Return the length of the invalid excess
+	// if we're just parsing
+	// Otherwise, throw an error or return tokens
+	return parseOnly ?
+		soFar.length :
+		soFar ?
+			Sizzle.error( selector ) :
+			// Cache the tokens
+			tokenCache( selector, groups ).slice( 0 );
+};
+
+function toSelector( tokens ) {
+	var i = 0,
+		len = tokens.length,
+		selector = "";
+	for ( ; i < len; i++ ) {
+		selector += tokens[i].value;
+	}
+	return selector;
+}
+
+function addCombinator( matcher, combinator, base ) {
+	var dir = combinator.dir,
+		skip = combinator.next,
+		key = skip || dir,
+		checkNonElements = base && key === "parentNode",
+		doneName = done++;
+
+	return combinator.first ?
+		// Check against closest ancestor/preceding element
+		function( elem, context, xml ) {
+			while ( (elem = elem[ dir ]) ) {
+				if ( elem.nodeType === 1 || checkNonElements ) {
+					return matcher( elem, context, xml );
+				}
+			}
+			return false;
+		} :
+
+		// Check against all ancestor/preceding elements
+		function( elem, context, xml ) {
+			var oldCache, uniqueCache, outerCache,
+				newCache = [ dirruns, doneName ];
+
+			// We can't set arbitrary data on XML nodes, so they don't benefit from combinator caching
+			if ( xml ) {
+				while ( (elem = elem[ dir ]) ) {
+					if ( elem.nodeType === 1 || checkNonElements ) {
+						if ( matcher( elem, context, xml ) ) {
+							return true;
+						}
+					}
+				}
+			} else {
+				while ( (elem = elem[ dir ]) ) {
+					if ( elem.nodeType === 1 || checkNonElements ) {
+						outerCache = elem[ expando ] || (elem[ expando ] = {});
+
+						// Support: IE <9 only
+						// Defend against cloned attroperties (jQuery gh-1709)
+						uniqueCache = outerCache[ elem.uniqueID ] || (outerCache[ elem.uniqueID ] = {});
+
+						if ( skip && skip === elem.nodeName.toLowerCase() ) {
+							elem = elem[ dir ] || elem;
+						} else if ( (oldCache = uniqueCache[ key ]) &&
+							oldCache[ 0 ] === dirruns && oldCache[ 1 ] === doneName ) {
+
+							// Assign to newCache so results back-propagate to previous elements
+							return (newCache[ 2 ] = oldCache[ 2 ]);
+						} else {
+							// Reuse newcache so results back-propagate to previous elements
+							uniqueCache[ key ] = newCache;
+
+							// A match means we're done; a fail means we have to keep checking
+							if ( (newCache[ 2 ] = matcher( elem, context, xml )) ) {
+								return true;
+							}
+						}
+					}
+				}
+			}
+			return false;
+		};
+}
+
+function elementMatcher( matchers ) {
+	return matchers.length > 1 ?
+		function( elem, context, xml ) {
+			var i = matchers.length;
+			while ( i-- ) {
+				if ( !matchers[i]( elem, context, xml ) ) {
+					return false;
+				}
+			}
+			return true;
+		} :
+		matchers[0];
+}
+
+function multipleContexts( selector, contexts, results ) {
+	var i = 0,
+		len = contexts.length;
+	for ( ; i < len; i++ ) {
+		Sizzle( selector, contexts[i], results );
+	}
+	return results;
+}
+
+function condense( unmatched, map, filter, context, xml ) {
+	var elem,
+		newUnmatched = [],
+		i = 0,
+		len = unmatched.length,
+		mapped = map != null;
+
+	for ( ; i < len; i++ ) {
+		if ( (elem = unmatched[i]) ) {
+			if ( !filter || filter( elem, context, xml ) ) {
+				newUnmatched.push( elem );
+				if ( mapped ) {
+					map.push( i );
+				}
+			}
+		}
+	}
+
+	return newUnmatched;
+}
+
+function setMatcher( preFilter, selector, matcher, postFilter, postFinder, postSelector ) {
+	if ( postFilter && !postFilter[ expando ] ) {
+		postFilter = setMatcher( postFilter );
+	}
+	if ( postFinder && !postFinder[ expando ] ) {
+		postFinder = setMatcher( postFinder, postSelector );
+	}
+	return markFunction(function( seed, results, context, xml ) {
+		var temp, i, elem,
+			preMap = [],
+			postMap = [],
+			preexisting = results.length,
+
+			// Get initial elements from seed or context
+			elems = seed || multipleContexts( selector || "*", context.nodeType ? [ context ] : context, [] ),
+
+			// Prefilter to get matcher input, preserving a map for seed-results synchronization
+			matcherIn = preFilter && ( seed || !selector ) ?
+				condense( elems, preMap, preFilter, context, xml ) :
+				elems,
+
+			matcherOut = matcher ?
+				// If we have a postFinder, or filtered seed, or non-seed postFilter or preexisting results,
+				postFinder || ( seed ? preFilter : preexisting || postFilter ) ?
+
+					// ...intermediate processing is necessary
+					[] :
+
+					// ...otherwise use results directly
+					results :
+				matcherIn;
+
+		// Find primary matches
+		if ( matcher ) {
+			matcher( matcherIn, matcherOut, context, xml );
+		}
+
+		// Apply postFilter
+		if ( postFilter ) {
+			temp = condense( matcherOut, postMap );
+			postFilter( temp, [], context, xml );
+
+			// Un-match failing elements by moving them back to matcherIn
+			i = temp.length;
+			while ( i-- ) {
+				if ( (elem = temp[i]) ) {
+					matcherOut[ postMap[i] ] = !(matcherIn[ postMap[i] ] = elem);
+				}
+			}
+		}
+
+		if ( seed ) {
+			if ( postFinder || preFilter ) {
+				if ( postFinder ) {
+					// Get the final matcherOut by condensing this intermediate into postFinder contexts
+					temp = [];
+					i = matcherOut.length;
+					while ( i-- ) {
+						if ( (elem = matcherOut[i]) ) {
+							// Restore matcherIn since elem is not yet a final match
+							temp.push( (matcherIn[i] = elem) );
+						}
+					}
+					postFinder( null, (matcherOut = []), temp, xml );
+				}
+
+				// Move matched elements from seed to results to keep them synchronized
+				i = matcherOut.length;
+				while ( i-- ) {
+					if ( (elem = matcherOut[i]) &&
+						(temp = postFinder ? indexOf( seed, elem ) : preMap[i]) > -1 ) {
+
+						seed[temp] = !(results[temp] = elem);
+					}
+				}
+			}
+
+		// Add elements to results, through postFinder if defined
+		} else {
+			matcherOut = condense(
+				matcherOut === results ?
+					matcherOut.splice( preexisting, matcherOut.length ) :
+					matcherOut
+			);
+			if ( postFinder ) {
+				postFinder( null, results, matcherOut, xml );
+			} else {
+				push.apply( results, matcherOut );
+			}
+		}
+	});
+}
+
+function matcherFromTokens( tokens ) {
+	var checkContext, matcher, j,
+		len = tokens.length,
+		leadingRelative = Expr.relative[ tokens[0].type ],
+		implicitRelative = leadingRelative || Expr.relative[" "],
+		i = leadingRelative ? 1 : 0,
+
+		// The foundational matcher ensures that elements are reachable from top-level context(s)
+		matchContext = addCombinator( function( elem ) {
+			return elem === checkContext;
+		}, implicitRelative, true ),
+		matchAnyContext = addCombinator( function( elem ) {
+			return indexOf( checkContext, elem ) > -1;
+		}, implicitRelative, true ),
+		matchers = [ function( elem, context, xml ) {
+			var ret = ( !leadingRelative && ( xml || context !== outermostContext ) ) || (
+				(checkContext = context).nodeType ?
+					matchContext( elem, context, xml ) :
+					matchAnyContext( elem, context, xml ) );
+			// Avoid hanging onto element (issue #299)
+			checkContext = null;
+			return ret;
+		} ];
+
+	for ( ; i < len; i++ ) {
+		if ( (matcher = Expr.relative[ tokens[i].type ]) ) {
+			matchers = [ addCombinator(elementMatcher( matchers ), matcher) ];
+		} else {
+			matcher = Expr.filter[ tokens[i].type ].apply( null, tokens[i].matches );
+
+			// Return special upon seeing a positional matcher
+			if ( matcher[ expando ] ) {
+				// Find the next relative operator (if any) for proper handling
+				j = ++i;
+				for ( ; j < len; j++ ) {
+					if ( Expr.relative[ tokens[j].type ] ) {
+						break;
+					}
+				}
+				return setMatcher(
+					i > 1 && elementMatcher( matchers ),
+					i > 1 && toSelector(
+						// If the preceding token was a descendant combinator, insert an implicit any-element `*`
+						tokens.slice( 0, i - 1 ).concat({ value: tokens[ i - 2 ].type === " " ? "*" : "" })
+					).replace( rtrim, "$1" ),
+					matcher,
+					i < j && matcherFromTokens( tokens.slice( i, j ) ),
+					j < len && matcherFromTokens( (tokens = tokens.slice( j )) ),
+					j < len && toSelector( tokens )
+				);
+			}
+			matchers.push( matcher );
+		}
+	}
+
+	return elementMatcher( matchers );
+}
+
+function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
+	var bySet = setMatchers.length > 0,
+		byElement = elementMatchers.length > 0,
+		superMatcher = function( seed, context, xml, results, outermost ) {
+			var elem, j, matcher,
+				matchedCount = 0,
+				i = "0",
+				unmatched = seed && [],
+				setMatched = [],
+				contextBackup = outermostContext,
+				// We must always have either seed elements or outermost context
+				elems = seed || byElement && Expr.find["TAG"]( "*", outermost ),
+				// Use integer dirruns iff this is the outermost matcher
+				dirrunsUnique = (dirruns += contextBackup == null ? 1 : Math.random() || 0.1),
+				len = elems.length;
+
+			if ( outermost ) {
+				outermostContext = context === document || context || outermost;
+			}
+
+			// Add elements passing elementMatchers directly to results
+			// Support: IE<9, Safari
+			// Tolerate NodeList properties (IE: "length"; Safari: <number>) matching elements by id
+			for ( ; i !== len && (elem = elems[i]) != null; i++ ) {
+				if ( byElement && elem ) {
+					j = 0;
+					if ( !context && elem.ownerDocument !== document ) {
+						setDocument( elem );
+						xml = !documentIsHTML;
+					}
+					while ( (matcher = elementMatchers[j++]) ) {
+						if ( matcher( elem, context || document, xml) ) {
+							results.push( elem );
+							break;
+						}
+					}
+					if ( outermost ) {
+						dirruns = dirrunsUnique;
+					}
+				}
+
+				// Track unmatched elements for set filters
+				if ( bySet ) {
+					// They will have gone through all possible matchers
+					if ( (elem = !matcher && elem) ) {
+						matchedCount--;
+					}
+
+					// Lengthen the array for every element, matched or not
+					if ( seed ) {
+						unmatched.push( elem );
+					}
+				}
+			}
+
+			// `i` is now the count of elements visited above, and adding it to `matchedCount`
+			// makes the latter nonnegative.
+			matchedCount += i;
+
+			// Apply set filters to unmatched elements
+			// NOTE: This can be skipped if there are no unmatched elements (i.e., `matchedCount`
+			// equals `i`), unless we didn't visit _any_ elements in the above loop because we have
+			// no element matchers and no seed.
+			// Incrementing an initially-string "0" `i` allows `i` to remain a string only in that
+			// case, which will result in a "00" `matchedCount` that differs from `i` but is also
+			// numerically zero.
+			if ( bySet && i !== matchedCount ) {
+				j = 0;
+				while ( (matcher = setMatchers[j++]) ) {
+					matcher( unmatched, setMatched, context, xml );
+				}
+
+				if ( seed ) {
+					// Reintegrate element matches to eliminate the need for sorting
+					if ( matchedCount > 0 ) {
+						while ( i-- ) {
+							if ( !(unmatched[i] || setMatched[i]) ) {
+								setMatched[i] = pop.call( results );
+							}
+						}
+					}
+
+					// Discard index placeholder values to get only actual matches
+					setMatched = condense( setMatched );
+				}
+
+				// Add matches to results
+				push.apply( results, setMatched );
+
+				// Seedless set matches succeeding multiple successful matchers stipulate sorting
+				if ( outermost && !seed && setMatched.length > 0 &&
+					( matchedCount + setMatchers.length ) > 1 ) {
+
+					Sizzle.uniqueSort( results );
+				}
+			}
+
+			// Override manipulation of globals by nested matchers
+			if ( outermost ) {
+				dirruns = dirrunsUnique;
+				outermostContext = contextBackup;
+			}
+
+			return unmatched;
+		};
+
+	return bySet ?
+		markFunction( superMatcher ) :
+		superMatcher;
+}
+
+compile = Sizzle.compile = function( selector, match /* Internal Use Only */ ) {
+	var i,
+		setMatchers = [],
+		elementMatchers = [],
+		cached = compilerCache[ selector + " " ];
+
+	if ( !cached ) {
+		// Generate a function of recursive functions that can be used to check each element
+		if ( !match ) {
+			match = tokenize( selector );
+		}
+		i = match.length;
+		while ( i-- ) {
+			cached = matcherFromTokens( match[i] );
+			if ( cached[ expando ] ) {
+				setMatchers.push( cached );
+			} else {
+				elementMatchers.push( cached );
+			}
+		}
+
+		// Cache the compiled function
+		cached = compilerCache( selector, matcherFromGroupMatchers( elementMatchers, setMatchers ) );
+
+		// Save selector and tokenization
+		cached.selector = selector;
+	}
+	return cached;
+};
+
+/**
+ * A low-level selection function that works with Sizzle's compiled
+ *  selector functions
+ * @param {String|Function} selector A selector or a pre-compiled
+ *  selector function built with Sizzle.compile
+ * @param {Element} context
+ * @param {Array} [results]
+ * @param {Array} [seed] A set of elements to match against
+ */
+select = Sizzle.select = function( selector, context, results, seed ) {
+	var i, tokens, token, type, find,
+		compiled = typeof selector === "function" && selector,
+		match = !seed && tokenize( (selector = compiled.selector || selector) );
+
+	results = results || [];
+
+	// Try to minimize operations if there is only one selector in the list and no seed
+	// (the latter of which guarantees us context)
+	if ( match.length === 1 ) {
+
+		// Reduce context if the leading compound selector is an ID
+		tokens = match[0] = match[0].slice( 0 );
+		if ( tokens.length > 2 && (token = tokens[0]).type === "ID" &&
+				context.nodeType === 9 && documentIsHTML && Expr.relative[ tokens[1].type ] ) {
+
+			context = ( Expr.find["ID"]( token.matches[0].replace(runescape, funescape), context ) || [] )[0];
+			if ( !context ) {
+				return results;
+
+			// Precompiled matchers will still verify ancestry, so step up a level
+			} else if ( compiled ) {
+				context = context.parentNode;
+			}
+
+			selector = selector.slice( tokens.shift().value.length );
+		}
+
+		// Fetch a seed set for right-to-left matching
+		i = matchExpr["needsContext"].test( selector ) ? 0 : tokens.length;
+		while ( i-- ) {
+			token = tokens[i];
+
+			// Abort if we hit a combinator
+			if ( Expr.relative[ (type = token.type) ] ) {
+				break;
+			}
+			if ( (find = Expr.find[ type ]) ) {
+				// Search, expanding context for leading sibling combinators
+				if ( (seed = find(
+					token.matches[0].replace( runescape, funescape ),
+					rsibling.test( tokens[0].type ) && testContext( context.parentNode ) || context
+				)) ) {
+
+					// If seed is empty or no tokens remain, we can return early
+					tokens.splice( i, 1 );
+					selector = seed.length && toSelector( tokens );
+					if ( !selector ) {
+						push.apply( results, seed );
+						return results;
+					}
+
+					break;
+				}
+			}
+		}
+	}
+
+	// Compile and execute a filtering function if one is not provided
+	// Provide `match` to avoid retokenization if we modified the selector above
+	( compiled || compile( selector, match ) )(
+		seed,
+		context,
+		!documentIsHTML,
+		results,
+		!context || rsibling.test( selector ) && testContext( context.parentNode ) || context
+	);
+	return results;
+};
+
+// One-time assignments
+
+// Sort stability
+support.sortStable = expando.split("").sort( sortOrder ).join("") === expando;
+
+// Support: Chrome 14-35+
+// Always assume duplicates if they aren't passed to the comparison function
+support.detectDuplicates = !!hasDuplicate;
+
+// Initialize against the default document
+setDocument();
+
+// Support: Webkit<537.32 - Safari 6.0.3/Chrome 25 (fixed in Chrome 27)
+// Detached nodes confoundingly follow *each other*
+support.sortDetached = assert(function( el ) {
+	// Should return 1, but returns 4 (following)
+	return el.compareDocumentPosition( document.createElement("fieldset") ) & 1;
+});
+
+// Support: IE<8
+// Prevent attribute/property "interpolation"
+// https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+if ( !assert(function( el ) {
+	el.innerHTML = "<a href='#'></a>";
+	return el.firstChild.getAttribute("href") === "#" ;
+}) ) {
+	addHandle( "type|href|height|width", function( elem, name, isXML ) {
+		if ( !isXML ) {
+			return elem.getAttribute( name, name.toLowerCase() === "type" ? 1 : 2 );
+		}
+	});
+}
+
+// Support: IE<9
+// Use defaultValue in place of getAttribute("value")
+if ( !support.attributes || !assert(function( el ) {
+	el.innerHTML = "<input/>";
+	el.firstChild.setAttribute( "value", "" );
+	return el.firstChild.getAttribute( "value" ) === "";
+}) ) {
+	addHandle( "value", function( elem, name, isXML ) {
+		if ( !isXML && elem.nodeName.toLowerCase() === "input" ) {
+			return elem.defaultValue;
+		}
+	});
+}
+
+// Support: IE<9
+// Use getAttributeNode to fetch booleans when getAttribute lies
+if ( !assert(function( el ) {
+	return el.getAttribute("disabled") == null;
+}) ) {
+	addHandle( booleans, function( elem, name, isXML ) {
+		var val;
+		if ( !isXML ) {
+			return elem[ name ] === true ? name.toLowerCase() :
+					(val = elem.getAttributeNode( name )) && val.specified ?
+					val.value :
+				null;
+		}
+	});
+}
+
+return Sizzle;
+
+})( window );
+
+
+
+jQuery.find = Sizzle;
+jQuery.expr = Sizzle.selectors;
+
+// Deprecated
+jQuery.expr[ ":" ] = jQuery.expr.pseudos;
+jQuery.uniqueSort = jQuery.unique = Sizzle.uniqueSort;
+jQuery.text = Sizzle.getText;
+jQuery.isXMLDoc = Sizzle.isXML;
+jQuery.contains = Sizzle.contains;
+jQuery.escapeSelector = Sizzle.escape;
+
+
+
+
+var dir = function( elem, dir, until ) {
+	var matched = [],
+		truncate = until !== undefined;
+
+	while ( ( elem = elem[ dir ] ) && elem.nodeType !== 9 ) {
+		if ( elem.nodeType === 1 ) {
+			if ( truncate && jQuery( elem ).is( until ) ) {
+				break;
+			}
+			matched.push( elem );
+		}
+	}
+	return matched;
+};
+
+
+var siblings = function( n, elem ) {
+	var matched = [];
+
+	for ( ; n; n = n.nextSibling ) {
+		if ( n.nodeType === 1 && n !== elem ) {
+			matched.push( n );
+		}
+	}
+
+	return matched;
+};
+
+
+var rneedsContext = jQuery.expr.match.needsContext;
+
+
+
+function nodeName( elem, name ) {
+
+  return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
+
+};
+var rsingleTag = ( /^<([a-z][^\/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>|)$/i );
+
+
+
+// Implement the identical functionality for filter and not
+function winnow( elements, qualifier, not ) {
+	if ( isFunction( qualifier ) ) {
+		return jQuery.grep( elements, function( elem, i ) {
+			return !!qualifier.call( elem, i, elem ) !== not;
+		} );
+	}
+
+	// Single element
+	if ( qualifier.nodeType ) {
+		return jQuery.grep( elements, function( elem ) {
+			return ( elem === qualifier ) !== not;
+		} );
+	}
+
+	// Arraylike of elements (jQuery, arguments, Array)
+	if ( typeof qualifier !== "string" ) {
+		return jQuery.grep( elements, function( elem ) {
+			return ( indexOf.call( qualifier, elem ) > -1 ) !== not;
+		} );
+	}
+
+	// Filtered directly for both simple and complex selectors
+	return jQuery.filter( qualifier, elements, not );
+}
+
+jQuery.filter = function( expr, elems, not ) {
+	var elem = elems[ 0 ];
+
+	if ( not ) {
+		expr = ":not(" + expr + ")";
+	}
+
+	if ( elems.length === 1 && elem.nodeType === 1 ) {
+		return jQuery.find.matchesSelector( elem, expr ) ? [ elem ] : [];
+	}
+
+	return jQuery.find.matches( expr, jQuery.grep( elems, function( elem ) {
+		return elem.nodeType === 1;
+	} ) );
+};
+
+jQuery.fn.extend( {
+	find: function( selector ) {
+		var i, ret,
+			len = this.length,
+			self = this;
+
+		if ( typeof selector !== "string" ) {
+			return this.pushStack( jQuery( selector ).filter( function() {
+				for ( i = 0; i < len; i++ ) {
+					if ( jQuery.contains( self[ i ], this ) ) {
+						return true;
+					}
+				}
+			} ) );
+		}
+
+		ret = this.pushStack( [] );
+
+		for ( i = 0; i < len; i++ ) {
+			jQuery.find( selector, self[ i ], ret );
+		}
+
+		return len > 1 ? jQuery.uniqueSort( ret ) : ret;
+	},
+	filter: function( selector ) {
+		return this.pushStack( winnow( this, selector || [], false ) );
+	},
+	not: function( selector ) {
+		return this.pushStack( winnow( this, selector || [], true ) );
+	},
+	is: function( selector ) {
+		return !!winnow(
+			this,
+
+			// If this is a positional/relative selector, check membership in the returned set
+			// so $("p:first").is("p:last") won't return true for a doc with two "p".
+			typeof selector === "string" && rneedsContext.test( selector ) ?
+				jQuery( selector ) :
+				selector || [],
+			false
+		).length;
+	}
+} );
+
+
+// Initialize a jQuery object
+
+
+// A central reference to the root jQuery(document)
+var rootjQuery,
+
+	// A simple way to check for HTML strings
+	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
+	// Strict HTML recognition (#11290: must start with <)
+	// Shortcut simple #id case for speed
+	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,
+
+	init = jQuery.fn.init = function( selector, context, root ) {
+		var match, elem;
+
+		// HANDLE: $(""), $(null), $(undefined), $(false)
+		if ( !selector ) {
+			return this;
+		}
+
+		// Method init() accepts an alternate rootjQuery
+		// so migrate can support jQuery.sub (gh-2101)
+		root = root || rootjQuery;
+
+		// Handle HTML strings
+		if ( typeof selector === "string" ) {
+			if ( selector[ 0 ] === "<" &&
+				selector[ selector.length - 1 ] === ">" &&
+				selector.length >= 3 ) {
+
+				// Assume that strings that start and end with <> are HTML and skip the regex check
+				match = [ null, selector, null ];
+
+			} else {
+				match = rquickExpr.exec( selector );
+			}
+
+			// Match html or make sure no context is specified for #id
+			if ( match && ( match[ 1 ] || !context ) ) {
+
+				// HANDLE: $(html) -> $(array)
+				if ( match[ 1 ] ) {
+					context = context instanceof jQuery ? context[ 0 ] : context;
+
+					// Option to run scripts is true for back-compat
+					// Intentionally let the error be thrown if parseHTML is not present
+					jQuery.merge( this, jQuery.parseHTML(
+						match[ 1 ],
+						context && context.nodeType ? context.ownerDocument || context : document,
+						true
+					) );
+
+					// HANDLE: $(html, props)
+					if ( rsingleTag.test( match[ 1 ] ) && jQuery.isPlainObject( context ) ) {
+						for ( match in context ) {
+
+							// Properties of context are called as methods if possible
+							if ( isFunction( this[ match ] ) ) {
+								this[ match ]( context[ match ] );
+
+							// ...and otherwise set as attributes
+							} else {
+								this.attr( match, context[ match ] );
+							}
+						}
+					}
+
+					return this;
+
+				// HANDLE: $(#id)
+				} else {
+					elem = document.getElementById( match[ 2 ] );
+
+					if ( elem ) {
+
+						// Inject the element directly into the jQuery object
+						this[ 0 ] = elem;
+						this.length = 1;
+					}
+					return this;
+				}
+
+			// HANDLE: $(expr, $(...))
+			} else if ( !context || context.jquery ) {
+				return ( context || root ).find( selector );
+
+			// HANDLE: $(expr, context)
+			// (which is just equivalent to: $(context).find(expr)
+			} else {
+				return this.constructor( context ).find( selector );
+			}
+
+		// HANDLE: $(DOMElement)
+		} else if ( selector.nodeType ) {
+			this[ 0 ] = selector;
+			this.length = 1;
+			return this;
+
+		// HANDLE: $(function)
+		// Shortcut for document ready
+		} else if ( isFunction( selector ) ) {
+			return root.ready !== undefined ?
+				root.ready( selector ) :
+
+				// Execute immediately if ready is not present
+				selector( jQuery );
+		}
+
+		return jQuery.makeArray( selector, this );
+	};
+
+// Give the init function the jQuery prototype for later instantiation
+init.prototype = jQuery.fn;
+
+// Initialize central reference
+rootjQuery = jQuery( document );
+
+
+var rparentsprev = /^(?:parents|prev(?:Until|All))/,
+
+	// Methods guaranteed to produce a unique set when starting from a unique set
+	guaranteedUnique = {
+		children: true,
+		contents: true,
+		next: true,
+		prev: true
+	};
+
+jQuery.fn.extend( {
+	has: function( target ) {
+		var targets = jQuery( target, this ),
+			l = targets.length;
+
+		return this.filter( function() {
+			var i = 0;
+			for ( ; i < l; i++ ) {
+				if ( jQuery.contains( this, targets[ i ] ) ) {
+					return true;
+				}
+			}
+		} );
+	},
+
+	closest: function( selectors, context ) {
+		var cur,
+			i = 0,
+			l = this.length,
+			matched = [],
+			targets = typeof selectors !== "string" && jQuery( selectors );
+
+		// Positional selectors never match, since there's no _selection_ context
+		if ( !rneedsContext.test( selectors ) ) {
+			for ( ; i < l; i++ ) {
+				for ( cur = this[ i ]; cur && cur !== context; cur = cur.parentNode ) {
+
+					// Always skip document fragments
+					if ( cur.nodeType < 11 && ( targets ?
+						targets.index( cur ) > -1 :
+
+						// Don't pass non-elements to Sizzle
+						cur.nodeType === 1 &&
+							jQuery.find.matchesSelector( cur, selectors ) ) ) {
+
+						matched.push( cur );
+						break;
+					}
+				}
+			}
+		}
+
+		return this.pushStack( matched.length > 1 ? jQuery.uniqueSort( matched ) : matched );
+	},
+
+	// Determine the position of an element within the set
+	index: function( elem ) {
+
+		// No argument, return index in parent
+		if ( !elem ) {
+			return ( this[ 0 ] && this[ 0 ].parentNode ) ? this.first().prevAll().length : -1;
+		}
+
+		// Index in selector
+		if ( typeof elem === "string" ) {
+			return indexOf.call( jQuery( elem ), this[ 0 ] );
+		}
+
+		// Locate the position of the desired element
+		return indexOf.call( this,
+
+			// If it receives a jQuery object, the first element is used
+			elem.jquery ? elem[ 0 ] : elem
+		);
+	},
+
+	add: function( selector, context ) {
+		return this.pushStack(
+			jQuery.uniqueSort(
+				jQuery.merge( this.get(), jQuery( selector, context ) )
+			)
+		);
+	},
+
+	addBack: function( selector ) {
+		return this.add( selector == null ?
+			this.prevObject : this.prevObject.filter( selector )
+		);
+	}
+} );
+
+function sibling( cur, dir ) {
+	while ( ( cur = cur[ dir ] ) && cur.nodeType !== 1 ) {}
+	return cur;
+}
+
+jQuery.each( {
+	parent: function( elem ) {
+		var parent = elem.parentNode;
+		return parent && parent.nodeType !== 11 ? parent : null;
+	},
+	parents: function( elem ) {
+		return dir( elem, "parentNode" );
+	},
+	parentsUntil: function( elem, i, until ) {
+		return dir( elem, "parentNode", until );
+	},
+	next: function( elem ) {
+		return sibling( elem, "nextSibling" );
+	},
+	prev: function( elem ) {
+		return sibling( elem, "previousSibling" );
+	},
+	nextAll: function( elem ) {
+		return dir( elem, "nextSibling" );
+	},
+	prevAll: function( elem ) {
+		return dir( elem, "previousSibling" );
+	},
+	nextUntil: function( elem, i, until ) {
+		return dir( elem, "nextSibling", until );
+	},
+	prevUntil: function( elem, i, until ) {
+		return dir( elem, "previousSibling", until );
+	},
+	siblings: function( elem ) {
+		return siblings( ( elem.parentNode || {} ).firstChild, elem );
+	},
+	children: function( elem ) {
+		return siblings( elem.firstChild );
+	},
+	contents: function( elem ) {
+		if ( typeof elem.contentDocument !== "undefined" ) {
+			return elem.contentDocument;
+		}
+
+		// Support: IE 9 - 11 only, iOS 7 only, Android Browser <=4.3 only
+		// Treat the template element as a regular one in browsers that
+		// don't support it.
+		if ( nodeName( elem, "template" ) ) {
+			elem = elem.content || elem;
+		}
+
+		return jQuery.merge( [], elem.childNodes );
+	}
+}, function( name, fn ) {
+	jQuery.fn[ name ] = function( until, selector ) {
+		var matched = jQuery.map( this, fn, until );
+
+		if ( name.slice( -5 ) !== "Until" ) {
+			selector = until;
+		}
+
+		if ( selector && typeof selector === "string" ) {
+			matched = jQuery.filter( selector, matched );
+		}
+
+		if ( this.length > 1 ) {
+
+			// Remove duplicates
+			if ( !guaranteedUnique[ name ] ) {
+				jQuery.uniqueSort( matched );
+			}
+
+			// Reverse order for parents* and prev-derivatives
+			if ( rparentsprev.test( name ) ) {
+				matched.reverse();
+			}
+		}
+
+		return this.pushStack( matched );
+	};
+} );
+var rnothtmlwhite = ( /[^\x20\t\r\n\f]+/g );
+
+
+
+// Convert String-formatted options into Object-formatted ones
+function createOptions( options ) {
+	var object = {};
+	jQuery.each( options.match( rnothtmlwhite ) || [], function( _, flag ) {
+		object[ flag ] = true;
+	} );
+	return object;
+}
+
+/*
+ * Create a callback list using the following parameters:
+ *
+ *	options: an optional list of space-separated options that will change how
+ *			the callback list behaves or a more traditional option object
+ *
+ * By default a callback list will act like an event callback list and can be
+ * "fired" multiple times.
+ *
+ * Possible options:
+ *
+ *	once:			will ensure the callback list can only be fired once (like a Deferred)
+ *
+ *	memory:			will keep track of previous values and will call any callback added
+ *					after the list has been fired right away with the latest "memorized"
+ *					values (like a Deferred)
+ *
+ *	unique:			will ensure a callback can only be added once (no duplicate in the list)
+ *
+ *	stopOnFalse:	interrupt callings when a callback returns false
+ *
+ */
+jQuery.Callbacks = function( options ) {
+
+	// Convert options from String-formatted to Object-formatted if needed
+	// (we check in cache first)
+	options = typeof options === "string" ?
+		createOptions( options ) :
+		jQuery.extend( {}, options );
+
+	var // Flag to know if list is currently firing
+		firing,
+
+		// Last fire value for non-forgettable lists
+		memory,
+
+		// Flag to know if list was already fired
+		fired,
+
+		// Flag to prevent firing
+		locked,
+
+		// Actual callback list
+		list = [],
+
+		// Queue of execution data for repeatable lists
+		queue = [],
+
+		// Index of currently firing callback (modified by add/remove as needed)
+		firingIndex = -1,
+
+		// Fire callbacks
+		fire = function() {
+
+			// Enforce single-firing
+			locked = locked || options.once;
+
+			// Execute callbacks for all pending executions,
+			// respecting firingIndex overrides and runtime changes
+			fired = firing = true;
+			for ( ; queue.length; firingIndex = -1 ) {
+				memory = queue.shift();
+				while ( ++firingIndex < list.length ) {
+
+					// Run callback and check for early termination
+					if ( list[ firingIndex ].apply( memory[ 0 ], memory[ 1 ] ) === false &&
+						options.stopOnFalse ) {
+
+						// Jump to end and forget the data so .add doesn't re-fire
+						firingIndex = list.length;
+						memory = false;
+					}
+				}
+			}
+
+			// Forget the data if we're done with it
+			if ( !options.memory ) {
+				memory = false;
+			}
+
+			firing = false;
+
+			// Clean up if we're done firing for good
+			if ( locked ) {
+
+				// Keep an empty list if we have data for future add calls
+				if ( memory ) {
+					list = [];
+
+				// Otherwise, this object is spent
+				} else {
+					list = "";
+				}
+			}
+		},
+
+		// Actual Callbacks object
+		self = {
+
+			// Add a callback or a collection of callbacks to the list
+			add: function() {
+				if ( list ) {
+
+					// If we have memory from a past run, we should fire after adding
+					if ( memory && !firing ) {
+						firingIndex = list.length - 1;
+						queue.push( memory );
+					}
+
+					( function add( args ) {
+						jQuery.each( args, function( _, arg ) {
+							if ( isFunction( arg ) ) {
+								if ( !options.unique || !self.has( arg ) ) {
+									list.push( arg );
+								}
+							} else if ( arg && arg.length && toType( arg ) !== "string" ) {
+
+								// Inspect recursively
+								add( arg );
+							}
+						} );
+					} )( arguments );
+
+					if ( memory && !firing ) {
+						fire();
+					}
+				}
+				return this;
+			},
+
+			// Remove a callback from the list
+			remove: function() {
+				jQuery.each( arguments, function( _, arg ) {
+					var index;
+					while ( ( index = jQuery.inArray( arg, list, index ) ) > -1 ) {
+						list.splice( index, 1 );
+
+						// Handle firing indexes
+						if ( index <= firingIndex ) {
+							firingIndex--;
+						}
+					}
+				} );
+				return this;
+			},
+
+			// Check if a given callback is in the list.
+			// If no argument is given, return whether or not list has callbacks attached.
+			has: function( fn ) {
+				return fn ?
+					jQuery.inArray( fn, list ) > -1 :
+					list.length > 0;
+			},
+
+			// Remove all callbacks from the list
+			empty: function() {
+				if ( list ) {
+					list = [];
+				}
+				return this;
+			},
+
+			// Disable .fire and .add
+			// Abort any current/pending executions
+			// Clear all callbacks and values
+			disable: function() {
+				locked = queue = [];
+				list = memory = "";
+				return this;
+			},
+			disabled: function() {
+				return !list;
+			},
+
+			// Disable .fire
+			// Also disable .add unless we have memory (since it would have no effect)
+			// Abort any pending executions
+			lock: function() {
+				locked = queue = [];
+				if ( !memory && !firing ) {
+					list = memory = "";
+				}
+				return this;
+			},
+			locked: function() {
+				return !!locked;
+			},
+
+			// Call all callbacks with the given context and arguments
+			fireWith: function( context, args ) {
+				if ( !locked ) {
+					args = args || [];
+					args = [ context, args.slice ? args.slice() : args ];
+					queue.push( args );
+					if ( !firing ) {
+						fire();
+					}
+				}
+				return this;
+			},
+
+			// Call all the callbacks with the given arguments
+			fire: function() {
+				self.fireWith( this, arguments );
+				return this;
+			},
+
+			// To know if the callbacks have already been called at least once
+			fired: function() {
+				return !!fired;
+			}
+		};
+
+	return self;
+};
+
+
+function Identity( v ) {
+	return v;
+}
+function Thrower( ex ) {
+	throw ex;
+}
+
+function adoptValue( value, resolve, reject, noValue ) {
+	var method;
+
+	try {
+
+		// Check for promise aspect first to privilege synchronous behavior
+		if ( value && isFunction( ( method = value.promise ) ) ) {
+			method.call( value ).done( resolve ).fail( reject );
+
+		// Other thenables
+		} else if ( value && isFunction( ( method = value.then ) ) ) {
+			method.call( value, resolve, reject );
+
+		// Other non-thenables
+		} else {
+
+			// Control `resolve` arguments by letting Array#slice cast boolean `noValue` to integer:
+			// * false: [ value ].slice( 0 ) => resolve( value )
+			// * true: [ value ].slice( 1 ) => resolve()
+			resolve.apply( undefined, [ value ].slice( noValue ) );
+		}
+
+	// For Promises/A+, convert exceptions into rejections
+	// Since jQuery.when doesn't unwrap thenables, we can skip the extra checks appearing in
+	// Deferred#then to conditionally suppress rejection.
+	} catch ( value ) {
+
+		// Support: Android 4.0 only
+		// Strict mode functions invoked without .call/.apply get global-object context
+		reject.apply( undefined, [ value ] );
+	}
+}
+
+jQuery.extend( {
+
+	Deferred: function( func ) {
+		var tuples = [
+
+				// action, add listener, callbacks,
+				// ... .then handlers, argument index, [final state]
+				[ "notify", "progress", jQuery.Callbacks( "memory" ),
+					jQuery.Callbacks( "memory" ), 2 ],
+				[ "resolve", "done", jQuery.Callbacks( "once memory" ),
+					jQuery.Callbacks( "once memory" ), 0, "resolved" ],
+				[ "reject", "fail", jQuery.Callbacks( "once memory" ),
+					jQuery.Callbacks( "once memory" ), 1, "rejected" ]
+			],
+			state = "pending",
+			promise = {
+				state: function() {
+					return state;
+				},
+				always: function() {
+					deferred.done( arguments ).fail( arguments );
+					return this;
+				},
+				"catch": function( fn ) {
+					return promise.then( null, fn );
+				},
+
+				// Keep pipe for back-compat
+				pipe: function( /* fnDone, fnFail, fnProgress */ ) {
+					var fns = arguments;
+
+					return jQuery.Deferred( function( newDefer ) {
+						jQuery.each( tuples, function( i, tuple ) {
+
+							// Map tuples (progress, done, fail) to arguments (done, fail, progress)
+							var fn = isFunction( fns[ tuple[ 4 ] ] ) && fns[ tuple[ 4 ] ];
+
+							// deferred.progress(function() { bind to newDefer or newDefer.notify })
+							// deferred.done(function() { bind to newDefer or newDefer.resolve })
+							// deferred.fail(function() { bind to newDefer or newDefer.reject })
+							deferred[ tuple[ 1 ] ]( function() {
+								var returned = fn && fn.apply( this, arguments );
+								if ( returned && isFunction( returned.promise ) ) {
+									returned.promise()
+										.progress( newDefer.notify )
+										.done( newDefer.resolve )
+										.fail( newDefer.reject );
+								} else {
+									newDefer[ tuple[ 0 ] + "With" ](
+										this,
+										fn ? [ returned ] : arguments
+									);
+								}
+							} );
+						} );
+						fns = null;
+					} ).promise();
+				},
+				then: function( onFulfilled, onRejected, onProgress ) {
+					var maxDepth = 0;
+					function resolve( depth, deferred, handler, special ) {
+						return function() {
+							var that = this,
+								args = arguments,
+								mightThrow = function() {
+									var returned, then;
+
+									// Support: Promises/A+ section 2.3.3.3.3
+									// https://promisesaplus.com/#point-59
+									// Ignore double-resolution attempts
+									if ( depth < maxDepth ) {
+										return;
+									}
+
+									returned = handler.apply( that, args );
+
+									// Support: Promises/A+ section 2.3.1
+									// https://promisesaplus.com/#point-48
+									if ( returned === deferred.promise() ) {
+										throw new TypeError( "Thenable self-resolution" );
+									}
+
+									// Support: Promises/A+ sections 2.3.3.1, 3.5
+									// https://promisesaplus.com/#point-54
+									// https://promisesaplus.com/#point-75
+									// Retrieve `then` only once
+									then = returned &&
+
+										// Support: Promises/A+ section 2.3.4
+										// https://promisesaplus.com/#point-64
+										// Only check objects and functions for thenability
+										( typeof returned === "object" ||
+											typeof returned === "function" ) &&
+										returned.then;
+
+									// Handle a returned thenable
+									if ( isFunction( then ) ) {
+
+										// Special processors (notify) just wait for resolution
+										if ( special ) {
+											then.call(
+												returned,
+												resolve( maxDepth, deferred, Identity, special ),
+												resolve( maxDepth, deferred, Thrower, special )
+											);
+
+										// Normal processors (resolve) also hook into progress
+										} else {
+
+											// ...and disregard older resolution values
+											maxDepth++;
+
+											then.call(
+												returned,
+												resolve( maxDepth, deferred, Identity, special ),
+												resolve( maxDepth, deferred, Thrower, special ),
+												resolve( maxDepth, deferred, Identity,
+													deferred.notifyWith )
+											);
+										}
+
+									// Handle all other returned values
+									} else {
+
+										// Only substitute handlers pass on context
+										// and multiple values (non-spec behavior)
+										if ( handler !== Identity ) {
+											that = undefined;
+											args = [ returned ];
+										}
+
+										// Process the value(s)
+										// Default process is resolve
+										( special || deferred.resolveWith )( that, args );
+									}
+								},
+
+								// Only normal processors (resolve) catch and reject exceptions
+								process = special ?
+									mightThrow :
+									function() {
+										try {
+											mightThrow();
+										} catch ( e ) {
+
+											if ( jQuery.Deferred.exceptionHook ) {
+												jQuery.Deferred.exceptionHook( e,
+													process.stackTrace );
+											}
+
+											// Support: Promises/A+ section 2.3.3.3.4.1
+											// https://promisesaplus.com/#point-61
+											// Ignore post-resolution exceptions
+											if ( depth + 1 >= maxDepth ) {
+
+												// Only substitute handlers pass on context
+												// and multiple values (non-spec behavior)
+												if ( handler !== Thrower ) {
+													that = undefined;
+													args = [ e ];
+												}
+
+												deferred.rejectWith( that, args );
+											}
+										}
+									};
+
+							// Support: Promises/A+ section 2.3.3.3.1
+							// https://promisesaplus.com/#point-57
+							// Re-resolve promises immediately to dodge false rejection from
+							// subsequent errors
+							if ( depth ) {
+								process();
+							} else {
+
+								// Call an optional hook to record the stack, in case of exception
+								// since it's otherwise lost when execution goes async
+								if ( jQuery.Deferred.getStackHook ) {
+									process.stackTrace = jQuery.Deferred.getStackHook();
+								}
+								window.setTimeout( process );
+							}
+						};
+					}
+
+					return jQuery.Deferred( function( newDefer ) {
+
+						// progress_handlers.add( ... )
+						tuples[ 0 ][ 3 ].add(
+							resolve(
+								0,
+								newDefer,
+								isFunction( onProgress ) ?
+									onProgress :
+									Identity,
+								newDefer.notifyWith
+							)
+						);
+
+						// fulfilled_handlers.add( ... )
+						tuples[ 1 ][ 3 ].add(
+							resolve(
+								0,
+								newDefer,
+								isFunction( onFulfilled ) ?
+									onFulfilled :
+									Identity
+							)
+						);
+
+						// rejected_handlers.add( ... )
+						tuples[ 2 ][ 3 ].add(
+							resolve(
+								0,
+								newDefer,
+								isFunction( onRejected ) ?
+									onRejected :
+									Thrower
+							)
+						);
+					} ).promise();
+				},
+
+				// Get a promise for this deferred
+				// If obj is provided, the promise aspect is added to the object
+				promise: function( obj ) {
+					return obj != null ? jQuery.extend( obj, promise ) : promise;
+				}
+			},
+			deferred = {};
+
+		// Add list-specific methods
+		jQuery.each( tuples, function( i, tuple ) {
+			var list = tuple[ 2 ],
+				stateString = tuple[ 5 ];
+
+			// promise.progress = list.add
+			// promise.done = list.add
+			// promise.fail = list.add
+			promise[ tuple[ 1 ] ] = list.add;
+
+			// Handle state
+			if ( stateString ) {
+				list.add(
+					function() {
+
+						// state = "resolved" (i.e., fulfilled)
+						// state = "rejected"
+						state = stateString;
+					},
+
+					// rejected_callbacks.disable
+					// fulfilled_callbacks.disable
+					tuples[ 3 - i ][ 2 ].disable,
+
+					// rejected_handlers.disable
+					// fulfilled_handlers.disable
+					tuples[ 3 - i ][ 3 ].disable,
+
+					// progress_callbacks.lock
+					tuples[ 0 ][ 2 ].lock,
+
+					// progress_handlers.lock
+					tuples[ 0 ][ 3 ].lock
+				);
+			}
+
+			// progress_handlers.fire
+			// fulfilled_handlers.fire
+			// rejected_handlers.fire
+			list.add( tuple[ 3 ].fire );
+
+			// deferred.notify = function() { deferred.notifyWith(...) }
+			// deferred.resolve = function() { deferred.resolveWith(...) }
+			// deferred.reject = function() { deferred.rejectWith(...) }
+			deferred[ tuple[ 0 ] ] = function() {
+				deferred[ tuple[ 0 ] + "With" ]( this === deferred ? undefined : this, arguments );
+				return this;
+			};
+
+			// deferred.notifyWith = list.fireWith
+			// deferred.resolveWith = list.fireWith
+			// deferred.rejectWith = list.fireWith
+			deferred[ tuple[ 0 ] + "With" ] = list.fireWith;
+		} );
+
+		// Make the deferred a promise
+		promise.promise( deferred );
+
+		// Call given func if any
+		if ( func ) {
+			func.call( deferred, deferred );
+		}
+
+		// All done!
+		return deferred;
+	},
+
+	// Deferred helper
+	when: function( singleValue ) {
+		var
+
+			// count of uncompleted subordinates
+			remaining = arguments.length,
+
+			// count of unprocessed arguments
+			i = remaining,
+
+			// subordinate fulfillment data
+			resolveContexts = Array( i ),
+			resolveValues = slice.call( arguments ),
+
+			// the master Deferred
+			master = jQuery.Deferred(),
+
+			// subordinate callback factory
+			updateFunc = function( i ) {
+				return function( value ) {
+					resolveContexts[ i ] = this;
+					resolveValues[ i ] = arguments.length > 1 ? slice.call( arguments ) : value;
+					if ( !( --remaining ) ) {
+						master.resolveWith( resolveContexts, resolveValues );
+					}
+				};
+			};
+
+		// Single- and empty arguments are adopted like Promise.resolve
+		if ( remaining <= 1 ) {
+			adoptValue( singleValue, master.done( updateFunc( i ) ).resolve, master.reject,
+				!remaining );
+
+			// Use .then() to unwrap secondary thenables (cf. gh-3000)
+			if ( master.state() === "pending" ||
+				isFunction( resolveValues[ i ] && resolveValues[ i ].then ) ) {
+
+				return master.then();
+			}
+		}
+
+		// Multiple arguments are aggregated like Promise.all array elements
+		while ( i-- ) {
+			adoptValue( resolveValues[ i ], updateFunc( i ), master.reject );
+		}
+
+		return master.promise();
+	}
+} );
+
+
+// These usually indicate a programmer mistake during development,
+// warn about them ASAP rather than swallowing them by default.
+var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
+jQuery.Deferred.exceptionHook = function( error, stack ) {
+
+	// Support: IE 8 - 9 only
+	// Console exists when dev tools are open, which can happen at any time
+	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
+		window.console.warn( "jQuery.Deferred exception: " + error.message, error.stack, stack );
+	}
+};
+
+
+
+
+jQuery.readyException = function( error ) {
+	window.setTimeout( function() {
+		throw error;
+	} );
+};
+
+
+
+
+// The deferred used on DOM ready
+var readyList = jQuery.Deferred();
+
+jQuery.fn.ready = function( fn ) {
+
+	readyList
+		.then( fn )
+
+		// Wrap jQuery.readyException in a function so that the lookup
+		// happens at the time of error handling instead of callback
+		// registration.
+		.catch( function( error ) {
+			jQuery.readyException( error );
+		} );
+
+	return this;
+};
+
+jQuery.extend( {
+
+	// Is the DOM ready to be used? Set to true once it occurs.
+	isReady: false,
+
+	// A counter to track how many items to wait for before
+	// the ready event fires. See #6781
+	readyWait: 1,
+
+	// Handle when the DOM is ready
+	ready: function( wait ) {
+
+		// Abort if there are pending holds or we're already ready
+		if ( wait === true ? --jQuery.readyWait : jQuery.isReady ) {
+			return;
+		}
+
+		// Remember that the DOM is ready
+		jQuery.isReady = true;
+
+		// If a normal DOM Ready event fired, decrement, and wait if need be
+		if ( wait !== true && --jQuery.readyWait > 0 ) {
+			return;
+		}
+
+		// If there are functions bound, to execute
+		readyList.resolveWith( document, [ jQuery ] );
+	}
+} );
+
+jQuery.ready.then = readyList.then;
+
+// The ready event handler and self cleanup method
+function completed() {
+	document.removeEventListener( "DOMContentLoaded", completed );
+	window.removeEventListener( "load", completed );
+	jQuery.ready();
+}
+
+// Catch cases where $(document).ready() is called
+// after the browser event has already occurred.
+// Support: IE <=9 - 10 only
+// Older IE sometimes signals "interactive" too soon
+if ( document.readyState === "complete" ||
+	( document.readyState !== "loading" && !document.documentElement.doScroll ) ) {
+
+	// Handle it asynchronously to allow scripts the opportunity to delay ready
+	window.setTimeout( jQuery.ready );
+
+} else {
+
+	// Use the handy event callback
+	document.addEventListener( "DOMContentLoaded", completed );
+
+	// A fallback to window.onload, that will always work
+	window.addEventListener( "load", completed );
+}
+
+
+
+
+// Multifunctional method to get and set values of a collection
+// The value/s can optionally be executed if it's a function
+var access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
+	var i = 0,
+		len = elems.length,
+		bulk = key == null;
+
+	// Sets many values
+	if ( toType( key ) === "object" ) {
+		chainable = true;
+		for ( i in key ) {
+			access( elems, fn, i, key[ i ], true, emptyGet, raw );
+		}
+
+	// Sets one value
+	} else if ( value !== undefined ) {
+		chainable = true;
+
+		if ( !isFunction( value ) ) {
+			raw = true;
+		}
+
+		if ( bulk ) {
+
+			// Bulk operations run against the entire set
+			if ( raw ) {
+				fn.call( elems, value );
+				fn = null;
+
+			// ...except when executing function values
+			} else {
+				bulk = fn;
+				fn = function( elem, key, value ) {
+					return bulk.call( jQuery( elem ), value );
+				};
+			}
+		}
+
+		if ( fn ) {
+			for ( ; i < len; i++ ) {
+				fn(
+					elems[ i ], key, raw ?
+					value :
+					value.call( elems[ i ], i, fn( elems[ i ], key ) )
+				);
+			}
+		}
+	}
+
+	if ( chainable ) {
+		return elems;
+	}
+
+	// Gets
+	if ( bulk ) {
+		return fn.call( elems );
+	}
+
+	return len ? fn( elems[ 0 ], key ) : emptyGet;
+};
+
+
+// Matches dashed string for camelizing
+var rmsPrefix = /^-ms-/,
+	rdashAlpha = /-([a-z])/g;
+
+// Used by camelCase as callback to replace()
+function fcamelCase( all, letter ) {
+	return letter.toUpperCase();
+}
+
+// Convert dashed to camelCase; used by the css and data modules
+// Support: IE <=9 - 11, Edge 12 - 15
+// Microsoft forgot to hump their vendor prefix (#9572)
+function camelCase( string ) {
+	return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
+}
+var acceptData = function( owner ) {
+
+	// Accepts only:
+	//  - Node
+	//    - Node.ELEMENT_NODE
+	//    - Node.DOCUMENT_NODE
+	//  - Object
+	//    - Any
+	return owner.nodeType === 1 || owner.nodeType === 9 || !( +owner.nodeType );
+};
+
+
+
+
+function Data() {
+	this.expando = jQuery.expando + Data.uid++;
+}
+
+Data.uid = 1;
+
+Data.prototype = {
+
+	cache: function( owner ) {
+
+		// Check if the owner object already has a cache
+		var value = owner[ this.expando ];
+
+		// If not, create one
+		if ( !value ) {
+			value = {};
+
+			// We can accept data for non-element nodes in modern browsers,
+			// but we should not, see #8335.
+			// Always return an empty object.
+			if ( acceptData( owner ) ) {
+
+				// If it is a node unlikely to be stringify-ed or looped over
+				// use plain assignment
+				if ( owner.nodeType ) {
+					owner[ this.expando ] = value;
+
+				// Otherwise secure it in a non-enumerable property
+				// configurable must be true to allow the property to be
+				// deleted when data is removed
+				} else {
+					Object.defineProperty( owner, this.expando, {
+						value: value,
+						configurable: true
+					} );
+				}
+			}
+		}
+
+		return value;
+	},
+	set: function( owner, data, value ) {
+		var prop,
+			cache = this.cache( owner );
+
+		// Handle: [ owner, key, value ] args
+		// Always use camelCase key (gh-2257)
+		if ( typeof data === "string" ) {
+			cache[ camelCase( data ) ] = value;
+
+		// Handle: [ owner, { properties } ] args
+		} else {
+
+			// Copy the properties one-by-one to the cache object
+			for ( prop in data ) {
+				cache[ camelCase( prop ) ] = data[ prop ];
+			}
+		}
+		return cache;
+	},
+	get: function( owner, key ) {
+		return key === undefined ?
+			this.cache( owner ) :
+
+			// Always use camelCase key (gh-2257)
+			owner[ this.expando ] && owner[ this.expando ][ camelCase( key ) ];
+	},
+	access: function( owner, key, value ) {
+
+		// In cases where either:
+		//
+		//   1. No key was specified
+		//   2. A string key was specified, but no value provided
+		//
+		// Take the "read" path and allow the get method to determine
+		// which value to return, respectively either:
+		//
+		//   1. The entire cache object
+		//   2. The data stored at the key
+		//
+		if ( key === undefined ||
+				( ( key && typeof key === "string" ) && value === undefined ) ) {
+
+			return this.get( owner, key );
+		}
+
+		// When the key is not a string, or both a key and value
+		// are specified, set or extend (existing objects) with either:
+		//
+		//   1. An object of properties
+		//   2. A key and value
+		//
+		this.set( owner, key, value );
+
+		// Since the "set" path can have two possible entry points
+		// return the expected data based on which path was taken[*]
+		return value !== undefined ? value : key;
+	},
+	remove: function( owner, key ) {
+		var i,
+			cache = owner[ this.expando ];
+
+		if ( cache === undefined ) {
+			return;
+		}
+
+		if ( key !== undefined ) {
+
+			// Support array or space separated string of keys
+			if ( Array.isArray( key ) ) {
+
+				// If key is an array of keys...
+				// We always set camelCase keys, so remove that.
+				key = key.map( camelCase );
+			} else {
+				key = camelCase( key );
+
+				// If a key with the spaces exists, use it.
+				// Otherwise, create an array by matching non-whitespace
+				key = key in cache ?
+					[ key ] :
+					( key.match( rnothtmlwhite ) || [] );
+			}
+
+			i = key.length;
+
+			while ( i-- ) {
+				delete cache[ key[ i ] ];
+			}
+		}
+
+		// Remove the expando if there's no more data
+		if ( key === undefined || jQuery.isEmptyObject( cache ) ) {
+
+			// Support: Chrome <=35 - 45
+			// Webkit & Blink performance suffers when deleting properties
+			// from DOM nodes, so set to undefined instead
+			// https://bugs.chromium.org/p/chromium/issues/detail?id=378607 (bug restricted)
+			if ( owner.nodeType ) {
+				owner[ this.expando ] = undefined;
+			} else {
+				delete owner[ this.expando ];
+			}
+		}
+	},
+	hasData: function( owner ) {
+		var cache = owner[ this.expando ];
+		return cache !== undefined && !jQuery.isEmptyObject( cache );
+	}
+};
+var dataPriv = new Data();
+
+var dataUser = new Data();
+
+
+
+//	Implementation Summary
+//
+//	1. Enforce API surface and semantic compatibility with 1.9.x branch
+//	2. Improve the module's maintainability by reducing the storage
+//		paths to a single mechanism.
+//	3. Use the same single mechanism to support "private" and "user" data.
+//	4. _Never_ expose "private" data to user code (TODO: Drop _data, _removeData)
+//	5. Avoid exposing implementation details on user objects (eg. expando properties)
+//	6. Provide a clear path for implementation upgrade to WeakMap in 2014
+
+var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,
+	rmultiDash = /[A-Z]/g;
+
+function getData( data ) {
+	if ( data === "true" ) {
+		return true;
+	}
+
+	if ( data === "false" ) {
+		return false;
+	}
+
+	if ( data === "null" ) {
+		return null;
+	}
+
+	// Only convert to a number if it doesn't change the string
+	if ( data === +data + "" ) {
+		return +data;
+	}
+
+	if ( rbrace.test( data ) ) {
+		return JSON.parse( data );
+	}
+
+	return data;
+}
+
+function dataAttr( elem, key, data ) {
+	var name;
+
+	// If nothing was found internally, try to fetch any
+	// data from the HTML5 data-* attribute
+	if ( data === undefined && elem.nodeType === 1 ) {
+		name = "data-" + key.replace( rmultiDash, "-$&" ).toLowerCase();
+		data = elem.getAttribute( name );
+
+		if ( typeof data === "string" ) {
+			try {
+				data = getData( data );
+			} catch ( e ) {}
+
+			// Make sure we set the data so it isn't changed later
+			dataUser.set( elem, key, data );
+		} else {
+			data = undefined;
+		}
+	}
+	return data;
+}
+
+jQuery.extend( {
+	hasData: function( elem ) {
+		return dataUser.hasData( elem ) || dataPriv.hasData( elem );
+	},
+
+	data: function( elem, name, data ) {
+		return dataUser.access( elem, name, data );
+	},
+
+	removeData: function( elem, name ) {
+		dataUser.remove( elem, name );
+	},
+
+	// TODO: Now that all calls to _data and _removeData have been replaced
+	// with direct calls to dataPriv methods, these can be deprecated.
+	_data: function( elem, name, data ) {
+		return dataPriv.access( elem, name, data );
+	},
+
+	_removeData: function( elem, name ) {
+		dataPriv.remove( elem, name );
+	}
+} );
+
+jQuery.fn.extend( {
+	data: function( key, value ) {
+		var i, name, data,
+			elem = this[ 0 ],
+			attrs = elem && elem.attributes;
+
+		// Gets all values
+		if ( key === undefined ) {
+			if ( this.length ) {
+				data = dataUser.get( elem );
+
+				if ( elem.nodeType === 1 && !dataPriv.get( elem, "hasDataAttrs" ) ) {
+					i = attrs.length;
+					while ( i-- ) {
+
+						// Support: IE 11 only
+						// The attrs elements can be null (#14894)
+						if ( attrs[ i ] ) {
+							name = attrs[ i ].name;
+							if ( name.indexOf( "data-" ) === 0 ) {
+								name = camelCase( name.slice( 5 ) );
+								dataAttr( elem, name, data[ name ] );
+							}
+						}
+					}
+					dataPriv.set( elem, "hasDataAttrs", true );
+				}
+			}
+
+			return data;
+		}
+
+		// Sets multiple values
+		if ( typeof key === "object" ) {
+			return this.each( function() {
+				dataUser.set( this, key );
+			} );
+		}
+
+		return access( this, function( value ) {
+			var data;
+
+			// The calling jQuery object (element matches) is not empty
+			// (and therefore has an element appears at this[ 0 ]) and the
+			// `value` parameter was not undefined. An empty jQuery object
+			// will result in `undefined` for elem = this[ 0 ] which will
+			// throw an exception if an attempt to read a data cache is made.
+			if ( elem && value === undefined ) {
+
+				// Attempt to get data from the cache
+				// The key will always be camelCased in Data
+				data = dataUser.get( elem, key );
+				if ( data !== undefined ) {
+					return data;
+				}
+
+				// Attempt to "discover" the data in
+				// HTML5 custom data-* attrs
+				data = dataAttr( elem, key );
+				if ( data !== undefined ) {
+					return data;
+				}
+
+				// We tried really hard, but the data doesn't exist.
+				return;
+			}
+
+			// Set the data...
+			this.each( function() {
+
+				// We always store the camelCased key
+				dataUser.set( this, key, value );
+			} );
+		}, null, value, arguments.length > 1, null, true );
+	},
+
+	removeData: function( key ) {
+		return this.each( function() {
+			dataUser.remove( this, key );
+		} );
+	}
+} );
+
+
+jQuery.extend( {
+	queue: function( elem, type, data ) {
+		var queue;
+
+		if ( elem ) {
+			type = ( type || "fx" ) + "queue";
+			queue = dataPriv.get( elem, type );
+
+			// Speed up dequeue by getting out quickly if this is just a lookup
+			if ( data ) {
+				if ( !queue || Array.isArray( data ) ) {
+					queue = dataPriv.access( elem, type, jQuery.makeArray( data ) );
+				} else {
+					queue.push( data );
+				}
+			}
+			return queue || [];
+		}
+	},
+
+	dequeue: function( elem, type ) {
+		type = type || "fx";
+
+		var queue = jQuery.queue( elem, type ),
+			startLength = queue.length,
+			fn = queue.shift(),
+			hooks = jQuery._queueHooks( elem, type ),
+			next = function() {
+				jQuery.dequeue( elem, type );
+			};
+
+		// If the fx queue is dequeued, always remove the progress sentinel
+		if ( fn === "inprogress" ) {
+			fn = queue.shift();
+			startLength--;
+		}
+
+		if ( fn ) {
+
+			// Add a progress sentinel to prevent the fx queue from being
+			// automatically dequeued
+			if ( type === "fx" ) {
+				queue.unshift( "inprogress" );
+			}
+
+			// Clear up the last queue stop function
+			delete hooks.stop;
+			fn.call( elem, next, hooks );
+		}
+
+		if ( !startLength && hooks ) {
+			hooks.empty.fire();
+		}
+	},
+
+	// Not public - generate a queueHooks object, or return the current one
+	_queueHooks: function( elem, type ) {
+		var key = type + "queueHooks";
+		return dataPriv.get( elem, key ) || dataPriv.access( elem, key, {
+			empty: jQuery.Callbacks( "once memory" ).add( function() {
+				dataPriv.remove( elem, [ type + "queue", key ] );
+			} )
+		} );
+	}
+} );
+
+jQuery.fn.extend( {
+	queue: function( type, data ) {
+		var setter = 2;
+
+		if ( typeof type !== "string" ) {
+			data = type;
+			type = "fx";
+			setter--;
+		}
+
+		if ( arguments.length < setter ) {
+			return jQuery.queue( this[ 0 ], type );
+		}
+
+		return data === undefined ?
+			this :
+			this.each( function() {
+				var queue = jQuery.queue( this, type, data );
+
+				// Ensure a hooks for this queue
+				jQuery._queueHooks( this, type );
+
+				if ( type === "fx" && queue[ 0 ] !== "inprogress" ) {
+					jQuery.dequeue( this, type );
+				}
+			} );
+	},
+	dequeue: function( type ) {
+		return this.each( function() {
+			jQuery.dequeue( this, type );
+		} );
+	},
+	clearQueue: function( type ) {
+		return this.queue( type || "fx", [] );
+	},
+
+	// Get a promise resolved when queues of a certain type
+	// are emptied (fx is the type by default)
+	promise: function( type, obj ) {
+		var tmp,
+			count = 1,
+			defer = jQuery.Deferred(),
+			elements = this,
+			i = this.length,
+			resolve = function() {
+				if ( !( --count ) ) {
+					defer.resolveWith( elements, [ elements ] );
+				}
+			};
+
+		if ( typeof type !== "string" ) {
+			obj = type;
+			type = undefined;
+		}
+		type = type || "fx";
+
+		while ( i-- ) {
+			tmp = dataPriv.get( elements[ i ], type + "queueHooks" );
+			if ( tmp && tmp.empty ) {
+				count++;
+				tmp.empty.add( resolve );
+			}
+		}
+		resolve();
+		return defer.promise( obj );
+	}
+} );
+var pnum = ( /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/ ).source;
+
+var rcssNum = new RegExp( "^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i" );
+
+
+var cssExpand = [ "Top", "Right", "Bottom", "Left" ];
+
+var documentElement = document.documentElement;
+
+
+
+	var isAttached = function( elem ) {
+			return jQuery.contains( elem.ownerDocument, elem );
+		},
+		composed = { composed: true };
+
+	// Support: IE 9 - 11+, Edge 12 - 18+, iOS 10.0 - 10.2 only
+	// Check attachment across shadow DOM boundaries when possible (gh-3504)
+	// Support: iOS 10.0-10.2 only
+	// Early iOS 10 versions support `attachShadow` but not `getRootNode`,
+	// leading to errors. We need to check for `getRootNode`.
+	if ( documentElement.getRootNode ) {
+		isAttached = function( elem ) {
+			return jQuery.contains( elem.ownerDocument, elem ) ||
+				elem.getRootNode( composed ) === elem.ownerDocument;
+		};
+	}
+var isHiddenWithinTree = function( elem, el ) {
+
+		// isHiddenWithinTree might be called from jQuery#filter function;
+		// in that case, element will be second argument
+		elem = el || elem;
+
+		// Inline style trumps all
+		return elem.style.display === "none" ||
+			elem.style.display === "" &&
+
+			// Otherwise, check computed style
+			// Support: Firefox <=43 - 45
+			// Disconnected elements can have computed display: none, so first confirm that elem is
+			// in the document.
+			isAttached( elem ) &&
+
+			jQuery.css( elem, "display" ) === "none";
+	};
+
+var swap = function( elem, options, callback, args ) {
+	var ret, name,
+		old = {};
+
+	// Remember the old values, and insert the new ones
+	for ( name in options ) {
+		old[ name ] = elem.style[ name ];
+		elem.style[ name ] = options[ name ];
+	}
+
+	ret = callback.apply( elem, args || [] );
+
+	// Revert the old values
+	for ( name in options ) {
+		elem.style[ name ] = old[ name ];
+	}
+
+	return ret;
+};
+
+
+
+
+function adjustCSS( elem, prop, valueParts, tween ) {
+	var adjusted, scale,
+		maxIterations = 20,
+		currentValue = tween ?
+			function() {
+				return tween.cur();
+			} :
+			function() {
+				return jQuery.css( elem, prop, "" );
+			},
+		initial = currentValue(),
+		unit = valueParts && valueParts[ 3 ] || ( jQuery.cssNumber[ prop ] ? "" : "px" ),
+
+		// Starting value computation is required for potential unit mismatches
+		initialInUnit = elem.nodeType &&
+			( jQuery.cssNumber[ prop ] || unit !== "px" && +initial ) &&
+			rcssNum.exec( jQuery.css( elem, prop ) );
+
+	if ( initialInUnit && initialInUnit[ 3 ] !== unit ) {
+
+		// Support: Firefox <=54
+		// Halve the iteration target value to prevent interference from CSS upper bounds (gh-2144)
+		initial = initial / 2;
+
+		// Trust units reported by jQuery.css
+		unit = unit || initialInUnit[ 3 ];
+
+		// Iteratively approximate from a nonzero starting point
+		initialInUnit = +initial || 1;
+
+		while ( maxIterations-- ) {
+
+			// Evaluate and update our best guess (doubling guesses that zero out).
+			// Finish if the scale equals or crosses 1 (making the old*new product non-positive).
+			jQuery.style( elem, prop, initialInUnit + unit );
+			if ( ( 1 - scale ) * ( 1 - ( scale = currentValue() / initial || 0.5 ) ) <= 0 ) {
+				maxIterations = 0;
+			}
+			initialInUnit = initialInUnit / scale;
+
+		}
+
+		initialInUnit = initialInUnit * 2;
+		jQuery.style( elem, prop, initialInUnit + unit );
+
+		// Make sure we update the tween properties later on
+		valueParts = valueParts || [];
+	}
+
+	if ( valueParts ) {
+		initialInUnit = +initialInUnit || +initial || 0;
+
+		// Apply relative offset (+=/-=) if specified
+		adjusted = valueParts[ 1 ] ?
+			initialInUnit + ( valueParts[ 1 ] + 1 ) * valueParts[ 2 ] :
+			+valueParts[ 2 ];
+		if ( tween ) {
+			tween.unit = unit;
+			tween.start = initialInUnit;
+			tween.end = adjusted;
+		}
+	}
+	return adjusted;
+}
+
+
+var defaultDisplayMap = {};
+
+function getDefaultDisplay( elem ) {
+	var temp,
+		doc = elem.ownerDocument,
+		nodeName = elem.nodeName,
+		display = defaultDisplayMap[ nodeName ];
+
+	if ( display ) {
+		return display;
+	}
+
+	temp = doc.body.appendChild( doc.createElement( nodeName ) );
+	display = jQuery.css( temp, "display" );
+
+	temp.parentNode.removeChild( temp );
+
+	if ( display === "none" ) {
+		display = "block";
+	}
+	defaultDisplayMap[ nodeName ] = display;
+
+	return display;
+}
+
+function showHide( elements, show ) {
+	var display, elem,
+		values = [],
+		index = 0,
+		length = elements.length;
+
+	// Determine new display value for elements that need to change
+	for ( ; index < length; index++ ) {
+		elem = elements[ index ];
+		if ( !elem.style ) {
+			continue;
+		}
+
+		display = elem.style.display;
+		if ( show ) {
+
+			// Since we force visibility upon cascade-hidden elements, an immediate (and slow)
+			// check is required in this first loop unless we have a nonempty display value (either
+			// inline or about-to-be-restored)
+			if ( display === "none" ) {
+				values[ index ] = dataPriv.get( elem, "display" ) || null;
+				if ( !values[ index ] ) {
+					elem.style.display = "";
+				}
+			}
+			if ( elem.style.display === "" && isHiddenWithinTree( elem ) ) {
+				values[ index ] = getDefaultDisplay( elem );
+			}
+		} else {
+			if ( display !== "none" ) {
+				values[ index ] = "none";
+
+				// Remember what we're overwriting
+				dataPriv.set( elem, "display", display );
+			}
+		}
+	}
+
+	// Set the display of the elements in a second loop to avoid constant reflow
+	for ( index = 0; index < length; index++ ) {
+		if ( values[ index ] != null ) {
+			elements[ index ].style.display = values[ index ];
+		}
+	}
+
+	return elements;
+}
+
+jQuery.fn.extend( {
+	show: function() {
+		return showHide( this, true );
+	},
+	hide: function() {
+		return showHide( this );
+	},
+	toggle: function( state ) {
+		if ( typeof state === "boolean" ) {
+			return state ? this.show() : this.hide();
+		}
+
+		return this.each( function() {
+			if ( isHiddenWithinTree( this ) ) {
+				jQuery( this ).show();
+			} else {
+				jQuery( this ).hide();
+			}
+		} );
+	}
+} );
+var rcheckableType = ( /^(?:checkbox|radio)$/i );
+
+var rtagName = ( /<([a-z][^\/\0>\x20\t\r\n\f]*)/i );
+
+var rscriptType = ( /^$|^module$|\/(?:java|ecma)script/i );
+
+
+
+// We have to close these tags to support XHTML (#13200)
+var wrapMap = {
+
+	// Support: IE <=9 only
+	option: [ 1, "<select multiple='multiple'>", "</select>" ],
+
+	// XHTML parsers do not magically insert elements in the
+	// same way that tag soup parsers do. So we cannot shorten
+	// this by omitting <tbody> or other required elements.
+	thead: [ 1, "<table>", "</table>" ],
+	col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
+	tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+	td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
+
+	_default: [ 0, "", "" ]
+};
+
+// Support: IE <=9 only
+wrapMap.optgroup = wrapMap.option;
+
+wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
+wrapMap.th = wrapMap.td;
+
+
+function getAll( context, tag ) {
+
+	// Support: IE <=9 - 11 only
+	// Use typeof to avoid zero-argument method invocation on host objects (#15151)
+	var ret;
+
+	if ( typeof context.getElementsByTagName !== "undefined" ) {
+		ret = context.getElementsByTagName( tag || "*" );
+
+	} else if ( typeof context.querySelectorAll !== "undefined" ) {
+		ret = context.querySelectorAll( tag || "*" );
+
+	} else {
+		ret = [];
+	}
+
+	if ( tag === undefined || tag && nodeName( context, tag ) ) {
+		return jQuery.merge( [ context ], ret );
+	}
+
+	return ret;
+}
+
+
+// Mark scripts as having already been evaluated
+function setGlobalEval( elems, refElements ) {
+	var i = 0,
+		l = elems.length;
+
+	for ( ; i < l; i++ ) {
+		dataPriv.set(
+			elems[ i ],
+			"globalEval",
+			!refElements || dataPriv.get( refElements[ i ], "globalEval" )
+		);
+	}
+}
+
+
+var rhtml = /<|&#?\w+;/;
+
+function buildFragment( elems, context, scripts, selection, ignored ) {
+	var elem, tmp, tag, wrap, attached, j,
+		fragment = context.createDocumentFragment(),
+		nodes = [],
+		i = 0,
+		l = elems.length;
+
+	for ( ; i < l; i++ ) {
+		elem = elems[ i ];
+
+		if ( elem || elem === 0 ) {
+
+			// Add nodes directly
+			if ( toType( elem ) === "object" ) {
+
+				// Support: Android <=4.0 only, PhantomJS 1 only
+				// push.apply(_, arraylike) throws on ancient WebKit
+				jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
+
+			// Convert non-html into a text node
+			} else if ( !rhtml.test( elem ) ) {
+				nodes.push( context.createTextNode( elem ) );
+
+			// Convert html into DOM nodes
+			} else {
+				tmp = tmp || fragment.appendChild( context.createElement( "div" ) );
+
+				// Deserialize a standard representation
+				tag = ( rtagName.exec( elem ) || [ "", "" ] )[ 1 ].toLowerCase();
+				wrap = wrapMap[ tag ] || wrapMap._default;
+				tmp.innerHTML = wrap[ 1 ] + jQuery.htmlPrefilter( elem ) + wrap[ 2 ];
+
+				// Descend through wrappers to the right content
+				j = wrap[ 0 ];
+				while ( j-- ) {
+					tmp = tmp.lastChild;
+				}
+
+				// Support: Android <=4.0 only, PhantomJS 1 only
+				// push.apply(_, arraylike) throws on ancient WebKit
+				jQuery.merge( nodes, tmp.childNodes );
+
+				// Remember the top-level container
+				tmp = fragment.firstChild;
+
+				// Ensure the created nodes are orphaned (#12392)
+				tmp.textContent = "";
+			}
+		}
+	}
+
+	// Remove wrapper from fragment
+	fragment.textContent = "";
+
+	i = 0;
+	while ( ( elem = nodes[ i++ ] ) ) {
+
+		// Skip elements already in the context collection (trac-4087)
+		if ( selection && jQuery.inArray( elem, selection ) > -1 ) {
+			if ( ignored ) {
+				ignored.push( elem );
+			}
+			continue;
+		}
+
+		attached = isAttached( elem );
+
+		// Append to fragment
+		tmp = getAll( fragment.appendChild( elem ), "script" );
+
+		// Preserve script evaluation history
+		if ( attached ) {
+			setGlobalEval( tmp );
+		}
+
+		// Capture executables
+		if ( scripts ) {
+			j = 0;
+			while ( ( elem = tmp[ j++ ] ) ) {
+				if ( rscriptType.test( elem.type || "" ) ) {
+					scripts.push( elem );
+				}
+			}
+		}
+	}
+
+	return fragment;
+}
+
+
+( function() {
+	var fragment = document.createDocumentFragment(),
+		div = fragment.appendChild( document.createElement( "div" ) ),
+		input = document.createElement( "input" );
+
+	// Support: Android 4.0 - 4.3 only
+	// Check state lost if the name is set (#11217)
+	// Support: Windows Web Apps (WWA)
+	// `name` and `type` must use .setAttribute for WWA (#14901)
+	input.setAttribute( "type", "radio" );
+	input.setAttribute( "checked", "checked" );
+	input.setAttribute( "name", "t" );
+
+	div.appendChild( input );
+
+	// Support: Android <=4.1 only
+	// Older WebKit doesn't clone checked state correctly in fragments
+	support.checkClone = div.cloneNode( true ).cloneNode( true ).lastChild.checked;
+
+	// Support: IE <=11 only
+	// Make sure textarea (and checkbox) defaultValue is properly cloned
+	div.innerHTML = "<textarea>x</textarea>";
+	support.noCloneChecked = !!div.cloneNode( true ).lastChild.defaultValue;
+} )();
+
+
+var
+	rkeyEvent = /^key/,
+	rmouseEvent = /^(?:mouse|pointer|contextmenu|drag|drop)|click/,
+	rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
+
+function returnTrue() {
+	return true;
+}
+
+function returnFalse() {
+	return false;
+}
+
+// Support: IE <=9 - 11+
+// focus() and blur() are asynchronous, except when they are no-op.
+// So expect focus to be synchronous when the element is already active,
+// and blur to be synchronous when the element is not already active.
+// (focus and blur are always synchronous in other supported browsers,
+// this just defines when we can count on it).
+function expectSync( elem, type ) {
+	return ( elem === safeActiveElement() ) === ( type === "focus" );
+}
+
+// Support: IE <=9 only
+// Accessing document.activeElement can throw unexpectedly
+// https://bugs.jquery.com/ticket/13393
+function safeActiveElement() {
+	try {
+		return document.activeElement;
+	} catch ( err ) { }
+}
+
+function on( elem, types, selector, data, fn, one ) {
+	var origFn, type;
+
+	// Types can be a map of types/handlers
+	if ( typeof types === "object" ) {
+
+		// ( types-Object, selector, data )
+		if ( typeof selector !== "string" ) {
+
+			// ( types-Object, data )
+			data = data || selector;
+			selector = undefined;
+		}
+		for ( type in types ) {
+			on( elem, type, selector, data, types[ type ], one );
+		}
+		return elem;
+	}
+
+	if ( data == null && fn == null ) {
+
+		// ( types, fn )
+		fn = selector;
+		data = selector = undefined;
+	} else if ( fn == null ) {
+		if ( typeof selector === "string" ) {
+
+			// ( types, selector, fn )
+			fn = data;
+			data = undefined;
+		} else {
+
+			// ( types, data, fn )
+			fn = data;
+			data = selector;
+			selector = undefined;
+		}
+	}
+	if ( fn === false ) {
+		fn = returnFalse;
+	} else if ( !fn ) {
+		return elem;
+	}
+
+	if ( one === 1 ) {
+		origFn = fn;
+		fn = function( event ) {
+
+			// Can use an empty set, since event contains the info
+			jQuery().off( event );
+			return origFn.apply( this, arguments );
+		};
+
+		// Use same guid so caller can remove using origFn
+		fn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
+	}
+	return elem.each( function() {
+		jQuery.event.add( this, types, fn, data, selector );
+	} );
+}
+
+/*
+ * Helper functions for managing events -- not part of the public interface.
+ * Props to Dean Edwards' addEvent library for many of the ideas.
+ */
+jQuery.event = {
+
+	global: {},
+
+	add: function( elem, types, handler, data, selector ) {
+
+		var handleObjIn, eventHandle, tmp,
+			events, t, handleObj,
+			special, handlers, type, namespaces, origType,
+			elemData = dataPriv.get( elem );
+
+		// Don't attach events to noData or text/comment nodes (but allow plain objects)
+		if ( !elemData ) {
+			return;
+		}
+
+		// Caller can pass in an object of custom data in lieu of the handler
+		if ( handler.handler ) {
+			handleObjIn = handler;
+			handler = handleObjIn.handler;
+			selector = handleObjIn.selector;
+		}
+
+		// Ensure that invalid selectors throw exceptions at attach time
+		// Evaluate against documentElement in case elem is a non-element node (e.g., document)
+		if ( selector ) {
+			jQuery.find.matchesSelector( documentElement, selector );
+		}
+
+		// Make sure that the handler has a unique ID, used to find/remove it later
+		if ( !handler.guid ) {
+			handler.guid = jQuery.guid++;
+		}
+
+		// Init the element's event structure and main handler, if this is the first
+		if ( !( events = elemData.events ) ) {
+			events = elemData.events = {};
+		}
+		if ( !( eventHandle = elemData.handle ) ) {
+			eventHandle = elemData.handle = function( e ) {
+
+				// Discard the second event of a jQuery.event.trigger() and
+				// when an event is called after a page has unloaded
+				return typeof jQuery !== "undefined" && jQuery.event.triggered !== e.type ?
+					jQuery.event.dispatch.apply( elem, arguments ) : undefined;
+			};
+		}
+
+		// Handle multiple events separated by a space
+		types = ( types || "" ).match( rnothtmlwhite ) || [ "" ];
+		t = types.length;
+		while ( t-- ) {
+			tmp = rtypenamespace.exec( types[ t ] ) || [];
+			type = origType = tmp[ 1 ];
+			namespaces = ( tmp[ 2 ] || "" ).split( "." ).sort();
+
+			// There *must* be a type, no attaching namespace-only handlers
+			if ( !type ) {
+				continue;
+			}
+
+			// If event changes its type, use the special event handlers for the changed type
+			special = jQuery.event.special[ type ] || {};
+
+			// If selector defined, determine special event api type, otherwise given type
+			type = ( selector ? special.delegateType : special.bindType ) || type;
+
+			// Update special based on newly reset type
+			special = jQuery.event.special[ type ] || {};
+
+			// handleObj is passed to all event handlers
+			handleObj = jQuery.extend( {
+				type: type,
+				origType: origType,
+				data: data,
+				handler: handler,
+				guid: handler.guid,
+				selector: selector,
+				needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
+				namespace: namespaces.join( "." )
+			}, handleObjIn );
+
+			// Init the event handler queue if we're the first
+			if ( !( handlers = events[ type ] ) ) {
+				handlers = events[ type ] = [];
+				handlers.delegateCount = 0;
+
+				// Only use addEventListener if the special events handler returns false
+				if ( !special.setup ||
+					special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
+
+					if ( elem.addEventListener ) {
+						elem.addEventListener( type, eventHandle );
+					}
+				}
+			}
+
+			if ( special.add ) {
+				special.add.call( elem, handleObj );
+
+				if ( !handleObj.handler.guid ) {
+					handleObj.handler.guid = handler.guid;
+				}
+			}
+
+			// Add to the element's handler list, delegates in front
+			if ( selector ) {
+				handlers.splice( handlers.delegateCount++, 0, handleObj );
+			} else {
+				handlers.push( handleObj );
+			}
+
+			// Keep track of which events have ever been used, for event optimization
+			jQuery.event.global[ type ] = true;
+		}
+
+	},
+
+	// Detach an event or set of events from an element
+	remove: function( elem, types, handler, selector, mappedTypes ) {
+
+		var j, origCount, tmp,
+			events, t, handleObj,
+			special, handlers, type, namespaces, origType,
+			elemData = dataPriv.hasData( elem ) && dataPriv.get( elem );
+
+		if ( !elemData || !( events = elemData.events ) ) {
+			return;
+		}
+
+		// Once for each type.namespace in types; type may be omitted
+		types = ( types || "" ).match( rnothtmlwhite ) || [ "" ];
+		t = types.length;
+		while ( t-- ) {
+			tmp = rtypenamespace.exec( types[ t ] ) || [];
+			type = origType = tmp[ 1 ];
+			namespaces = ( tmp[ 2 ] || "" ).split( "." ).sort();
+
+			// Unbind all events (on this namespace, if provided) for the element
+			if ( !type ) {
+				for ( type in events ) {
+					jQuery.event.remove( elem, type + types[ t ], handler, selector, true );
+				}
+				continue;
+			}
+
+			special = jQuery.event.special[ type ] || {};
+			type = ( selector ? special.delegateType : special.bindType ) || type;
+			handlers = events[ type ] || [];
+			tmp = tmp[ 2 ] &&
+				new RegExp( "(^|\\.)" + namespaces.join( "\\.(?:.*\\.|)" ) + "(\\.|$)" );
+
+			// Remove matching events
+			origCount = j = handlers.length;
+			while ( j-- ) {
+				handleObj = handlers[ j ];
+
+				if ( ( mappedTypes || origType === handleObj.origType ) &&
+					( !handler || handler.guid === handleObj.guid ) &&
+					( !tmp || tmp.test( handleObj.namespace ) ) &&
+					( !selector || selector === handleObj.selector ||
+						selector === "**" && handleObj.selector ) ) {
+					handlers.splice( j, 1 );
+
+					if ( handleObj.selector ) {
+						handlers.delegateCount--;
+					}
+					if ( special.remove ) {
+						special.remove.call( elem, handleObj );
+					}
+				}
+			}
+
+			// Remove generic event handler if we removed something and no more handlers exist
+			// (avoids potential for endless recursion during removal of special event handlers)
+			if ( origCount && !handlers.length ) {
+				if ( !special.teardown ||
+					special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
+
+					jQuery.removeEvent( elem, type, elemData.handle );
+				}
+
+				delete events[ type ];
+			}
+		}
+
+		// Remove data and the expando if it's no longer used
+		if ( jQuery.isEmptyObject( events ) ) {
+			dataPriv.remove( elem, "handle events" );
+		}
+	},
+
+	dispatch: function( nativeEvent ) {
+
+		// Make a writable jQuery.Event from the native event object
+		var event = jQuery.event.fix( nativeEvent );
+
+		var i, j, ret, matched, handleObj, handlerQueue,
+			args = new Array( arguments.length ),
+			handlers = ( dataPriv.get( this, "events" ) || {} )[ event.type ] || [],
+			special = jQuery.event.special[ event.type ] || {};
+
+		// Use the fix-ed jQuery.Event rather than the (read-only) native event
+		args[ 0 ] = event;
+
+		for ( i = 1; i < arguments.length; i++ ) {
+			args[ i ] = arguments[ i ];
+		}
+
+		event.delegateTarget = this;
+
+		// Call the preDispatch hook for the mapped type, and let it bail if desired
+		if ( special.preDispatch && special.preDispatch.call( this, event ) === false ) {
+			return;
+		}
+
+		// Determine handlers
+		handlerQueue = jQuery.event.handlers.call( this, event, handlers );
+
+		// Run delegates first; they may want to stop propagation beneath us
+		i = 0;
+		while ( ( matched = handlerQueue[ i++ ] ) && !event.isPropagationStopped() ) {
+			event.currentTarget = matched.elem;
+
+			j = 0;
+			while ( ( handleObj = matched.handlers[ j++ ] ) &&
+				!event.isImmediatePropagationStopped() ) {
+
+				// If the event is namespaced, then each handler is only invoked if it is
+				// specially universal or its namespaces are a superset of the event's.
+				if ( !event.rnamespace || handleObj.namespace === false ||
+					event.rnamespace.test( handleObj.namespace ) ) {
+
+					event.handleObj = handleObj;
+					event.data = handleObj.data;
+
+					ret = ( ( jQuery.event.special[ handleObj.origType ] || {} ).handle ||
+						handleObj.handler ).apply( matched.elem, args );
+
+					if ( ret !== undefined ) {
+						if ( ( event.result = ret ) === false ) {
+							event.preventDefault();
+							event.stopPropagation();
+						}
+					}
+				}
+			}
+		}
+
+		// Call the postDispatch hook for the mapped type
+		if ( special.postDispatch ) {
+			special.postDispatch.call( this, event );
+		}
+
+		return event.result;
+	},
+
+	handlers: function( event, handlers ) {
+		var i, handleObj, sel, matchedHandlers, matchedSelectors,
+			handlerQueue = [],
+			delegateCount = handlers.delegateCount,
+			cur = event.target;
+
+		// Find delegate handlers
+		if ( delegateCount &&
+
+			// Support: IE <=9
+			// Black-hole SVG <use> instance trees (trac-13180)
+			cur.nodeType &&
+
+			// Support: Firefox <=42
+			// Suppress spec-violating clicks indicating a non-primary pointer button (trac-3861)
+			// https://www.w3.org/TR/DOM-Level-3-Events/#event-type-click
+			// Support: IE 11 only
+			// ...but not arrow key "clicks" of radio inputs, which can have `button` -1 (gh-2343)
+			!( event.type === "click" && event.button >= 1 ) ) {
+
+			for ( ; cur !== this; cur = cur.parentNode || this ) {
+
+				// Don't check non-elements (#13208)
+				// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
+				if ( cur.nodeType === 1 && !( event.type === "click" && cur.disabled === true ) ) {
+					matchedHandlers = [];
+					matchedSelectors = {};
+					for ( i = 0; i < delegateCount; i++ ) {
+						handleObj = handlers[ i ];
+
+						// Don't conflict with Object.prototype properties (#13203)
+						sel = handleObj.selector + " ";
+
+						if ( matchedSelectors[ sel ] === undefined ) {
+							matchedSelectors[ sel ] = handleObj.needsContext ?
+								jQuery( sel, this ).index( cur ) > -1 :
+								jQuery.find( sel, this, null, [ cur ] ).length;
+						}
+						if ( matchedSelectors[ sel ] ) {
+							matchedHandlers.push( handleObj );
+						}
+					}
+					if ( matchedHandlers.length ) {
+						handlerQueue.push( { elem: cur, handlers: matchedHandlers } );
+					}
+				}
+			}
+		}
+
+		// Add the remaining (directly-bound) handlers
+		cur = this;
+		if ( delegateCount < handlers.length ) {
+			handlerQueue.push( { elem: cur, handlers: handlers.slice( delegateCount ) } );
+		}
+
+		return handlerQueue;
+	},
+
+	addProp: function( name, hook ) {
+		Object.defineProperty( jQuery.Event.prototype, name, {
+			enumerable: true,
+			configurable: true,
+
+			get: isFunction( hook ) ?
+				function() {
+					if ( this.originalEvent ) {
+							return hook( this.originalEvent );
+					}
+				} :
+				function() {
+					if ( this.originalEvent ) {
+							return this.originalEvent[ name ];
+					}
+				},
+
+			set: function( value ) {
+				Object.defineProperty( this, name, {
+					enumerable: true,
+					configurable: true,
+					writable: true,
+					value: value
+				} );
+			}
+		} );
+	},
+
+	fix: function( originalEvent ) {
+		return originalEvent[ jQuery.expando ] ?
+			originalEvent :
+			new jQuery.Event( originalEvent );
+	},
+
+	special: {
+		load: {
+
+			// Prevent triggered image.load events from bubbling to window.load
+			noBubble: true
+		},
+		click: {
+
+			// Utilize native event to ensure correct state for checkable inputs
+			setup: function( data ) {
+
+				// For mutual compressibility with _default, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
+
+				// Claim the first handler
+				if ( rcheckableType.test( el.type ) &&
+					el.click && nodeName( el, "input" ) ) {
+
+					// dataPriv.set( el, "click", ... )
+					leverageNative( el, "click", returnTrue );
+				}
+
+				// Return false to allow normal processing in the caller
+				return false;
+			},
+			trigger: function( data ) {
+
+				// For mutual compressibility with _default, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
+
+				// Force setup before triggering a click
+				if ( rcheckableType.test( el.type ) &&
+					el.click && nodeName( el, "input" ) ) {
+
+					leverageNative( el, "click" );
+				}
+
+				// Return non-false to allow normal event-path propagation
+				return true;
+			},
+
+			// For cross-browser consistency, suppress native .click() on links
+			// Also prevent it if we're currently inside a leveraged native-event stack
+			_default: function( event ) {
+				var target = event.target;
+				return rcheckableType.test( target.type ) &&
+					target.click && nodeName( target, "input" ) &&
+					dataPriv.get( target, "click" ) ||
+					nodeName( target, "a" );
+			}
+		},
+
+		beforeunload: {
+			postDispatch: function( event ) {
+
+				// Support: Firefox 20+
+				// Firefox doesn't alert if the returnValue field is not set.
+				if ( event.result !== undefined && event.originalEvent ) {
+					event.originalEvent.returnValue = event.result;
+				}
+			}
+		}
+	}
+};
+
+// Ensure the presence of an event listener that handles manually-triggered
+// synthetic events by interrupting progress until reinvoked in response to
+// *native* events that it fires directly, ensuring that state changes have
+// already occurred before other listeners are invoked.
+function leverageNative( el, type, expectSync ) {
+
+	// Missing expectSync indicates a trigger call, which must force setup through jQuery.event.add
+	if ( !expectSync ) {
+		if ( dataPriv.get( el, type ) === undefined ) {
+			jQuery.event.add( el, type, returnTrue );
+		}
+		return;
+	}
+
+	// Register the controller as a special universal handler for all event namespaces
+	dataPriv.set( el, type, false );
+	jQuery.event.add( el, type, {
+		namespace: false,
+		handler: function( event ) {
+			var notAsync, result,
+				saved = dataPriv.get( this, type );
+
+			if ( ( event.isTrigger & 1 ) && this[ type ] ) {
+
+				// Interrupt processing of the outer synthetic .trigger()ed event
+				// Saved data should be false in such cases, but might be a leftover capture object
+				// from an async native handler (gh-4350)
+				if ( !saved.length ) {
+
+					// Store arguments for use when handling the inner native event
+					// There will always be at least one argument (an event object), so this array
+					// will not be confused with a leftover capture object.
+					saved = slice.call( arguments );
+					dataPriv.set( this, type, saved );
+
+					// Trigger the native event and capture its result
+					// Support: IE <=9 - 11+
+					// focus() and blur() are asynchronous
+					notAsync = expectSync( this, type );
+					this[ type ]();
+					result = dataPriv.get( this, type );
+					if ( saved !== result || notAsync ) {
+						dataPriv.set( this, type, false );
+					} else {
+						result = {};
+					}
+					if ( saved !== result ) {
+
+						// Cancel the outer synthetic event
+						event.stopImmediatePropagation();
+						event.preventDefault();
+						return result.value;
+					}
+
+				// If this is an inner synthetic event for an event with a bubbling surrogate
+				// (focus or blur), assume that the surrogate already propagated from triggering the
+				// native event and prevent that from happening again here.
+				// This technically gets the ordering wrong w.r.t. to `.trigger()` (in which the
+				// bubbling surrogate propagates *after* the non-bubbling base), but that seems
+				// less bad than duplication.
+				} else if ( ( jQuery.event.special[ type ] || {} ).delegateType ) {
+					event.stopPropagation();
+				}
+
+			// If this is a native event triggered above, everything is now in order
+			// Fire an inner synthetic event with the original arguments
+			} else if ( saved.length ) {
+
+				// ...and capture the result
+				dataPriv.set( this, type, {
+					value: jQuery.event.trigger(
+
+						// Support: IE <=9 - 11+
+						// Extend with the prototype to reset the above stopImmediatePropagation()
+						jQuery.extend( saved[ 0 ], jQuery.Event.prototype ),
+						saved.slice( 1 ),
+						this
+					)
+				} );
+
+				// Abort handling of the native event
+				event.stopImmediatePropagation();
+			}
+		}
+	} );
+}
+
+jQuery.removeEvent = function( elem, type, handle ) {
+
+	// This "if" is needed for plain objects
+	if ( elem.removeEventListener ) {
+		elem.removeEventListener( type, handle );
+	}
+};
+
+jQuery.Event = function( src, props ) {
+
+	// Allow instantiation without the 'new' keyword
+	if ( !( this instanceof jQuery.Event ) ) {
+		return new jQuery.Event( src, props );
+	}
+
+	// Event object
+	if ( src && src.type ) {
+		this.originalEvent = src;
+		this.type = src.type;
+
+		// Events bubbling up the document may have been marked as prevented
+		// by a handler lower down the tree; reflect the correct value.
+		this.isDefaultPrevented = src.defaultPrevented ||
+				src.defaultPrevented === undefined &&
+
+				// Support: Android <=2.3 only
+				src.returnValue === false ?
+			returnTrue :
+			returnFalse;
+
+		// Create target properties
+		// Support: Safari <=6 - 7 only
+		// Target should not be a text node (#504, #13143)
+		this.target = ( src.target && src.target.nodeType === 3 ) ?
+			src.target.parentNode :
+			src.target;
+
+		this.currentTarget = src.currentTarget;
+		this.relatedTarget = src.relatedTarget;
+
+	// Event type
+	} else {
+		this.type = src;
+	}
+
+	// Put explicitly provided properties onto the event object
+	if ( props ) {
+		jQuery.extend( this, props );
+	}
+
+	// Create a timestamp if incoming event doesn't have one
+	this.timeStamp = src && src.timeStamp || Date.now();
+
+	// Mark it as fixed
+	this[ jQuery.expando ] = true;
+};
+
+// jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
+// https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+jQuery.Event.prototype = {
+	constructor: jQuery.Event,
+	isDefaultPrevented: returnFalse,
+	isPropagationStopped: returnFalse,
+	isImmediatePropagationStopped: returnFalse,
+	isSimulated: false,
+
+	preventDefault: function() {
+		var e = this.originalEvent;
+
+		this.isDefaultPrevented = returnTrue;
+
+		if ( e && !this.isSimulated ) {
+			e.preventDefault();
+		}
+	},
+	stopPropagation: function() {
+		var e = this.originalEvent;
+
+		this.isPropagationStopped = returnTrue;
+
+		if ( e && !this.isSimulated ) {
+			e.stopPropagation();
+		}
+	},
+	stopImmediatePropagation: function() {
+		var e = this.originalEvent;
+
+		this.isImmediatePropagationStopped = returnTrue;
+
+		if ( e && !this.isSimulated ) {
+			e.stopImmediatePropagation();
+		}
+
+		this.stopPropagation();
+	}
+};
+
+// Includes all common event props including KeyEvent and MouseEvent specific props
+jQuery.each( {
+	altKey: true,
+	bubbles: true,
+	cancelable: true,
+	changedTouches: true,
+	ctrlKey: true,
+	detail: true,
+	eventPhase: true,
+	metaKey: true,
+	pageX: true,
+	pageY: true,
+	shiftKey: true,
+	view: true,
+	"char": true,
+	code: true,
+	charCode: true,
+	key: true,
+	keyCode: true,
+	button: true,
+	buttons: true,
+	clientX: true,
+	clientY: true,
+	offsetX: true,
+	offsetY: true,
+	pointerId: true,
+	pointerType: true,
+	screenX: true,
+	screenY: true,
+	targetTouches: true,
+	toElement: true,
+	touches: true,
+
+	which: function( event ) {
+		var button = event.button;
+
+		// Add which for key events
+		if ( event.which == null && rkeyEvent.test( event.type ) ) {
+			return event.charCode != null ? event.charCode : event.keyCode;
+		}
+
+		// Add which for click: 1 === left; 2 === middle; 3 === right
+		if ( !event.which && button !== undefined && rmouseEvent.test( event.type ) ) {
+			if ( button & 1 ) {
+				return 1;
+			}
+
+			if ( button & 2 ) {
+				return 3;
+			}
+
+			if ( button & 4 ) {
+				return 2;
+			}
+
+			return 0;
+		}
+
+		return event.which;
+	}
+}, jQuery.event.addProp );
+
+jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateType ) {
+	jQuery.event.special[ type ] = {
+
+		// Utilize native event if possible so blur/focus sequence is correct
+		setup: function() {
+
+			// Claim the first handler
+			// dataPriv.set( this, "focus", ... )
+			// dataPriv.set( this, "blur", ... )
+			leverageNative( this, type, expectSync );
+
+			// Return false to allow normal processing in the caller
+			return false;
+		},
+		trigger: function() {
+
+			// Force setup before trigger
+			leverageNative( this, type );
+
+			// Return non-false to allow normal event-path propagation
+			return true;
+		},
+
+		delegateType: delegateType
+	};
+} );
+
+// Create mouseenter/leave events using mouseover/out and event-time checks
+// so that event delegation works in jQuery.
+// Do the same for pointerenter/pointerleave and pointerover/pointerout
+//
+// Support: Safari 7 only
+// Safari sends mouseenter too often; see:
+// https://bugs.chromium.org/p/chromium/issues/detail?id=470258
+// for the description of the bug (it existed in older Chrome versions as well).
+jQuery.each( {
+	mouseenter: "mouseover",
+	mouseleave: "mouseout",
+	pointerenter: "pointerover",
+	pointerleave: "pointerout"
+}, function( orig, fix ) {
+	jQuery.event.special[ orig ] = {
+		delegateType: fix,
+		bindType: fix,
+
+		handle: function( event ) {
+			var ret,
+				target = this,
+				related = event.relatedTarget,
+				handleObj = event.handleObj;
+
+			// For mouseenter/leave call the handler if related is outside the target.
+			// NB: No relatedTarget if the mouse left/entered the browser window
+			if ( !related || ( related !== target && !jQuery.contains( target, related ) ) ) {
+				event.type = handleObj.origType;
+				ret = handleObj.handler.apply( this, arguments );
+				event.type = fix;
+			}
+			return ret;
+		}
+	};
+} );
+
+jQuery.fn.extend( {
+
+	on: function( types, selector, data, fn ) {
+		return on( this, types, selector, data, fn );
+	},
+	one: function( types, selector, data, fn ) {
+		return on( this, types, selector, data, fn, 1 );
+	},
+	off: function( types, selector, fn ) {
+		var handleObj, type;
+		if ( types && types.preventDefault && types.handleObj ) {
+
+			// ( event )  dispatched jQuery.Event
+			handleObj = types.handleObj;
+			jQuery( types.delegateTarget ).off(
+				handleObj.namespace ?
+					handleObj.origType + "." + handleObj.namespace :
+					handleObj.origType,
+				handleObj.selector,
+				handleObj.handler
+			);
+			return this;
+		}
+		if ( typeof types === "object" ) {
+
+			// ( types-object [, selector] )
+			for ( type in types ) {
+				this.off( type, selector, types[ type ] );
+			}
+			return this;
+		}
+		if ( selector === false || typeof selector === "function" ) {
+
+			// ( types [, fn] )
+			fn = selector;
+			selector = undefined;
+		}
+		if ( fn === false ) {
+			fn = returnFalse;
+		}
+		return this.each( function() {
+			jQuery.event.remove( this, types, fn, selector );
+		} );
+	}
+} );
+
+
+var
+
+	/* eslint-disable max-len */
+
+	// See https://github.com/eslint/eslint/issues/3229
+	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
+
+	/* eslint-enable */
+
+	// Support: IE <=10 - 11, Edge 12 - 13 only
+	// In IE/Edge using regex groups here causes severe slowdowns.
+	// See https://connect.microsoft.com/IE/feedback/details/1736512/
+	rnoInnerhtml = /<script|<style|<link/i,
+
+	// checked="checked" or checked
+	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
+	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
+
+// Prefer a tbody over its parent table for containing new rows
+function manipulationTarget( elem, content ) {
+	if ( nodeName( elem, "table" ) &&
+		nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ) {
+
+		return jQuery( elem ).children( "tbody" )[ 0 ] || elem;
+	}
+
+	return elem;
+}
+
+// Replace/restore the type attribute of script elements for safe DOM manipulation
+function disableScript( elem ) {
+	elem.type = ( elem.getAttribute( "type" ) !== null ) + "/" + elem.type;
+	return elem;
+}
+function restoreScript( elem ) {
+	if ( ( elem.type || "" ).slice( 0, 5 ) === "true/" ) {
+		elem.type = elem.type.slice( 5 );
+	} else {
+		elem.removeAttribute( "type" );
+	}
+
+	return elem;
+}
+
+function cloneCopyEvent( src, dest ) {
+	var i, l, type, pdataOld, pdataCur, udataOld, udataCur, events;
+
+	if ( dest.nodeType !== 1 ) {
+		return;
+	}
+
+	// 1. Copy private data: events, handlers, etc.
+	if ( dataPriv.hasData( src ) ) {
+		pdataOld = dataPriv.access( src );
+		pdataCur = dataPriv.set( dest, pdataOld );
+		events = pdataOld.events;
+
+		if ( events ) {
+			delete pdataCur.handle;
+			pdataCur.events = {};
+
+			for ( type in events ) {
+				for ( i = 0, l = events[ type ].length; i < l; i++ ) {
+					jQuery.event.add( dest, type, events[ type ][ i ] );
+				}
+			}
+		}
+	}
+
+	// 2. Copy user data
+	if ( dataUser.hasData( src ) ) {
+		udataOld = dataUser.access( src );
+		udataCur = jQuery.extend( {}, udataOld );
+
+		dataUser.set( dest, udataCur );
+	}
+}
+
+// Fix IE bugs, see support tests
+function fixInput( src, dest ) {
+	var nodeName = dest.nodeName.toLowerCase();
+
+	// Fails to persist the checked state of a cloned checkbox or radio button.
+	if ( nodeName === "input" && rcheckableType.test( src.type ) ) {
+		dest.checked = src.checked;
+
+	// Fails to return the selected option to the default selected state when cloning options
+	} else if ( nodeName === "input" || nodeName === "textarea" ) {
+		dest.defaultValue = src.defaultValue;
+	}
+}
+
+function domManip( collection, args, callback, ignored ) {
+
+	// Flatten any nested arrays
+	args = concat.apply( [], args );
+
+	var fragment, first, scripts, hasScripts, node, doc,
+		i = 0,
+		l = collection.length,
+		iNoClone = l - 1,
+		value = args[ 0 ],
+		valueIsFunction = isFunction( value );
+
+	// We can't cloneNode fragments that contain checked, in WebKit
+	if ( valueIsFunction ||
+			( l > 1 && typeof value === "string" &&
+				!support.checkClone && rchecked.test( value ) ) ) {
+		return collection.each( function( index ) {
+			var self = collection.eq( index );
+			if ( valueIsFunction ) {
+				args[ 0 ] = value.call( this, index, self.html() );
+			}
+			domManip( self, args, callback, ignored );
+		} );
+	}
+
+	if ( l ) {
+		fragment = buildFragment( args, collection[ 0 ].ownerDocument, false, collection, ignored );
+		first = fragment.firstChild;
+
+		if ( fragment.childNodes.length === 1 ) {
+			fragment = first;
+		}
+
+		// Require either new content or an interest in ignored elements to invoke the callback
+		if ( first || ignored ) {
+			scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
+			hasScripts = scripts.length;
+
+			// Use the original fragment for the last item
+			// instead of the first because it can end up
+			// being emptied incorrectly in certain situations (#8070).
+			for ( ; i < l; i++ ) {
+				node = fragment;
+
+				if ( i !== iNoClone ) {
+					node = jQuery.clone( node, true, true );
+
+					// Keep references to cloned scripts for later restoration
+					if ( hasScripts ) {
+
+						// Support: Android <=4.0 only, PhantomJS 1 only
+						// push.apply(_, arraylike) throws on ancient WebKit
+						jQuery.merge( scripts, getAll( node, "script" ) );
+					}
+				}
+
+				callback.call( collection[ i ], node, i );
+			}
+
+			if ( hasScripts ) {
+				doc = scripts[ scripts.length - 1 ].ownerDocument;
+
+				// Reenable scripts
+				jQuery.map( scripts, restoreScript );
+
+				// Evaluate executable scripts on first document insertion
+				for ( i = 0; i < hasScripts; i++ ) {
+					node = scripts[ i ];
+					if ( rscriptType.test( node.type || "" ) &&
+						!dataPriv.access( node, "globalEval" ) &&
+						jQuery.contains( doc, node ) ) {
+
+						if ( node.src && ( node.type || "" ).toLowerCase()  !== "module" ) {
+
+							// Optional AJAX dependency, but won't run scripts if not present
+							if ( jQuery._evalUrl && !node.noModule ) {
+								jQuery._evalUrl( node.src, {
+									nonce: node.nonce || node.getAttribute( "nonce" )
+								} );
+							}
+						} else {
+							DOMEval( node.textContent.replace( rcleanScript, "" ), node, doc );
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return collection;
+}
+
+function remove( elem, selector, keepData ) {
+	var node,
+		nodes = selector ? jQuery.filter( selector, elem ) : elem,
+		i = 0;
+
+	for ( ; ( node = nodes[ i ] ) != null; i++ ) {
+		if ( !keepData && node.nodeType === 1 ) {
+			jQuery.cleanData( getAll( node ) );
+		}
+
+		if ( node.parentNode ) {
+			if ( keepData && isAttached( node ) ) {
+				setGlobalEval( getAll( node, "script" ) );
+			}
+			node.parentNode.removeChild( node );
+		}
+	}
+
+	return elem;
+}
+
+jQuery.extend( {
+	htmlPrefilter: function( html ) {
+		return html.replace( rxhtmlTag, "<$1></$2>" );
+	},
+
+	clone: function( elem, dataAndEvents, deepDataAndEvents ) {
+		var i, l, srcElements, destElements,
+			clone = elem.cloneNode( true ),
+			inPage = isAttached( elem );
+
+		// Fix IE cloning issues
+		if ( !support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) &&
+				!jQuery.isXMLDoc( elem ) ) {
+
+			// We eschew Sizzle here for performance reasons: https://jsperf.com/getall-vs-sizzle/2
+			destElements = getAll( clone );
+			srcElements = getAll( elem );
+
+			for ( i = 0, l = srcElements.length; i < l; i++ ) {
+				fixInput( srcElements[ i ], destElements[ i ] );
+			}
+		}
+
+		// Copy the events from the original to the clone
+		if ( dataAndEvents ) {
+			if ( deepDataAndEvents ) {
+				srcElements = srcElements || getAll( elem );
+				destElements = destElements || getAll( clone );
+
+				for ( i = 0, l = srcElements.length; i < l; i++ ) {
+					cloneCopyEvent( srcElements[ i ], destElements[ i ] );
+				}
+			} else {
+				cloneCopyEvent( elem, clone );
+			}
+		}
+
+		// Preserve script evaluation history
+		destElements = getAll( clone, "script" );
+		if ( destElements.length > 0 ) {
+			setGlobalEval( destElements, !inPage && getAll( elem, "script" ) );
+		}
+
+		// Return the cloned set
+		return clone;
+	},
+
+	cleanData: function( elems ) {
+		var data, elem, type,
+			special = jQuery.event.special,
+			i = 0;
+
+		for ( ; ( elem = elems[ i ] ) !== undefined; i++ ) {
+			if ( acceptData( elem ) ) {
+				if ( ( data = elem[ dataPriv.expando ] ) ) {
+					if ( data.events ) {
+						for ( type in data.events ) {
+							if ( special[ type ] ) {
+								jQuery.event.remove( elem, type );
+
+							// This is a shortcut to avoid jQuery.event.remove's overhead
+							} else {
+								jQuery.removeEvent( elem, type, data.handle );
+							}
+						}
+					}
+
+					// Support: Chrome <=35 - 45+
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataPriv.expando ] = undefined;
+				}
+				if ( elem[ dataUser.expando ] ) {
+
+					// Support: Chrome <=35 - 45+
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataUser.expando ] = undefined;
+				}
+			}
+		}
+	}
+} );
+
+jQuery.fn.extend( {
+	detach: function( selector ) {
+		return remove( this, selector, true );
+	},
+
+	remove: function( selector ) {
+		return remove( this, selector );
+	},
+
+	text: function( value ) {
+		return access( this, function( value ) {
+			return value === undefined ?
+				jQuery.text( this ) :
+				this.empty().each( function() {
+					if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
+						this.textContent = value;
+					}
+				} );
+		}, null, value, arguments.length );
+	},
+
+	append: function() {
+		return domManip( this, arguments, function( elem ) {
+			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
+				var target = manipulationTarget( this, elem );
+				target.appendChild( elem );
+			}
+		} );
+	},
+
+	prepend: function() {
+		return domManip( this, arguments, function( elem ) {
+			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
+				var target = manipulationTarget( this, elem );
+				target.insertBefore( elem, target.firstChild );
+			}
+		} );
+	},
+
+	before: function() {
+		return domManip( this, arguments, function( elem ) {
+			if ( this.parentNode ) {
+				this.parentNode.insertBefore( elem, this );
+			}
+		} );
+	},
+
+	after: function() {
+		return domManip( this, arguments, function( elem ) {
+			if ( this.parentNode ) {
+				this.parentNode.insertBefore( elem, this.nextSibling );
+			}
+		} );
+	},
+
+	empty: function() {
+		var elem,
+			i = 0;
+
+		for ( ; ( elem = this[ i ] ) != null; i++ ) {
+			if ( elem.nodeType === 1 ) {
+
+				// Prevent memory leaks
+				jQuery.cleanData( getAll( elem, false ) );
+
+				// Remove any remaining nodes
+				elem.textContent = "";
+			}
+		}
+
+		return this;
+	},
+
+	clone: function( dataAndEvents, deepDataAndEvents ) {
+		dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
+		deepDataAndEvents = deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
+
+		return this.map( function() {
+			return jQuery.clone( this, dataAndEvents, deepDataAndEvents );
+		} );
+	},
+
+	html: function( value ) {
+		return access( this, function( value ) {
+			var elem = this[ 0 ] || {},
+				i = 0,
+				l = this.length;
+
+			if ( value === undefined && elem.nodeType === 1 ) {
+				return elem.innerHTML;
+			}
+
+			// See if we can take a shortcut and just use innerHTML
+			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
+				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
+
+				value = jQuery.htmlPrefilter( value );
+
+				try {
+					for ( ; i < l; i++ ) {
+						elem = this[ i ] || {};
+
+						// Remove element nodes and prevent memory leaks
+						if ( elem.nodeType === 1 ) {
+							jQuery.cleanData( getAll( elem, false ) );
+							elem.innerHTML = value;
+						}
+					}
+
+					elem = 0;
+
+				// If using innerHTML throws an exception, use the fallback method
+				} catch ( e ) {}
+			}
+
+			if ( elem ) {
+				this.empty().append( value );
+			}
+		}, null, value, arguments.length );
+	},
+
+	replaceWith: function() {
+		var ignored = [];
+
+		// Make the changes, replacing each non-ignored context element with the new content
+		return domManip( this, arguments, function( elem ) {
+			var parent = this.parentNode;
+
+			if ( jQuery.inArray( this, ignored ) < 0 ) {
+				jQuery.cleanData( getAll( this ) );
+				if ( parent ) {
+					parent.replaceChild( elem, this );
+				}
+			}
+
+		// Force callback invocation
+		}, ignored );
+	}
+} );
+
+jQuery.each( {
+	appendTo: "append",
+	prependTo: "prepend",
+	insertBefore: "before",
+	insertAfter: "after",
+	replaceAll: "replaceWith"
+}, function( name, original ) {
+	jQuery.fn[ name ] = function( selector ) {
+		var elems,
+			ret = [],
+			insert = jQuery( selector ),
+			last = insert.length - 1,
+			i = 0;
+
+		for ( ; i <= last; i++ ) {
+			elems = i === last ? this : this.clone( true );
+			jQuery( insert[ i ] )[ original ]( elems );
+
+			// Support: Android <=4.0 only, PhantomJS 1 only
+			// .get() because push.apply(_, arraylike) throws on ancient WebKit
+			push.apply( ret, elems.get() );
+		}
+
+		return this.pushStack( ret );
+	};
+} );
+var rnumnonpx = new RegExp( "^(" + pnum + ")(?!px)[a-z%]+$", "i" );
+
+var getStyles = function( elem ) {
+
+		// Support: IE <=11 only, Firefox <=30 (#15098, #14150)
+		// IE throws on elements created in popups
+		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+		var view = elem.ownerDocument.defaultView;
+
+		if ( !view || !view.opener ) {
+			view = window;
+		}
+
+		return view.getComputedStyle( elem );
+	};
+
+var rboxStyle = new RegExp( cssExpand.join( "|" ), "i" );
+
+
+
+( function() {
+
+	// Executing both pixelPosition & boxSizingReliable tests require only one layout
+	// so they're executed at the same time to save the second computation.
+	function computeStyleTests() {
+
+		// This is a singleton, we need to execute it only once
+		if ( !div ) {
+			return;
+		}
+
+		container.style.cssText = "position:absolute;left:-11111px;width:60px;" +
+			"margin-top:1px;padding:0;border:0";
+		div.style.cssText =
+			"position:relative;display:block;box-sizing:border-box;overflow:scroll;" +
+			"margin:auto;border:1px;padding:1px;" +
+			"width:60%;top:1%";
+		documentElement.appendChild( container ).appendChild( div );
+
+		var divStyle = window.getComputedStyle( div );
+		pixelPositionVal = divStyle.top !== "1%";
+
+		// Support: Android 4.0 - 4.3 only, Firefox <=3 - 44
+		reliableMarginLeftVal = roundPixelMeasures( divStyle.marginLeft ) === 12;
+
+		// Support: Android 4.0 - 4.3 only, Safari <=9.1 - 10.1, iOS <=7.0 - 9.3
+		// Some styles come back with percentage values, even though they shouldn't
+		div.style.right = "60%";
+		pixelBoxStylesVal = roundPixelMeasures( divStyle.right ) === 36;
+
+		// Support: IE 9 - 11 only
+		// Detect misreporting of content dimensions for box-sizing:border-box elements
+		boxSizingReliableVal = roundPixelMeasures( divStyle.width ) === 36;
+
+		// Support: IE 9 only
+		// Detect overflow:scroll screwiness (gh-3699)
+		// Support: Chrome <=64
+		// Don't get tricked when zoom affects offsetWidth (gh-4029)
+		div.style.position = "absolute";
+		scrollboxSizeVal = roundPixelMeasures( div.offsetWidth / 3 ) === 12;
+
+		documentElement.removeChild( container );
+
+		// Nullify the div so it wouldn't be stored in the memory and
+		// it will also be a sign that checks already performed
+		div = null;
+	}
+
+	function roundPixelMeasures( measure ) {
+		return Math.round( parseFloat( measure ) );
+	}
+
+	var pixelPositionVal, boxSizingReliableVal, scrollboxSizeVal, pixelBoxStylesVal,
+		reliableMarginLeftVal,
+		container = document.createElement( "div" ),
+		div = document.createElement( "div" );
+
+	// Finish early in limited (non-browser) environments
+	if ( !div.style ) {
+		return;
+	}
+
+	// Support: IE <=9 - 11 only
+	// Style of cloned element affects source element cloned (#8908)
+	div.style.backgroundClip = "content-box";
+	div.cloneNode( true ).style.backgroundClip = "";
+	support.clearCloneStyle = div.style.backgroundClip === "content-box";
+
+	jQuery.extend( support, {
+		boxSizingReliable: function() {
+			computeStyleTests();
+			return boxSizingReliableVal;
+		},
+		pixelBoxStyles: function() {
+			computeStyleTests();
+			return pixelBoxStylesVal;
+		},
+		pixelPosition: function() {
+			computeStyleTests();
+			return pixelPositionVal;
+		},
+		reliableMarginLeft: function() {
+			computeStyleTests();
+			return reliableMarginLeftVal;
+		},
+		scrollboxSize: function() {
+			computeStyleTests();
+			return scrollboxSizeVal;
+		}
+	} );
+} )();
+
+
+function curCSS( elem, name, computed ) {
+	var width, minWidth, maxWidth, ret,
+
+		// Support: Firefox 51+
+		// Retrieving style before computed somehow
+		// fixes an issue with getting wrong values
+		// on detached elements
+		style = elem.style;
+
+	computed = computed || getStyles( elem );
+
+	// getPropertyValue is needed for:
+	//   .css('filter') (IE 9 only, #12537)
+	//   .css('--customProperty) (#3144)
+	if ( computed ) {
+		ret = computed.getPropertyValue( name ) || computed[ name ];
+
+		if ( ret === "" && !isAttached( elem ) ) {
+			ret = jQuery.style( elem, name );
+		}
+
+		// A tribute to the "awesome hack by Dean Edwards"
+		// Android Browser returns percentage for some values,
+		// but width seems to be reliably pixels.
+		// This is against the CSSOM draft spec:
+		// https://drafts.csswg.org/cssom/#resolved-values
+		if ( !support.pixelBoxStyles() && rnumnonpx.test( ret ) && rboxStyle.test( name ) ) {
+
+			// Remember the original values
+			width = style.width;
+			minWidth = style.minWidth;
+			maxWidth = style.maxWidth;
+
+			// Put in the new values to get a computed value out
+			style.minWidth = style.maxWidth = style.width = ret;
+			ret = computed.width;
+
+			// Revert the changed values
+			style.width = width;
+			style.minWidth = minWidth;
+			style.maxWidth = maxWidth;
+		}
+	}
+
+	return ret !== undefined ?
+
+		// Support: IE <=9 - 11 only
+		// IE returns zIndex value as an integer.
+		ret + "" :
+		ret;
+}
+
+
+function addGetHookIf( conditionFn, hookFn ) {
+
+	// Define the hook, we'll check on the first run if it's really needed.
+	return {
+		get: function() {
+			if ( conditionFn() ) {
+
+				// Hook not needed (or it's not possible to use it due
+				// to missing dependency), remove it.
+				delete this.get;
+				return;
+			}
+
+			// Hook needed; redefine it so that the support test is not executed again.
+			return ( this.get = hookFn ).apply( this, arguments );
+		}
+	};
+}
+
+
+var cssPrefixes = [ "Webkit", "Moz", "ms" ],
+	emptyStyle = document.createElement( "div" ).style,
+	vendorProps = {};
+
+// Return a vendor-prefixed property or undefined
+function vendorPropName( name ) {
+
+	// Check for vendor prefixed names
+	var capName = name[ 0 ].toUpperCase() + name.slice( 1 ),
+		i = cssPrefixes.length;
+
+	while ( i-- ) {
+		name = cssPrefixes[ i ] + capName;
+		if ( name in emptyStyle ) {
+			return name;
+		}
+	}
+}
+
+// Return a potentially-mapped jQuery.cssProps or vendor prefixed property
+function finalPropName( name ) {
+	var final = jQuery.cssProps[ name ] || vendorProps[ name ];
+
+	if ( final ) {
+		return final;
+	}
+	if ( name in emptyStyle ) {
+		return name;
+	}
+	return vendorProps[ name ] = vendorPropName( name ) || name;
+}
+
+
+var
+
+	// Swappable if display is none or starts with table
+	// except "table", "table-cell", or "table-caption"
+	// See here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+	rdisplayswap = /^(none|table(?!-c[ea]).+)/,
+	rcustomProp = /^--/,
+	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
+	cssNormalTransform = {
+		letterSpacing: "0",
+		fontWeight: "400"
+	};
+
+function setPositiveNumber( elem, value, subtract ) {
+
+	// Any relative (+/-) values have already been
+	// normalized at this point
+	var matches = rcssNum.exec( value );
+	return matches ?
+
+		// Guard against undefined "subtract", e.g., when used as in cssHooks
+		Math.max( 0, matches[ 2 ] - ( subtract || 0 ) ) + ( matches[ 3 ] || "px" ) :
+		value;
+}
+
+function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computedVal ) {
+	var i = dimension === "width" ? 1 : 0,
+		extra = 0,
+		delta = 0;
+
+	// Adjustment may not be necessary
+	if ( box === ( isBorderBox ? "border" : "content" ) ) {
+		return 0;
+	}
+
+	for ( ; i < 4; i += 2 ) {
+
+		// Both box models exclude margin
+		if ( box === "margin" ) {
+			delta += jQuery.css( elem, box + cssExpand[ i ], true, styles );
+		}
+
+		// If we get here with a content-box, we're seeking "padding" or "border" or "margin"
+		if ( !isBorderBox ) {
+
+			// Add padding
+			delta += jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+
+			// For "border" or "margin", add border
+			if ( box !== "padding" ) {
+				delta += jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+
+			// But still keep track of it otherwise
+			} else {
+				extra += jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+			}
+
+		// If we get here with a border-box (content + padding + border), we're seeking "content" or
+		// "padding" or "margin"
+		} else {
+
+			// For "content", subtract padding
+			if ( box === "content" ) {
+				delta -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+			}
+
+			// For "content" or "padding", subtract border
+			if ( box !== "margin" ) {
+				delta -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+			}
+		}
+	}
+
+	// Account for positive content-box scroll gutter when requested by providing computedVal
+	if ( !isBorderBox && computedVal >= 0 ) {
+
+		// offsetWidth/offsetHeight is a rounded sum of content, padding, scroll gutter, and border
+		// Assuming integer scroll gutter, subtract the rest and round down
+		delta += Math.max( 0, Math.ceil(
+			elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] -
+			computedVal -
+			delta -
+			extra -
+			0.5
+
+		// If offsetWidth/offsetHeight is unknown, then we can't determine content-box scroll gutter
+		// Use an explicit zero to avoid NaN (gh-3964)
+		) ) || 0;
+	}
+
+	return delta;
+}
+
+function getWidthOrHeight( elem, dimension, extra ) {
+
+	// Start with computed style
+	var styles = getStyles( elem ),
+
+		// To avoid forcing a reflow, only fetch boxSizing if we need it (gh-4322).
+		// Fake content-box until we know it's needed to know the true value.
+		boxSizingNeeded = !support.boxSizingReliable() || extra,
+		isBorderBox = boxSizingNeeded &&
+			jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+		valueIsBorderBox = isBorderBox,
+
+		val = curCSS( elem, dimension, styles ),
+		offsetProp = "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 );
+
+	// Support: Firefox <=54
+	// Return a confounding non-pixel value or feign ignorance, as appropriate.
+	if ( rnumnonpx.test( val ) ) {
+		if ( !extra ) {
+			return val;
+		}
+		val = "auto";
+	}
+
+
+	// Fall back to offsetWidth/offsetHeight when value is "auto"
+	// This happens for inline elements with no explicit setting (gh-3571)
+	// Support: Android <=4.1 - 4.3 only
+	// Also use offsetWidth/offsetHeight for misreported inline dimensions (gh-3602)
+	// Support: IE 9-11 only
+	// Also use offsetWidth/offsetHeight for when box sizing is unreliable
+	// We use getClientRects() to check for hidden/disconnected.
+	// In those cases, the computed value can be trusted to be border-box
+	if ( ( !support.boxSizingReliable() && isBorderBox ||
+		val === "auto" ||
+		!parseFloat( val ) && jQuery.css( elem, "display", false, styles ) === "inline" ) &&
+		elem.getClientRects().length ) {
+
+		isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
+
+		// Where available, offsetWidth/offsetHeight approximate border box dimensions.
+		// Where not available (e.g., SVG), assume unreliable box-sizing and interpret the
+		// retrieved value as a content box dimension.
+		valueIsBorderBox = offsetProp in elem;
+		if ( valueIsBorderBox ) {
+			val = elem[ offsetProp ];
+		}
+	}
+
+	// Normalize "" and auto
+	val = parseFloat( val ) || 0;
+
+	// Adjust for the element's box model
+	return ( val +
+		boxModelAdjustment(
+			elem,
+			dimension,
+			extra || ( isBorderBox ? "border" : "content" ),
+			valueIsBorderBox,
+			styles,
+
+			// Provide the current computed size to request scroll gutter calculation (gh-3589)
+			val
+		)
+	) + "px";
+}
+
+jQuery.extend( {
+
+	// Add in style property hooks for overriding the default
+	// behavior of getting and setting a style property
+	cssHooks: {
+		opacity: {
+			get: function( elem, computed ) {
+				if ( computed ) {
+
+					// We should always get a number back from opacity
+					var ret = curCSS( elem, "opacity" );
+					return ret === "" ? "1" : ret;
+				}
+			}
+		}
+	},
+
+	// Don't automatically add "px" to these possibly-unitless properties
+	cssNumber: {
+		"animationIterationCount": true,
+		"columnCount": true,
+		"fillOpacity": true,
+		"flexGrow": true,
+		"flexShrink": true,
+		"fontWeight": true,
+		"gridArea": true,
+		"gridColumn": true,
+		"gridColumnEnd": true,
+		"gridColumnStart": true,
+		"gridRow": true,
+		"gridRowEnd": true,
+		"gridRowStart": true,
+		"lineHeight": true,
+		"opacity": true,
+		"order": true,
+		"orphans": true,
+		"widows": true,
+		"zIndex": true,
+		"zoom": true
+	},
+
+	// Add in properties whose names you wish to fix before
+	// setting or getting the value
+	cssProps: {},
+
+	// Get and set the style property on a DOM Node
+	style: function( elem, name, value, extra ) {
+
+		// Don't set styles on text and comment nodes
+		if ( !elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style ) {
+			return;
+		}
+
+		// Make sure that we're working with the right name
+		var ret, type, hooks,
+			origName = camelCase( name ),
+			isCustomProp = rcustomProp.test( name ),
+			style = elem.style;
+
+		// Make sure that we're working with the right name. We don't
+		// want to query the value if it is a CSS custom property
+		// since they are user-defined.
+		if ( !isCustomProp ) {
+			name = finalPropName( origName );
+		}
+
+		// Gets hook for the prefixed version, then unprefixed version
+		hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
+
+		// Check if we're setting a value
+		if ( value !== undefined ) {
+			type = typeof value;
+
+			// Convert "+=" or "-=" to relative numbers (#7345)
+			if ( type === "string" && ( ret = rcssNum.exec( value ) ) && ret[ 1 ] ) {
+				value = adjustCSS( elem, name, ret );
+
+				// Fixes bug #9237
+				type = "number";
+			}
+
+			// Make sure that null and NaN values aren't set (#7116)
+			if ( value == null || value !== value ) {
+				return;
+			}
+
+			// If a number was passed in, add the unit (except for certain CSS properties)
+			// The isCustomProp check can be removed in jQuery 4.0 when we only auto-append
+			// "px" to a few hardcoded values.
+			if ( type === "number" && !isCustomProp ) {
+				value += ret && ret[ 3 ] || ( jQuery.cssNumber[ origName ] ? "" : "px" );
+			}
+
+			// background-* props affect original clone's values
+			if ( !support.clearCloneStyle && value === "" && name.indexOf( "background" ) === 0 ) {
+				style[ name ] = "inherit";
+			}
+
+			// If a hook was provided, use that value, otherwise just set the specified value
+			if ( !hooks || !( "set" in hooks ) ||
+				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
+
+				if ( isCustomProp ) {
+					style.setProperty( name, value );
+				} else {
+					style[ name ] = value;
+				}
+			}
+
+		} else {
+
+			// If a hook was provided get the non-computed value from there
+			if ( hooks && "get" in hooks &&
+				( ret = hooks.get( elem, false, extra ) ) !== undefined ) {
+
+				return ret;
+			}
+
+			// Otherwise just get the value from the style object
+			return style[ name ];
+		}
+	},
+
+	css: function( elem, name, extra, styles ) {
+		var val, num, hooks,
+			origName = camelCase( name ),
+			isCustomProp = rcustomProp.test( name );
+
+		// Make sure that we're working with the right name. We don't
+		// want to modify the value if it is a CSS custom property
+		// since they are user-defined.
+		if ( !isCustomProp ) {
+			name = finalPropName( origName );
+		}
+
+		// Try prefixed name followed by the unprefixed name
+		hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
+
+		// If a hook was provided get the computed value from there
+		if ( hooks && "get" in hooks ) {
+			val = hooks.get( elem, true, extra );
+		}
+
+		// Otherwise, if a way to get the computed value exists, use that
+		if ( val === undefined ) {
+			val = curCSS( elem, name, styles );
+		}
+
+		// Convert "normal" to computed value
+		if ( val === "normal" && name in cssNormalTransform ) {
+			val = cssNormalTransform[ name ];
+		}
+
+		// Make numeric if forced or a qualifier was provided and val looks numeric
+		if ( extra === "" || extra ) {
+			num = parseFloat( val );
+			return extra === true || isFinite( num ) ? num || 0 : val;
+		}
+
+		return val;
+	}
+} );
+
+jQuery.each( [ "height", "width" ], function( i, dimension ) {
+	jQuery.cssHooks[ dimension ] = {
+		get: function( elem, computed, extra ) {
+			if ( computed ) {
+
+				// Certain elements can have dimension info if we invisibly show them
+				// but it must have a current display style that would benefit
+				return rdisplayswap.test( jQuery.css( elem, "display" ) ) &&
+
+					// Support: Safari 8+
+					// Table columns in Safari have non-zero offsetWidth & zero
+					// getBoundingClientRect().width unless display is changed.
+					// Support: IE <=11 only
+					// Running getBoundingClientRect on a disconnected node
+					// in IE throws an error.
+					( !elem.getClientRects().length || !elem.getBoundingClientRect().width ) ?
+						swap( elem, cssShow, function() {
+							return getWidthOrHeight( elem, dimension, extra );
+						} ) :
+						getWidthOrHeight( elem, dimension, extra );
+			}
+		},
+
+		set: function( elem, value, extra ) {
+			var matches,
+				styles = getStyles( elem ),
+
+				// Only read styles.position if the test has a chance to fail
+				// to avoid forcing a reflow.
+				scrollboxSizeBuggy = !support.scrollboxSize() &&
+					styles.position === "absolute",
+
+				// To avoid forcing a reflow, only fetch boxSizing if we need it (gh-3991)
+				boxSizingNeeded = scrollboxSizeBuggy || extra,
+				isBorderBox = boxSizingNeeded &&
+					jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+				subtract = extra ?
+					boxModelAdjustment(
+						elem,
+						dimension,
+						extra,
+						isBorderBox,
+						styles
+					) :
+					0;
+
+			// Account for unreliable border-box dimensions by comparing offset* to computed and
+			// faking a content-box to get border and padding (gh-3699)
+			if ( isBorderBox && scrollboxSizeBuggy ) {
+				subtract -= Math.ceil(
+					elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] -
+					parseFloat( styles[ dimension ] ) -
+					boxModelAdjustment( elem, dimension, "border", false, styles ) -
+					0.5
+				);
+			}
+
+			// Convert to pixels if value adjustment is needed
+			if ( subtract && ( matches = rcssNum.exec( value ) ) &&
+				( matches[ 3 ] || "px" ) !== "px" ) {
+
+				elem.style[ dimension ] = value;
+				value = jQuery.css( elem, dimension );
+			}
+
+			return setPositiveNumber( elem, value, subtract );
+		}
+	};
+} );
+
+jQuery.cssHooks.marginLeft = addGetHookIf( support.reliableMarginLeft,
+	function( elem, computed ) {
+		if ( computed ) {
+			return ( parseFloat( curCSS( elem, "marginLeft" ) ) ||
+				elem.getBoundingClientRect().left -
+					swap( elem, { marginLeft: 0 }, function() {
+						return elem.getBoundingClientRect().left;
+					} )
+				) + "px";
+		}
+	}
+);
+
+// These hooks are used by animate to expand properties
+jQuery.each( {
+	margin: "",
+	padding: "",
+	border: "Width"
+}, function( prefix, suffix ) {
+	jQuery.cssHooks[ prefix + suffix ] = {
+		expand: function( value ) {
+			var i = 0,
+				expanded = {},
+
+				// Assumes a single number if not a string
+				parts = typeof value === "string" ? value.split( " " ) : [ value ];
+
+			for ( ; i < 4; i++ ) {
+				expanded[ prefix + cssExpand[ i ] + suffix ] =
+					parts[ i ] || parts[ i - 2 ] || parts[ 0 ];
+			}
+
+			return expanded;
+		}
+	};
+
+	if ( prefix !== "margin" ) {
+		jQuery.cssHooks[ prefix + suffix ].set = setPositiveNumber;
+	}
+} );
+
+jQuery.fn.extend( {
+	css: function( name, value ) {
+		return access( this, function( elem, name, value ) {
+			var styles, len,
+				map = {},
+				i = 0;
+
+			if ( Array.isArray( name ) ) {
+				styles = getStyles( elem );
+				len = name.length;
+
+				for ( ; i < len; i++ ) {
+					map[ name[ i ] ] = jQuery.css( elem, name[ i ], false, styles );
+				}
+
+				return map;
+			}
+
+			return value !== undefined ?
+				jQuery.style( elem, name, value ) :
+				jQuery.css( elem, name );
+		}, name, value, arguments.length > 1 );
+	}
+} );
+
+
+function Tween( elem, options, prop, end, easing ) {
+	return new Tween.prototype.init( elem, options, prop, end, easing );
+}
+jQuery.Tween = Tween;
+
+Tween.prototype = {
+	constructor: Tween,
+	init: function( elem, options, prop, end, easing, unit ) {
+		this.elem = elem;
+		this.prop = prop;
+		this.easing = easing || jQuery.easing._default;
+		this.options = options;
+		this.start = this.now = this.cur();
+		this.end = end;
+		this.unit = unit || ( jQuery.cssNumber[ prop ] ? "" : "px" );
+	},
+	cur: function() {
+		var hooks = Tween.propHooks[ this.prop ];
+
+		return hooks && hooks.get ?
+			hooks.get( this ) :
+			Tween.propHooks._default.get( this );
+	},
+	run: function( percent ) {
+		var eased,
+			hooks = Tween.propHooks[ this.prop ];
+
+		if ( this.options.duration ) {
+			this.pos = eased = jQuery.easing[ this.easing ](
+				percent, this.options.duration * percent, 0, 1, this.options.duration
+			);
+		} else {
+			this.pos = eased = percent;
+		}
+		this.now = ( this.end - this.start ) * eased + this.start;
+
+		if ( this.options.step ) {
+			this.options.step.call( this.elem, this.now, this );
+		}
+
+		if ( hooks && hooks.set ) {
+			hooks.set( this );
+		} else {
+			Tween.propHooks._default.set( this );
+		}
+		return this;
+	}
+};
+
+Tween.prototype.init.prototype = Tween.prototype;
+
+Tween.propHooks = {
+	_default: {
+		get: function( tween ) {
+			var result;
+
+			// Use a property on the element directly when it is not a DOM element,
+			// or when there is no matching style property that exists.
+			if ( tween.elem.nodeType !== 1 ||
+				tween.elem[ tween.prop ] != null && tween.elem.style[ tween.prop ] == null ) {
+				return tween.elem[ tween.prop ];
+			}
+
+			// Passing an empty string as a 3rd parameter to .css will automatically
+			// attempt a parseFloat and fallback to a string if the parse fails.
+			// Simple values such as "10px" are parsed to Float;
+			// complex values such as "rotate(1rad)" are returned as-is.
+			result = jQuery.css( tween.elem, tween.prop, "" );
+
+			// Empty strings, null, undefined and "auto" are converted to 0.
+			return !result || result === "auto" ? 0 : result;
+		},
+		set: function( tween ) {
+
+			// Use step hook for back compat.
+			// Use cssHook if its there.
+			// Use .style if available and use plain properties where available.
+			if ( jQuery.fx.step[ tween.prop ] ) {
+				jQuery.fx.step[ tween.prop ]( tween );
+			} else if ( tween.elem.nodeType === 1 && (
+					jQuery.cssHooks[ tween.prop ] ||
+					tween.elem.style[ finalPropName( tween.prop ) ] != null ) ) {
+				jQuery.style( tween.elem, tween.prop, tween.now + tween.unit );
+			} else {
+				tween.elem[ tween.prop ] = tween.now;
+			}
+		}
+	}
+};
+
+// Support: IE <=9 only
+// Panic based approach to setting things on disconnected nodes
+Tween.propHooks.scrollTop = Tween.propHooks.scrollLeft = {
+	set: function( tween ) {
+		if ( tween.elem.nodeType && tween.elem.parentNode ) {
+			tween.elem[ tween.prop ] = tween.now;
+		}
+	}
+};
+
+jQuery.easing = {
+	linear: function( p ) {
+		return p;
+	},
+	swing: function( p ) {
+		return 0.5 - Math.cos( p * Math.PI ) / 2;
+	},
+	_default: "swing"
+};
+
+jQuery.fx = Tween.prototype.init;
+
+// Back compat <1.8 extension point
+jQuery.fx.step = {};
+
+
+
+
+var
+	fxNow, inProgress,
+	rfxtypes = /^(?:toggle|show|hide)$/,
+	rrun = /queueHooks$/;
+
+function schedule() {
+	if ( inProgress ) {
+		if ( document.hidden === false && window.requestAnimationFrame ) {
+			window.requestAnimationFrame( schedule );
+		} else {
+			window.setTimeout( schedule, jQuery.fx.interval );
+		}
+
+		jQuery.fx.tick();
+	}
+}
+
+// Animations created synchronously will run synchronously
+function createFxNow() {
+	window.setTimeout( function() {
+		fxNow = undefined;
+	} );
+	return ( fxNow = Date.now() );
+}
+
+// Generate parameters to create a standard animation
+function genFx( type, includeWidth ) {
+	var which,
+		i = 0,
+		attrs = { height: type };
+
+	// If we include width, step value is 1 to do all cssExpand values,
+	// otherwise step value is 2 to skip over Left and Right
+	includeWidth = includeWidth ? 1 : 0;
+	for ( ; i < 4; i += 2 - includeWidth ) {
+		which = cssExpand[ i ];
+		attrs[ "margin" + which ] = attrs[ "padding" + which ] = type;
+	}
+
+	if ( includeWidth ) {
+		attrs.opacity = attrs.width = type;
+	}
+
+	return attrs;
+}
+
+function createTween( value, prop, animation ) {
+	var tween,
+		collection = ( Animation.tweeners[ prop ] || [] ).concat( Animation.tweeners[ "*" ] ),
+		index = 0,
+		length = collection.length;
+	for ( ; index < length; index++ ) {
+		if ( ( tween = collection[ index ].call( animation, prop, value ) ) ) {
+
+			// We're done with this property
+			return tween;
+		}
+	}
+}
+
+function defaultPrefilter( elem, props, opts ) {
+	var prop, value, toggle, hooks, oldfire, propTween, restoreDisplay, display,
+		isBox = "width" in props || "height" in props,
+		anim = this,
+		orig = {},
+		style = elem.style,
+		hidden = elem.nodeType && isHiddenWithinTree( elem ),
+		dataShow = dataPriv.get( elem, "fxshow" );
+
+	// Queue-skipping animations hijack the fx hooks
+	if ( !opts.queue ) {
+		hooks = jQuery._queueHooks( elem, "fx" );
+		if ( hooks.unqueued == null ) {
+			hooks.unqueued = 0;
+			oldfire = hooks.empty.fire;
+			hooks.empty.fire = function() {
+				if ( !hooks.unqueued ) {
+					oldfire();
+				}
+			};
+		}
+		hooks.unqueued++;
+
+		anim.always( function() {
+
+			// Ensure the complete handler is called before this completes
+			anim.always( function() {
+				hooks.unqueued--;
+				if ( !jQuery.queue( elem, "fx" ).length ) {
+					hooks.empty.fire();
+				}
+			} );
+		} );
+	}
+
+	// Detect show/hide animations
+	for ( prop in props ) {
+		value = props[ prop ];
+		if ( rfxtypes.test( value ) ) {
+			delete props[ prop ];
+			toggle = toggle || value === "toggle";
+			if ( value === ( hidden ? "hide" : "show" ) ) {
+
+				// Pretend to be hidden if this is a "show" and
+				// there is still data from a stopped show/hide
+				if ( value === "show" && dataShow && dataShow[ prop ] !== undefined ) {
+					hidden = true;
+
+				// Ignore all other no-op show/hide data
+				} else {
+					continue;
+				}
+			}
+			orig[ prop ] = dataShow && dataShow[ prop ] || jQuery.style( elem, prop );
+		}
+	}
+
+	// Bail out if this is a no-op like .hide().hide()
+	propTween = !jQuery.isEmptyObject( props );
+	if ( !propTween && jQuery.isEmptyObject( orig ) ) {
+		return;
+	}
+
+	// Restrict "overflow" and "display" styles during box animations
+	if ( isBox && elem.nodeType === 1 ) {
+
+		// Support: IE <=9 - 11, Edge 12 - 15
+		// Record all 3 overflow attributes because IE does not infer the shorthand
+		// from identically-valued overflowX and overflowY and Edge just mirrors
+		// the overflowX value there.
+		opts.overflow = [ style.overflow, style.overflowX, style.overflowY ];
+
+		// Identify a display type, preferring old show/hide data over the CSS cascade
+		restoreDisplay = dataShow && dataShow.display;
+		if ( restoreDisplay == null ) {
+			restoreDisplay = dataPriv.get( elem, "display" );
+		}
+		display = jQuery.css( elem, "display" );
+		if ( display === "none" ) {
+			if ( restoreDisplay ) {
+				display = restoreDisplay;
+			} else {
+
+				// Get nonempty value(s) by temporarily forcing visibility
+				showHide( [ elem ], true );
+				restoreDisplay = elem.style.display || restoreDisplay;
+				display = jQuery.css( elem, "display" );
+				showHide( [ elem ] );
+			}
+		}
+
+		// Animate inline elements as inline-block
+		if ( display === "inline" || display === "inline-block" && restoreDisplay != null ) {
+			if ( jQuery.css( elem, "float" ) === "none" ) {
+
+				// Restore the original display value at the end of pure show/hide animations
+				if ( !propTween ) {
+					anim.done( function() {
+						style.display = restoreDisplay;
+					} );
+					if ( restoreDisplay == null ) {
+						display = style.display;
+						restoreDisplay = display === "none" ? "" : display;
+					}
+				}
+				style.display = "inline-block";
+			}
+		}
+	}
+
+	if ( opts.overflow ) {
+		style.overflow = "hidden";
+		anim.always( function() {
+			style.overflow = opts.overflow[ 0 ];
+			style.overflowX = opts.overflow[ 1 ];
+			style.overflowY = opts.overflow[ 2 ];
+		} );
+	}
+
+	// Implement show/hide animations
+	propTween = false;
+	for ( prop in orig ) {
+
+		// General show/hide setup for this element animation
+		if ( !propTween ) {
+			if ( dataShow ) {
+				if ( "hidden" in dataShow ) {
+					hidden = dataShow.hidden;
+				}
+			} else {
+				dataShow = dataPriv.access( elem, "fxshow", { display: restoreDisplay } );
+			}
+
+			// Store hidden/visible for toggle so `.stop().toggle()` "reverses"
+			if ( toggle ) {
+				dataShow.hidden = !hidden;
+			}
+
+			// Show elements before animating them
+			if ( hidden ) {
+				showHide( [ elem ], true );
+			}
+
+			/* eslint-disable no-loop-func */
+
+			anim.done( function() {
+
+			/* eslint-enable no-loop-func */
+
+				// The final step of a "hide" animation is actually hiding the element
+				if ( !hidden ) {
+					showHide( [ elem ] );
+				}
+				dataPriv.remove( elem, "fxshow" );
+				for ( prop in orig ) {
+					jQuery.style( elem, prop, orig[ prop ] );
+				}
+			} );
+		}
+
+		// Per-property setup
+		propTween = createTween( hidden ? dataShow[ prop ] : 0, prop, anim );
+		if ( !( prop in dataShow ) ) {
+			dataShow[ prop ] = propTween.start;
+			if ( hidden ) {
+				propTween.end = propTween.start;
+				propTween.start = 0;
+			}
+		}
+	}
+}
+
+function propFilter( props, specialEasing ) {
+	var index, name, easing, value, hooks;
+
+	// camelCase, specialEasing and expand cssHook pass
+	for ( index in props ) {
+		name = camelCase( index );
+		easing = specialEasing[ name ];
+		value = props[ index ];
+		if ( Array.isArray( value ) ) {
+			easing = value[ 1 ];
+			value = props[ index ] = value[ 0 ];
+		}
+
+		if ( index !== name ) {
+			props[ name ] = value;
+			delete props[ index ];
+		}
+
+		hooks = jQuery.cssHooks[ name ];
+		if ( hooks && "expand" in hooks ) {
+			value = hooks.expand( value );
+			delete props[ name ];
+
+			// Not quite $.extend, this won't overwrite existing keys.
+			// Reusing 'index' because we have the correct "name"
+			for ( index in value ) {
+				if ( !( index in props ) ) {
+					props[ index ] = value[ index ];
+					specialEasing[ index ] = easing;
+				}
+			}
+		} else {
+			specialEasing[ name ] = easing;
+		}
+	}
+}
+
+function Animation( elem, properties, options ) {
+	var result,
+		stopped,
+		index = 0,
+		length = Animation.prefilters.length,
+		deferred = jQuery.Deferred().always( function() {
+
+			// Don't match elem in the :animated selector
+			delete tick.elem;
+		} ),
+		tick = function() {
+			if ( stopped ) {
+				return false;
+			}
+			var currentTime = fxNow || createFxNow(),
+				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
+
+				// Support: Android 2.3 only
+				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
+				temp = remaining / animation.duration || 0,
+				percent = 1 - temp,
+				index = 0,
+				length = animation.tweens.length;
+
+			for ( ; index < length; index++ ) {
+				animation.tweens[ index ].run( percent );
+			}
+
+			deferred.notifyWith( elem, [ animation, percent, remaining ] );
+
+			// If there's more to do, yield
+			if ( percent < 1 && length ) {
+				return remaining;
+			}
+
+			// If this was an empty animation, synthesize a final progress notification
+			if ( !length ) {
+				deferred.notifyWith( elem, [ animation, 1, 0 ] );
+			}
+
+			// Resolve the animation and report its conclusion
+			deferred.resolveWith( elem, [ animation ] );
+			return false;
+		},
+		animation = deferred.promise( {
+			elem: elem,
+			props: jQuery.extend( {}, properties ),
+			opts: jQuery.extend( true, {
+				specialEasing: {},
+				easing: jQuery.easing._default
+			}, options ),
+			originalProperties: properties,
+			originalOptions: options,
+			startTime: fxNow || createFxNow(),
+			duration: options.duration,
+			tweens: [],
+			createTween: function( prop, end ) {
+				var tween = jQuery.Tween( elem, animation.opts, prop, end,
+						animation.opts.specialEasing[ prop ] || animation.opts.easing );
+				animation.tweens.push( tween );
+				return tween;
+			},
+			stop: function( gotoEnd ) {
+				var index = 0,
+
+					// If we are going to the end, we want to run all the tweens
+					// otherwise we skip this part
+					length = gotoEnd ? animation.tweens.length : 0;
+				if ( stopped ) {
+					return this;
+				}
+				stopped = true;
+				for ( ; index < length; index++ ) {
+					animation.tweens[ index ].run( 1 );
+				}
+
+				// Resolve when we played the last frame; otherwise, reject
+				if ( gotoEnd ) {
+					deferred.notifyWith( elem, [ animation, 1, 0 ] );
+					deferred.resolveWith( elem, [ animation, gotoEnd ] );
+				} else {
+					deferred.rejectWith( elem, [ animation, gotoEnd ] );
+				}
+				return this;
+			}
+		} ),
+		props = animation.props;
+
+	propFilter( props, animation.opts.specialEasing );
+
+	for ( ; index < length; index++ ) {
+		result = Animation.prefilters[ index ].call( animation, elem, props, animation.opts );
+		if ( result ) {
+			if ( isFunction( result.stop ) ) {
+				jQuery._queueHooks( animation.elem, animation.opts.queue ).stop =
+					result.stop.bind( result );
+			}
+			return result;
+		}
+	}
+
+	jQuery.map( props, createTween, animation );
+
+	if ( isFunction( animation.opts.start ) ) {
+		animation.opts.start.call( elem, animation );
+	}
+
+	// Attach callbacks from options
+	animation
+		.progress( animation.opts.progress )
+		.done( animation.opts.done, animation.opts.complete )
+		.fail( animation.opts.fail )
+		.always( animation.opts.always );
+
+	jQuery.fx.timer(
+		jQuery.extend( tick, {
+			elem: elem,
+			anim: animation,
+			queue: animation.opts.queue
+		} )
+	);
+
+	return animation;
+}
+
+jQuery.Animation = jQuery.extend( Animation, {
+
+	tweeners: {
+		"*": [ function( prop, value ) {
+			var tween = this.createTween( prop, value );
+			adjustCSS( tween.elem, prop, rcssNum.exec( value ), tween );
+			return tween;
+		} ]
+	},
+
+	tweener: function( props, callback ) {
+		if ( isFunction( props ) ) {
+			callback = props;
+			props = [ "*" ];
+		} else {
+			props = props.match( rnothtmlwhite );
+		}
+
+		var prop,
+			index = 0,
+			length = props.length;
+
+		for ( ; index < length; index++ ) {
+			prop = props[ index ];
+			Animation.tweeners[ prop ] = Animation.tweeners[ prop ] || [];
+			Animation.tweeners[ prop ].unshift( callback );
+		}
+	},
+
+	prefilters: [ defaultPrefilter ],
+
+	prefilter: function( callback, prepend ) {
+		if ( prepend ) {
+			Animation.prefilters.unshift( callback );
+		} else {
+			Animation.prefilters.push( callback );
+		}
+	}
+} );
+
+jQuery.speed = function( speed, easing, fn ) {
+	var opt = speed && typeof speed === "object" ? jQuery.extend( {}, speed ) : {
+		complete: fn || !fn && easing ||
+			isFunction( speed ) && speed,
+		duration: speed,
+		easing: fn && easing || easing && !isFunction( easing ) && easing
+	};
+
+	// Go to the end state if fx are off
+	if ( jQuery.fx.off ) {
+		opt.duration = 0;
+
+	} else {
+		if ( typeof opt.duration !== "number" ) {
+			if ( opt.duration in jQuery.fx.speeds ) {
+				opt.duration = jQuery.fx.speeds[ opt.duration ];
+
+			} else {
+				opt.duration = jQuery.fx.speeds._default;
+			}
+		}
+	}
+
+	// Normalize opt.queue - true/undefined/null -> "fx"
+	if ( opt.queue == null || opt.queue === true ) {
+		opt.queue = "fx";
+	}
+
+	// Queueing
+	opt.old = opt.complete;
+
+	opt.complete = function() {
+		if ( isFunction( opt.old ) ) {
+			opt.old.call( this );
+		}
+
+		if ( opt.queue ) {
+			jQuery.dequeue( this, opt.queue );
+		}
+	};
+
+	return opt;
+};
+
+jQuery.fn.extend( {
+	fadeTo: function( speed, to, easing, callback ) {
+
+		// Show any hidden elements after setting opacity to 0
+		return this.filter( isHiddenWithinTree ).css( "opacity", 0 ).show()
+
+			// Animate to the value specified
+			.end().animate( { opacity: to }, speed, easing, callback );
+	},
+	animate: function( prop, speed, easing, callback ) {
+		var empty = jQuery.isEmptyObject( prop ),
+			optall = jQuery.speed( speed, easing, callback ),
+			doAnimation = function() {
+
+				// Operate on a copy of prop so per-property easing won't be lost
+				var anim = Animation( this, jQuery.extend( {}, prop ), optall );
+
+				// Empty animations, or finishing resolves immediately
+				if ( empty || dataPriv.get( this, "finish" ) ) {
+					anim.stop( true );
+				}
+			};
+			doAnimation.finish = doAnimation;
+
+		return empty || optall.queue === false ?
+			this.each( doAnimation ) :
+			this.queue( optall.queue, doAnimation );
+	},
+	stop: function( type, clearQueue, gotoEnd ) {
+		var stopQueue = function( hooks ) {
+			var stop = hooks.stop;
+			delete hooks.stop;
+			stop( gotoEnd );
+		};
+
+		if ( typeof type !== "string" ) {
+			gotoEnd = clearQueue;
+			clearQueue = type;
+			type = undefined;
+		}
+		if ( clearQueue && type !== false ) {
+			this.queue( type || "fx", [] );
+		}
+
+		return this.each( function() {
+			var dequeue = true,
+				index = type != null && type + "queueHooks",
+				timers = jQuery.timers,
+				data = dataPriv.get( this );
+
+			if ( index ) {
+				if ( data[ index ] && data[ index ].stop ) {
+					stopQueue( data[ index ] );
+				}
+			} else {
+				for ( index in data ) {
+					if ( data[ index ] && data[ index ].stop && rrun.test( index ) ) {
+						stopQueue( data[ index ] );
+					}
+				}
+			}
+
+			for ( index = timers.length; index--; ) {
+				if ( timers[ index ].elem === this &&
+					( type == null || timers[ index ].queue === type ) ) {
+
+					timers[ index ].anim.stop( gotoEnd );
+					dequeue = false;
+					timers.splice( index, 1 );
+				}
+			}
+
+			// Start the next in the queue if the last step wasn't forced.
+			// Timers currently will call their complete callbacks, which
+			// will dequeue but only if they were gotoEnd.
+			if ( dequeue || !gotoEnd ) {
+				jQuery.dequeue( this, type );
+			}
+		} );
+	},
+	finish: function( type ) {
+		if ( type !== false ) {
+			type = type || "fx";
+		}
+		return this.each( function() {
+			var index,
+				data = dataPriv.get( this ),
+				queue = data[ type + "queue" ],
+				hooks = data[ type + "queueHooks" ],
+				timers = jQuery.timers,
+				length = queue ? queue.length : 0;
+
+			// Enable finishing flag on private data
+			data.finish = true;
+
+			// Empty the queue first
+			jQuery.queue( this, type, [] );
+
+			if ( hooks && hooks.stop ) {
+				hooks.stop.call( this, true );
+			}
+
+			// Look for any active animations, and finish them
+			for ( index = timers.length; index--; ) {
+				if ( timers[ index ].elem === this && timers[ index ].queue === type ) {
+					timers[ index ].anim.stop( true );
+					timers.splice( index, 1 );
+				}
+			}
+
+			// Look for any animations in the old queue and finish them
+			for ( index = 0; index < length; index++ ) {
+				if ( queue[ index ] && queue[ index ].finish ) {
+					queue[ index ].finish.call( this );
+				}
+			}
+
+			// Turn off finishing flag
+			delete data.finish;
+		} );
+	}
+} );
+
+jQuery.each( [ "toggle", "show", "hide" ], function( i, name ) {
+	var cssFn = jQuery.fn[ name ];
+	jQuery.fn[ name ] = function( speed, easing, callback ) {
+		return speed == null || typeof speed === "boolean" ?
+			cssFn.apply( this, arguments ) :
+			this.animate( genFx( name, true ), speed, easing, callback );
+	};
+} );
+
+// Generate shortcuts for custom animations
+jQuery.each( {
+	slideDown: genFx( "show" ),
+	slideUp: genFx( "hide" ),
+	slideToggle: genFx( "toggle" ),
+	fadeIn: { opacity: "show" },
+	fadeOut: { opacity: "hide" },
+	fadeToggle: { opacity: "toggle" }
+}, function( name, props ) {
+	jQuery.fn[ name ] = function( speed, easing, callback ) {
+		return this.animate( props, speed, easing, callback );
+	};
+} );
+
+jQuery.timers = [];
+jQuery.fx.tick = function() {
+	var timer,
+		i = 0,
+		timers = jQuery.timers;
+
+	fxNow = Date.now();
+
+	for ( ; i < timers.length; i++ ) {
+		timer = timers[ i ];
+
+		// Run the timer and safely remove it when done (allowing for external removal)
+		if ( !timer() && timers[ i ] === timer ) {
+			timers.splice( i--, 1 );
+		}
+	}
+
+	if ( !timers.length ) {
+		jQuery.fx.stop();
+	}
+	fxNow = undefined;
+};
+
+jQuery.fx.timer = function( timer ) {
+	jQuery.timers.push( timer );
+	jQuery.fx.start();
+};
+
+jQuery.fx.interval = 13;
+jQuery.fx.start = function() {
+	if ( inProgress ) {
+		return;
+	}
+
+	inProgress = true;
+	schedule();
+};
+
+jQuery.fx.stop = function() {
+	inProgress = null;
+};
+
+jQuery.fx.speeds = {
+	slow: 600,
+	fast: 200,
+
+	// Default speed
+	_default: 400
+};
+
+
+// Based off of the plugin by Clint Helfers, with permission.
+// https://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
+jQuery.fn.delay = function( time, type ) {
+	time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
+	type = type || "fx";
+
+	return this.queue( type, function( next, hooks ) {
+		var timeout = window.setTimeout( next, time );
+		hooks.stop = function() {
+			window.clearTimeout( timeout );
+		};
+	} );
+};
+
+
+( function() {
+	var input = document.createElement( "input" ),
+		select = document.createElement( "select" ),
+		opt = select.appendChild( document.createElement( "option" ) );
+
+	input.type = "checkbox";
+
+	// Support: Android <=4.3 only
+	// Default value for a checkbox should be "on"
+	support.checkOn = input.value !== "";
+
+	// Support: IE <=11 only
+	// Must access selectedIndex to make default options select
+	support.optSelected = opt.selected;
+
+	// Support: IE <=11 only
+	// An input loses its value after becoming a radio
+	input = document.createElement( "input" );
+	input.value = "t";
+	input.type = "radio";
+	support.radioValue = input.value === "t";
+} )();
+
+
+var boolHook,
+	attrHandle = jQuery.expr.attrHandle;
+
+jQuery.fn.extend( {
+	attr: function( name, value ) {
+		return access( this, jQuery.attr, name, value, arguments.length > 1 );
+	},
+
+	removeAttr: function( name ) {
+		return this.each( function() {
+			jQuery.removeAttr( this, name );
+		} );
+	}
+} );
+
+jQuery.extend( {
+	attr: function( elem, name, value ) {
+		var ret, hooks,
+			nType = elem.nodeType;
+
+		// Don't get/set attributes on text, comment and attribute nodes
+		if ( nType === 3 || nType === 8 || nType === 2 ) {
+			return;
+		}
+
+		// Fallback to prop when attributes are not supported
+		if ( typeof elem.getAttribute === "undefined" ) {
+			return jQuery.prop( elem, name, value );
+		}
+
+		// Attribute hooks are determined by the lowercase version
+		// Grab necessary hook if one is defined
+		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
+			hooks = jQuery.attrHooks[ name.toLowerCase() ] ||
+				( jQuery.expr.match.bool.test( name ) ? boolHook : undefined );
+		}
+
+		if ( value !== undefined ) {
+			if ( value === null ) {
+				jQuery.removeAttr( elem, name );
+				return;
+			}
+
+			if ( hooks && "set" in hooks &&
+				( ret = hooks.set( elem, value, name ) ) !== undefined ) {
+				return ret;
+			}
+
+			elem.setAttribute( name, value + "" );
+			return value;
+		}
+
+		if ( hooks && "get" in hooks && ( ret = hooks.get( elem, name ) ) !== null ) {
+			return ret;
+		}
+
+		ret = jQuery.find.attr( elem, name );
+
+		// Non-existent attributes return null, we normalize to undefined
+		return ret == null ? undefined : ret;
+	},
+
+	attrHooks: {
+		type: {
+			set: function( elem, value ) {
+				if ( !support.radioValue && value === "radio" &&
+					nodeName( elem, "input" ) ) {
+					var val = elem.value;
+					elem.setAttribute( "type", value );
+					if ( val ) {
+						elem.value = val;
+					}
+					return value;
+				}
+			}
+		}
+	},
+
+	removeAttr: function( elem, value ) {
+		var name,
+			i = 0,
+
+			// Attribute names can contain non-HTML whitespace characters
+			// https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+			attrNames = value && value.match( rnothtmlwhite );
+
+		if ( attrNames && elem.nodeType === 1 ) {
+			while ( ( name = attrNames[ i++ ] ) ) {
+				elem.removeAttribute( name );
+			}
+		}
+	}
+} );
+
+// Hooks for boolean attributes
+boolHook = {
+	set: function( elem, value, name ) {
+		if ( value === false ) {
+
+			// Remove boolean attributes when set to false
+			jQuery.removeAttr( elem, name );
+		} else {
+			elem.setAttribute( name, name );
+		}
+		return name;
+	}
+};
+
+jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
+	var getter = attrHandle[ name ] || jQuery.find.attr;
+
+	attrHandle[ name ] = function( elem, name, isXML ) {
+		var ret, handle,
+			lowercaseName = name.toLowerCase();
+
+		if ( !isXML ) {
+
+			// Avoid an infinite loop by temporarily removing this function from the getter
+			handle = attrHandle[ lowercaseName ];
+			attrHandle[ lowercaseName ] = ret;
+			ret = getter( elem, name, isXML ) != null ?
+				lowercaseName :
+				null;
+			attrHandle[ lowercaseName ] = handle;
+		}
+		return ret;
+	};
+} );
+
+
+
+
+var rfocusable = /^(?:input|select|textarea|button)$/i,
+	rclickable = /^(?:a|area)$/i;
+
+jQuery.fn.extend( {
+	prop: function( name, value ) {
+		return access( this, jQuery.prop, name, value, arguments.length > 1 );
+	},
+
+	removeProp: function( name ) {
+		return this.each( function() {
+			delete this[ jQuery.propFix[ name ] || name ];
+		} );
+	}
+} );
+
+jQuery.extend( {
+	prop: function( elem, name, value ) {
+		var ret, hooks,
+			nType = elem.nodeType;
+
+		// Don't get/set properties on text, comment and attribute nodes
+		if ( nType === 3 || nType === 8 || nType === 2 ) {
+			return;
+		}
+
+		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
+
+			// Fix name and attach hooks
+			name = jQuery.propFix[ name ] || name;
+			hooks = jQuery.propHooks[ name ];
+		}
+
+		if ( value !== undefined ) {
+			if ( hooks && "set" in hooks &&
+				( ret = hooks.set( elem, value, name ) ) !== undefined ) {
+				return ret;
+			}
+
+			return ( elem[ name ] = value );
+		}
+
+		if ( hooks && "get" in hooks && ( ret = hooks.get( elem, name ) ) !== null ) {
+			return ret;
+		}
+
+		return elem[ name ];
+	},
+
+	propHooks: {
+		tabIndex: {
+			get: function( elem ) {
+
+				// Support: IE <=9 - 11 only
+				// elem.tabIndex doesn't always return the
+				// correct value when it hasn't been explicitly set
+				// https://web.archive.org/web/20141116233347/http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
+				// Use proper attribute retrieval(#12072)
+				var tabindex = jQuery.find.attr( elem, "tabindex" );
+
+				if ( tabindex ) {
+					return parseInt( tabindex, 10 );
+				}
+
+				if (
+					rfocusable.test( elem.nodeName ) ||
+					rclickable.test( elem.nodeName ) &&
+					elem.href
+				) {
+					return 0;
+				}
+
+				return -1;
+			}
+		}
+	},
+
+	propFix: {
+		"for": "htmlFor",
+		"class": "className"
+	}
+} );
+
+// Support: IE <=11 only
+// Accessing the selectedIndex property
+// forces the browser to respect setting selected
+// on the option
+// The getter ensures a default option is selected
+// when in an optgroup
+// eslint rule "no-unused-expressions" is disabled for this code
+// since it considers such accessions noop
+if ( !support.optSelected ) {
+	jQuery.propHooks.selected = {
+		get: function( elem ) {
+
+			/* eslint no-unused-expressions: "off" */
+
+			var parent = elem.parentNode;
+			if ( parent && parent.parentNode ) {
+				parent.parentNode.selectedIndex;
+			}
+			return null;
+		},
+		set: function( elem ) {
+
+			/* eslint no-unused-expressions: "off" */
+
+			var parent = elem.parentNode;
+			if ( parent ) {
+				parent.selectedIndex;
+
+				if ( parent.parentNode ) {
+					parent.parentNode.selectedIndex;
+				}
+			}
+		}
+	};
+}
+
+jQuery.each( [
+	"tabIndex",
+	"readOnly",
+	"maxLength",
+	"cellSpacing",
+	"cellPadding",
+	"rowSpan",
+	"colSpan",
+	"useMap",
+	"frameBorder",
+	"contentEditable"
+], function() {
+	jQuery.propFix[ this.toLowerCase() ] = this;
+} );
+
+
+
+
+	// Strip and collapse whitespace according to HTML spec
+	// https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace
+	function stripAndCollapse( value ) {
+		var tokens = value.match( rnothtmlwhite ) || [];
+		return tokens.join( " " );
+	}
+
+
+function getClass( elem ) {
+	return elem.getAttribute && elem.getAttribute( "class" ) || "";
+}
+
+function classesToArray( value ) {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	if ( typeof value === "string" ) {
+		return value.match( rnothtmlwhite ) || [];
+	}
+	return [];
+}
+
+jQuery.fn.extend( {
+	addClass: function( value ) {
+		var classes, elem, cur, curValue, clazz, j, finalValue,
+			i = 0;
+
+		if ( isFunction( value ) ) {
+			return this.each( function( j ) {
+				jQuery( this ).addClass( value.call( this, j, getClass( this ) ) );
+			} );
+		}
+
+		classes = classesToArray( value );
+
+		if ( classes.length ) {
+			while ( ( elem = this[ i++ ] ) ) {
+				curValue = getClass( elem );
+				cur = elem.nodeType === 1 && ( " " + stripAndCollapse( curValue ) + " " );
+
+				if ( cur ) {
+					j = 0;
+					while ( ( clazz = classes[ j++ ] ) ) {
+						if ( cur.indexOf( " " + clazz + " " ) < 0 ) {
+							cur += clazz + " ";
+						}
+					}
+
+					// Only assign if different to avoid unneeded rendering.
+					finalValue = stripAndCollapse( cur );
+					if ( curValue !== finalValue ) {
+						elem.setAttribute( "class", finalValue );
+					}
+				}
+			}
+		}
+
+		return this;
+	},
+
+	removeClass: function( value ) {
+		var classes, elem, cur, curValue, clazz, j, finalValue,
+			i = 0;
+
+		if ( isFunction( value ) ) {
+			return this.each( function( j ) {
+				jQuery( this ).removeClass( value.call( this, j, getClass( this ) ) );
+			} );
+		}
+
+		if ( !arguments.length ) {
+			return this.attr( "class", "" );
+		}
+
+		classes = classesToArray( value );
+
+		if ( classes.length ) {
+			while ( ( elem = this[ i++ ] ) ) {
+				curValue = getClass( elem );
+
+				// This expression is here for better compressibility (see addClass)
+				cur = elem.nodeType === 1 && ( " " + stripAndCollapse( curValue ) + " " );
+
+				if ( cur ) {
+					j = 0;
+					while ( ( clazz = classes[ j++ ] ) ) {
+
+						// Remove *all* instances
+						while ( cur.indexOf( " " + clazz + " " ) > -1 ) {
+							cur = cur.replace( " " + clazz + " ", " " );
+						}
+					}
+
+					// Only assign if different to avoid unneeded rendering.
+					finalValue = stripAndCollapse( cur );
+					if ( curValue !== finalValue ) {
+						elem.setAttribute( "class", finalValue );
+					}
+				}
+			}
+		}
+
+		return this;
+	},
+
+	toggleClass: function( value, stateVal ) {
+		var type = typeof value,
+			isValidValue = type === "string" || Array.isArray( value );
+
+		if ( typeof stateVal === "boolean" && isValidValue ) {
+			return stateVal ? this.addClass( value ) : this.removeClass( value );
+		}
+
+		if ( isFunction( value ) ) {
+			return this.each( function( i ) {
+				jQuery( this ).toggleClass(
+					value.call( this, i, getClass( this ), stateVal ),
+					stateVal
+				);
+			} );
+		}
+
+		return this.each( function() {
+			var className, i, self, classNames;
+
+			if ( isValidValue ) {
+
+				// Toggle individual class names
+				i = 0;
+				self = jQuery( this );
+				classNames = classesToArray( value );
+
+				while ( ( className = classNames[ i++ ] ) ) {
+
+					// Check each className given, space separated list
+					if ( self.hasClass( className ) ) {
+						self.removeClass( className );
+					} else {
+						self.addClass( className );
+					}
+				}
+
+			// Toggle whole class name
+			} else if ( value === undefined || type === "boolean" ) {
+				className = getClass( this );
+				if ( className ) {
+
+					// Store className if set
+					dataPriv.set( this, "__className__", className );
+				}
+
+				// If the element has a class name or if we're passed `false`,
+				// then remove the whole classname (if there was one, the above saved it).
+				// Otherwise bring back whatever was previously saved (if anything),
+				// falling back to the empty string if nothing was stored.
+				if ( this.setAttribute ) {
+					this.setAttribute( "class",
+						className || value === false ?
+						"" :
+						dataPriv.get( this, "__className__" ) || ""
+					);
+				}
+			}
+		} );
+	},
+
+	hasClass: function( selector ) {
+		var className, elem,
+			i = 0;
+
+		className = " " + selector + " ";
+		while ( ( elem = this[ i++ ] ) ) {
+			if ( elem.nodeType === 1 &&
+				( " " + stripAndCollapse( getClass( elem ) ) + " " ).indexOf( className ) > -1 ) {
+					return true;
+			}
+		}
+
+		return false;
+	}
+} );
+
+
+
+
+var rreturn = /\r/g;
+
+jQuery.fn.extend( {
+	val: function( value ) {
+		var hooks, ret, valueIsFunction,
+			elem = this[ 0 ];
+
+		if ( !arguments.length ) {
+			if ( elem ) {
+				hooks = jQuery.valHooks[ elem.type ] ||
+					jQuery.valHooks[ elem.nodeName.toLowerCase() ];
+
+				if ( hooks &&
+					"get" in hooks &&
+					( ret = hooks.get( elem, "value" ) ) !== undefined
+				) {
+					return ret;
+				}
+
+				ret = elem.value;
+
+				// Handle most common string cases
+				if ( typeof ret === "string" ) {
+					return ret.replace( rreturn, "" );
+				}
+
+				// Handle cases where value is null/undef or number
+				return ret == null ? "" : ret;
+			}
+
+			return;
+		}
+
+		valueIsFunction = isFunction( value );
+
+		return this.each( function( i ) {
+			var val;
+
+			if ( this.nodeType !== 1 ) {
+				return;
+			}
+
+			if ( valueIsFunction ) {
+				val = value.call( this, i, jQuery( this ).val() );
+			} else {
+				val = value;
+			}
+
+			// Treat null/undefined as ""; convert numbers to string
+			if ( val == null ) {
+				val = "";
+
+			} else if ( typeof val === "number" ) {
+				val += "";
+
+			} else if ( Array.isArray( val ) ) {
+				val = jQuery.map( val, function( value ) {
+					return value == null ? "" : value + "";
+				} );
+			}
+
+			hooks = jQuery.valHooks[ this.type ] || jQuery.valHooks[ this.nodeName.toLowerCase() ];
+
+			// If set returns undefined, fall back to normal setting
+			if ( !hooks || !( "set" in hooks ) || hooks.set( this, val, "value" ) === undefined ) {
+				this.value = val;
+			}
+		} );
+	}
+} );
+
+jQuery.extend( {
+	valHooks: {
+		option: {
+			get: function( elem ) {
+
+				var val = jQuery.find.attr( elem, "value" );
+				return val != null ?
+					val :
+
+					// Support: IE <=10 - 11 only
+					// option.text throws exceptions (#14686, #14858)
+					// Strip and collapse whitespace
+					// https://html.spec.whatwg.org/#strip-and-collapse-whitespace
+					stripAndCollapse( jQuery.text( elem ) );
+			}
+		},
+		select: {
+			get: function( elem ) {
+				var value, option, i,
+					options = elem.options,
+					index = elem.selectedIndex,
+					one = elem.type === "select-one",
+					values = one ? null : [],
+					max = one ? index + 1 : options.length;
+
+				if ( index < 0 ) {
+					i = max;
+
+				} else {
+					i = one ? index : 0;
+				}
+
+				// Loop through all the selected options
+				for ( ; i < max; i++ ) {
+					option = options[ i ];
+
+					// Support: IE <=9 only
+					// IE8-9 doesn't update selected after form reset (#2551)
+					if ( ( option.selected || i === index ) &&
+
+							// Don't return options that are disabled or in a disabled optgroup
+							!option.disabled &&
+							( !option.parentNode.disabled ||
+								!nodeName( option.parentNode, "optgroup" ) ) ) {
+
+						// Get the specific value for the option
+						value = jQuery( option ).val();
+
+						// We don't need an array for one selects
+						if ( one ) {
+							return value;
+						}
+
+						// Multi-Selects return an array
+						values.push( value );
+					}
+				}
+
+				return values;
+			},
+
+			set: function( elem, value ) {
+				var optionSet, option,
+					options = elem.options,
+					values = jQuery.makeArray( value ),
+					i = options.length;
+
+				while ( i-- ) {
+					option = options[ i ];
+
+					/* eslint-disable no-cond-assign */
+
+					if ( option.selected =
+						jQuery.inArray( jQuery.valHooks.option.get( option ), values ) > -1
+					) {
+						optionSet = true;
+					}
+
+					/* eslint-enable no-cond-assign */
+				}
+
+				// Force browsers to behave consistently when non-matching value is set
+				if ( !optionSet ) {
+					elem.selectedIndex = -1;
+				}
+				return values;
+			}
+		}
+	}
+} );
+
+// Radios and checkboxes getter/setter
+jQuery.each( [ "radio", "checkbox" ], function() {
+	jQuery.valHooks[ this ] = {
+		set: function( elem, value ) {
+			if ( Array.isArray( value ) ) {
+				return ( elem.checked = jQuery.inArray( jQuery( elem ).val(), value ) > -1 );
+			}
+		}
+	};
+	if ( !support.checkOn ) {
+		jQuery.valHooks[ this ].get = function( elem ) {
+			return elem.getAttribute( "value" ) === null ? "on" : elem.value;
+		};
+	}
+} );
+
+
+
+
+// Return jQuery for attributes-only inclusion
+
+
+support.focusin = "onfocusin" in window;
+
+
+var rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
+	stopPropagationCallback = function( e ) {
+		e.stopPropagation();
+	};
+
+jQuery.extend( jQuery.event, {
+
+	trigger: function( event, data, elem, onlyHandlers ) {
+
+		var i, cur, tmp, bubbleType, ontype, handle, special, lastElement,
+			eventPath = [ elem || document ],
+			type = hasOwn.call( event, "type" ) ? event.type : event,
+			namespaces = hasOwn.call( event, "namespace" ) ? event.namespace.split( "." ) : [];
+
+		cur = lastElement = tmp = elem = elem || document;
+
+		// Don't do events on text and comment nodes
+		if ( elem.nodeType === 3 || elem.nodeType === 8 ) {
+			return;
+		}
+
+		// focus/blur morphs to focusin/out; ensure we're not firing them right now
+		if ( rfocusMorph.test( type + jQuery.event.triggered ) ) {
+			return;
+		}
+
+		if ( type.indexOf( "." ) > -1 ) {
+
+			// Namespaced trigger; create a regexp to match event type in handle()
+			namespaces = type.split( "." );
+			type = namespaces.shift();
+			namespaces.sort();
+		}
+		ontype = type.indexOf( ":" ) < 0 && "on" + type;
+
+		// Caller can pass in a jQuery.Event object, Object, or just an event type string
+		event = event[ jQuery.expando ] ?
+			event :
+			new jQuery.Event( type, typeof event === "object" && event );
+
+		// Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
+		event.isTrigger = onlyHandlers ? 2 : 3;
+		event.namespace = namespaces.join( "." );
+		event.rnamespace = event.namespace ?
+			new RegExp( "(^|\\.)" + namespaces.join( "\\.(?:.*\\.|)" ) + "(\\.|$)" ) :
+			null;
+
+		// Clean up the event in case it is being reused
+		event.result = undefined;
+		if ( !event.target ) {
+			event.target = elem;
+		}
+
+		// Clone any incoming data and prepend the event, creating the handler arg list
+		data = data == null ?
+			[ event ] :
+			jQuery.makeArray( data, [ event ] );
+
+		// Allow special events to draw outside the lines
+		special = jQuery.event.special[ type ] || {};
+		if ( !onlyHandlers && special.trigger && special.trigger.apply( elem, data ) === false ) {
+			return;
+		}
+
+		// Determine event propagation path in advance, per W3C events spec (#9951)
+		// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
+		if ( !onlyHandlers && !special.noBubble && !isWindow( elem ) ) {
+
+			bubbleType = special.delegateType || type;
+			if ( !rfocusMorph.test( bubbleType + type ) ) {
+				cur = cur.parentNode;
+			}
+			for ( ; cur; cur = cur.parentNode ) {
+				eventPath.push( cur );
+				tmp = cur;
+			}
+
+			// Only add window if we got to document (e.g., not plain obj or detached DOM)
+			if ( tmp === ( elem.ownerDocument || document ) ) {
+				eventPath.push( tmp.defaultView || tmp.parentWindow || window );
+			}
+		}
+
+		// Fire handlers on the event path
+		i = 0;
+		while ( ( cur = eventPath[ i++ ] ) && !event.isPropagationStopped() ) {
+			lastElement = cur;
+			event.type = i > 1 ?
+				bubbleType :
+				special.bindType || type;
+
+			// jQuery handler
+			handle = ( dataPriv.get( cur, "events" ) || {} )[ event.type ] &&
+				dataPriv.get( cur, "handle" );
+			if ( handle ) {
+				handle.apply( cur, data );
+			}
+
+			// Native handler
+			handle = ontype && cur[ ontype ];
+			if ( handle && handle.apply && acceptData( cur ) ) {
+				event.result = handle.apply( cur, data );
+				if ( event.result === false ) {
+					event.preventDefault();
+				}
+			}
+		}
+		event.type = type;
+
+		// If nobody prevented the default action, do it now
+		if ( !onlyHandlers && !event.isDefaultPrevented() ) {
+
+			if ( ( !special._default ||
+				special._default.apply( eventPath.pop(), data ) === false ) &&
+				acceptData( elem ) ) {
+
+				// Call a native DOM method on the target with the same name as the event.
+				// Don't do default actions on window, that's where global variables be (#6170)
+				if ( ontype && isFunction( elem[ type ] ) && !isWindow( elem ) ) {
+
+					// Don't re-trigger an onFOO event when we call its FOO() method
+					tmp = elem[ ontype ];
+
+					if ( tmp ) {
+						elem[ ontype ] = null;
+					}
+
+					// Prevent re-triggering of the same event, since we already bubbled it above
+					jQuery.event.triggered = type;
+
+					if ( event.isPropagationStopped() ) {
+						lastElement.addEventListener( type, stopPropagationCallback );
+					}
+
+					elem[ type ]();
+
+					if ( event.isPropagationStopped() ) {
+						lastElement.removeEventListener( type, stopPropagationCallback );
+					}
+
+					jQuery.event.triggered = undefined;
+
+					if ( tmp ) {
+						elem[ ontype ] = tmp;
+					}
+				}
+			}
+		}
+
+		return event.result;
+	},
+
+	// Piggyback on a donor event to simulate a different one
+	// Used only for `focus(in | out)` events
+	simulate: function( type, elem, event ) {
+		var e = jQuery.extend(
+			new jQuery.Event(),
+			event,
+			{
+				type: type,
+				isSimulated: true
+			}
+		);
+
+		jQuery.event.trigger( e, null, elem );
+	}
+
+} );
+
+jQuery.fn.extend( {
+
+	trigger: function( type, data ) {
+		return this.each( function() {
+			jQuery.event.trigger( type, data, this );
+		} );
+	},
+	triggerHandler: function( type, data ) {
+		var elem = this[ 0 ];
+		if ( elem ) {
+			return jQuery.event.trigger( type, data, elem, true );
+		}
+	}
+} );
+
+
+// Support: Firefox <=44
+// Firefox doesn't have focus(in | out) events
+// Related ticket - https://bugzilla.mozilla.org/show_bug.cgi?id=687787
+//
+// Support: Chrome <=48 - 49, Safari <=9.0 - 9.1
+// focus(in | out) events fire after focus & blur events,
+// which is spec violation - http://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
+// Related ticket - https://bugs.chromium.org/p/chromium/issues/detail?id=449857
+if ( !support.focusin ) {
+	jQuery.each( { focus: "focusin", blur: "focusout" }, function( orig, fix ) {
+
+		// Attach a single capturing handler on the document while someone wants focusin/focusout
+		var handler = function( event ) {
+			jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ) );
+		};
+
+		jQuery.event.special[ fix ] = {
+			setup: function() {
+				var doc = this.ownerDocument || this,
+					attaches = dataPriv.access( doc, fix );
+
+				if ( !attaches ) {
+					doc.addEventListener( orig, handler, true );
+				}
+				dataPriv.access( doc, fix, ( attaches || 0 ) + 1 );
+			},
+			teardown: function() {
+				var doc = this.ownerDocument || this,
+					attaches = dataPriv.access( doc, fix ) - 1;
+
+				if ( !attaches ) {
+					doc.removeEventListener( orig, handler, true );
+					dataPriv.remove( doc, fix );
+
+				} else {
+					dataPriv.access( doc, fix, attaches );
+				}
+			}
+		};
+	} );
+}
+var location = window.location;
+
+var nonce = Date.now();
+
+var rquery = ( /\?/ );
+
+
+
+// Cross-browser xml parsing
+jQuery.parseXML = function( data ) {
+	var xml;
+	if ( !data || typeof data !== "string" ) {
+		return null;
+	}
+
+	// Support: IE 9 - 11 only
+	// IE throws on parseFromString with invalid input.
+	try {
+		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
+	} catch ( e ) {
+		xml = undefined;
+	}
+
+	if ( !xml || xml.getElementsByTagName( "parsererror" ).length ) {
+		jQuery.error( "Invalid XML: " + data );
+	}
+	return xml;
+};
+
+
+var
+	rbracket = /\[\]$/,
+	rCRLF = /\r?\n/g,
+	rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
+	rsubmittable = /^(?:input|select|textarea|keygen)/i;
+
+function buildParams( prefix, obj, traditional, add ) {
+	var name;
+
+	if ( Array.isArray( obj ) ) {
+
+		// Serialize array item.
+		jQuery.each( obj, function( i, v ) {
+			if ( traditional || rbracket.test( prefix ) ) {
+
+				// Treat each array item as a scalar.
+				add( prefix, v );
+
+			} else {
+
+				// Item is non-scalar (array or object), encode its numeric index.
+				buildParams(
+					prefix + "[" + ( typeof v === "object" && v != null ? i : "" ) + "]",
+					v,
+					traditional,
+					add
+				);
+			}
+		} );
+
+	} else if ( !traditional && toType( obj ) === "object" ) {
+
+		// Serialize object item.
+		for ( name in obj ) {
+			buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
+		}
+
+	} else {
+
+		// Serialize scalar item.
+		add( prefix, obj );
+	}
+}
+
+// Serialize an array of form elements or a set of
+// key/values into a query string
+jQuery.param = function( a, traditional ) {
+	var prefix,
+		s = [],
+		add = function( key, valueOrFunction ) {
+
+			// If value is a function, invoke it and use its return value
+			var value = isFunction( valueOrFunction ) ?
+				valueOrFunction() :
+				valueOrFunction;
+
+			s[ s.length ] = encodeURIComponent( key ) + "=" +
+				encodeURIComponent( value == null ? "" : value );
+		};
+
+	if ( a == null ) {
+		return "";
+	}
+
+	// If an array was passed in, assume that it is an array of form elements.
+	if ( Array.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
+
+		// Serialize the form elements
+		jQuery.each( a, function() {
+			add( this.name, this.value );
+		} );
+
+	} else {
+
+		// If traditional, encode the "old" way (the way 1.3.2 or older
+		// did it), otherwise encode params recursively.
+		for ( prefix in a ) {
+			buildParams( prefix, a[ prefix ], traditional, add );
+		}
+	}
+
+	// Return the resulting serialization
+	return s.join( "&" );
+};
+
+jQuery.fn.extend( {
+	serialize: function() {
+		return jQuery.param( this.serializeArray() );
+	},
+	serializeArray: function() {
+		return this.map( function() {
+
+			// Can add propHook for "elements" to filter or add form elements
+			var elements = jQuery.prop( this, "elements" );
+			return elements ? jQuery.makeArray( elements ) : this;
+		} )
+		.filter( function() {
+			var type = this.type;
+
+			// Use .is( ":disabled" ) so that fieldset[disabled] works
+			return this.name && !jQuery( this ).is( ":disabled" ) &&
+				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
+				( this.checked || !rcheckableType.test( type ) );
+		} )
+		.map( function( i, elem ) {
+			var val = jQuery( this ).val();
+
+			if ( val == null ) {
+				return null;
+			}
+
+			if ( Array.isArray( val ) ) {
+				return jQuery.map( val, function( val ) {
+					return { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
+				} );
+			}
+
+			return { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
+		} ).get();
+	}
+} );
+
+
+var
+	r20 = /%20/g,
+	rhash = /#.*$/,
+	rantiCache = /([?&])_=[^&]*/,
+	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
+
+	// #7653, #8125, #8152: local protocol detection
+	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
+	rnoContent = /^(?:GET|HEAD)$/,
+	rprotocol = /^\/\//,
+
+	/* Prefilters
+	 * 1) They are useful to introduce custom dataTypes (see ajax/jsonp.js for an example)
+	 * 2) These are called:
+	 *    - BEFORE asking for a transport
+	 *    - AFTER param serialization (s.data is a string if s.processData is true)
+	 * 3) key is the dataType
+	 * 4) the catchall symbol "*" can be used
+	 * 5) execution will start with transport dataType and THEN continue down to "*" if needed
+	 */
+	prefilters = {},
+
+	/* Transports bindings
+	 * 1) key is the dataType
+	 * 2) the catchall symbol "*" can be used
+	 * 3) selection will start with transport dataType and THEN go to "*" if needed
+	 */
+	transports = {},
+
+	// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
+	allTypes = "*/".concat( "*" ),
+
+	// Anchor tag for parsing the document origin
+	originAnchor = document.createElement( "a" );
+	originAnchor.href = location.href;
+
+// Base "constructor" for jQuery.ajaxPrefilter and jQuery.ajaxTransport
+function addToPrefiltersOrTransports( structure ) {
+
+	// dataTypeExpression is optional and defaults to "*"
+	return function( dataTypeExpression, func ) {
+
+		if ( typeof dataTypeExpression !== "string" ) {
+			func = dataTypeExpression;
+			dataTypeExpression = "*";
+		}
+
+		var dataType,
+			i = 0,
+			dataTypes = dataTypeExpression.toLowerCase().match( rnothtmlwhite ) || [];
+
+		if ( isFunction( func ) ) {
+
+			// For each dataType in the dataTypeExpression
+			while ( ( dataType = dataTypes[ i++ ] ) ) {
+
+				// Prepend if requested
+				if ( dataType[ 0 ] === "+" ) {
+					dataType = dataType.slice( 1 ) || "*";
+					( structure[ dataType ] = structure[ dataType ] || [] ).unshift( func );
+
+				// Otherwise append
+				} else {
+					( structure[ dataType ] = structure[ dataType ] || [] ).push( func );
+				}
+			}
+		}
+	};
+}
+
+// Base inspection function for prefilters and transports
+function inspectPrefiltersOrTransports( structure, options, originalOptions, jqXHR ) {
+
+	var inspected = {},
+		seekingTransport = ( structure === transports );
+
+	function inspect( dataType ) {
+		var selected;
+		inspected[ dataType ] = true;
+		jQuery.each( structure[ dataType ] || [], function( _, prefilterOrFactory ) {
+			var dataTypeOrTransport = prefilterOrFactory( options, originalOptions, jqXHR );
+			if ( typeof dataTypeOrTransport === "string" &&
+				!seekingTransport && !inspected[ dataTypeOrTransport ] ) {
+
+				options.dataTypes.unshift( dataTypeOrTransport );
+				inspect( dataTypeOrTransport );
+				return false;
+			} else if ( seekingTransport ) {
+				return !( selected = dataTypeOrTransport );
+			}
+		} );
+		return selected;
+	}
+
+	return inspect( options.dataTypes[ 0 ] ) || !inspected[ "*" ] && inspect( "*" );
+}
+
+// A special extend for ajax options
+// that takes "flat" options (not to be deep extended)
+// Fixes #9887
+function ajaxExtend( target, src ) {
+	var key, deep,
+		flatOptions = jQuery.ajaxSettings.flatOptions || {};
+
+	for ( key in src ) {
+		if ( src[ key ] !== undefined ) {
+			( flatOptions[ key ] ? target : ( deep || ( deep = {} ) ) )[ key ] = src[ key ];
+		}
+	}
+	if ( deep ) {
+		jQuery.extend( true, target, deep );
+	}
+
+	return target;
+}
+
+/* Handles responses to an ajax request:
+ * - finds the right dataType (mediates between content-type and expected dataType)
+ * - returns the corresponding response
+ */
+function ajaxHandleResponses( s, jqXHR, responses ) {
+
+	var ct, type, finalDataType, firstDataType,
+		contents = s.contents,
+		dataTypes = s.dataTypes;
+
+	// Remove auto dataType and get content-type in the process
+	while ( dataTypes[ 0 ] === "*" ) {
+		dataTypes.shift();
+		if ( ct === undefined ) {
+			ct = s.mimeType || jqXHR.getResponseHeader( "Content-Type" );
+		}
+	}
+
+	// Check if we're dealing with a known content-type
+	if ( ct ) {
+		for ( type in contents ) {
+			if ( contents[ type ] && contents[ type ].test( ct ) ) {
+				dataTypes.unshift( type );
+				break;
+			}
+		}
+	}
+
+	// Check to see if we have a response for the expected dataType
+	if ( dataTypes[ 0 ] in responses ) {
+		finalDataType = dataTypes[ 0 ];
+	} else {
+
+		// Try convertible dataTypes
+		for ( type in responses ) {
+			if ( !dataTypes[ 0 ] || s.converters[ type + " " + dataTypes[ 0 ] ] ) {
+				finalDataType = type;
+				break;
+			}
+			if ( !firstDataType ) {
+				firstDataType = type;
+			}
+		}
+
+		// Or just use first one
+		finalDataType = finalDataType || firstDataType;
+	}
+
+	// If we found a dataType
+	// We add the dataType to the list if needed
+	// and return the corresponding response
+	if ( finalDataType ) {
+		if ( finalDataType !== dataTypes[ 0 ] ) {
+			dataTypes.unshift( finalDataType );
+		}
+		return responses[ finalDataType ];
+	}
+}
+
+/* Chain conversions given the request and the original response
+ * Also sets the responseXXX fields on the jqXHR instance
+ */
+function ajaxConvert( s, response, jqXHR, isSuccess ) {
+	var conv2, current, conv, tmp, prev,
+		converters = {},
+
+		// Work with a copy of dataTypes in case we need to modify it for conversion
+		dataTypes = s.dataTypes.slice();
+
+	// Create converters map with lowercased keys
+	if ( dataTypes[ 1 ] ) {
+		for ( conv in s.converters ) {
+			converters[ conv.toLowerCase() ] = s.converters[ conv ];
+		}
+	}
+
+	current = dataTypes.shift();
+
+	// Convert to each sequential dataType
+	while ( current ) {
+
+		if ( s.responseFields[ current ] ) {
+			jqXHR[ s.responseFields[ current ] ] = response;
+		}
+
+		// Apply the dataFilter if provided
+		if ( !prev && isSuccess && s.dataFilter ) {
+			response = s.dataFilter( response, s.dataType );
+		}
+
+		prev = current;
+		current = dataTypes.shift();
+
+		if ( current ) {
+
+			// There's only work to do if current dataType is non-auto
+			if ( current === "*" ) {
+
+				current = prev;
+
+			// Convert response if prev dataType is non-auto and differs from current
+			} else if ( prev !== "*" && prev !== current ) {
+
+				// Seek a direct converter
+				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
+
+				// If none found, seek a pair
+				if ( !conv ) {
+					for ( conv2 in converters ) {
+
+						// If conv2 outputs current
+						tmp = conv2.split( " " );
+						if ( tmp[ 1 ] === current ) {
+
+							// If prev can be converted to accepted input
+							conv = converters[ prev + " " + tmp[ 0 ] ] ||
+								converters[ "* " + tmp[ 0 ] ];
+							if ( conv ) {
+
+								// Condense equivalence converters
+								if ( conv === true ) {
+									conv = converters[ conv2 ];
+
+								// Otherwise, insert the intermediate dataType
+								} else if ( converters[ conv2 ] !== true ) {
+									current = tmp[ 0 ];
+									dataTypes.unshift( tmp[ 1 ] );
+								}
+								break;
+							}
+						}
+					}
+				}
+
+				// Apply converter (if not an equivalence)
+				if ( conv !== true ) {
+
+					// Unless errors are allowed to bubble, catch and return them
+					if ( conv && s.throws ) {
+						response = conv( response );
+					} else {
+						try {
+							response = conv( response );
+						} catch ( e ) {
+							return {
+								state: "parsererror",
+								error: conv ? e : "No conversion from " + prev + " to " + current
+							};
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return { state: "success", data: response };
+}
+
+jQuery.extend( {
+
+	// Counter for holding the number of active queries
+	active: 0,
+
+	// Last-Modified header cache for next request
+	lastModified: {},
+	etag: {},
+
+	ajaxSettings: {
+		url: location.href,
+		type: "GET",
+		isLocal: rlocalProtocol.test( location.protocol ),
+		global: true,
+		processData: true,
+		async: true,
+		contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+
+		/*
+		timeout: 0,
+		data: null,
+		dataType: null,
+		username: null,
+		password: null,
+		cache: null,
+		throws: false,
+		traditional: false,
+		headers: {},
+		*/
+
+		accepts: {
+			"*": allTypes,
+			text: "text/plain",
+			html: "text/html",
+			xml: "application/xml, text/xml",
+			json: "application/json, text/javascript"
+		},
+
+		contents: {
+			xml: /\bxml\b/,
+			html: /\bhtml/,
+			json: /\bjson\b/
+		},
+
+		responseFields: {
+			xml: "responseXML",
+			text: "responseText",
+			json: "responseJSON"
+		},
+
+		// Data converters
+		// Keys separate source (or catchall "*") and destination types with a single space
+		converters: {
+
+			// Convert anything to text
+			"* text": String,
+
+			// Text to html (true = no transformation)
+			"text html": true,
+
+			// Evaluate text as a json expression
+			"text json": JSON.parse,
+
+			// Parse text as xml
+			"text xml": jQuery.parseXML
+		},
+
+		// For options that shouldn't be deep extended:
+		// you can add your own custom options here if
+		// and when you create one that shouldn't be
+		// deep extended (see ajaxExtend)
+		flatOptions: {
+			url: true,
+			context: true
+		}
+	},
+
+	// Creates a full fledged settings object into target
+	// with both ajaxSettings and settings fields.
+	// If target is omitted, writes into ajaxSettings.
+	ajaxSetup: function( target, settings ) {
+		return settings ?
+
+			// Building a settings object
+			ajaxExtend( ajaxExtend( target, jQuery.ajaxSettings ), settings ) :
+
+			// Extending ajaxSettings
+			ajaxExtend( jQuery.ajaxSettings, target );
+	},
+
+	ajaxPrefilter: addToPrefiltersOrTransports( prefilters ),
+	ajaxTransport: addToPrefiltersOrTransports( transports ),
+
+	// Main method
+	ajax: function( url, options ) {
+
+		// If url is an object, simulate pre-1.5 signature
+		if ( typeof url === "object" ) {
+			options = url;
+			url = undefined;
+		}
+
+		// Force options to be an object
+		options = options || {};
+
+		var transport,
+
+			// URL without anti-cache param
+			cacheURL,
+
+			// Response headers
+			responseHeadersString,
+			responseHeaders,
+
+			// timeout handle
+			timeoutTimer,
+
+			// Url cleanup var
+			urlAnchor,
+
+			// Request state (becomes false upon send and true upon completion)
+			completed,
+
+			// To know if global events are to be dispatched
+			fireGlobals,
+
+			// Loop variable
+			i,
+
+			// uncached part of the url
+			uncached,
+
+			// Create the final options object
+			s = jQuery.ajaxSetup( {}, options ),
+
+			// Callbacks context
+			callbackContext = s.context || s,
+
+			// Context for global events is callbackContext if it is a DOM node or jQuery collection
+			globalEventContext = s.context &&
+				( callbackContext.nodeType || callbackContext.jquery ) ?
+					jQuery( callbackContext ) :
+					jQuery.event,
+
+			// Deferreds
+			deferred = jQuery.Deferred(),
+			completeDeferred = jQuery.Callbacks( "once memory" ),
+
+			// Status-dependent callbacks
+			statusCode = s.statusCode || {},
+
+			// Headers (they are sent all at once)
+			requestHeaders = {},
+			requestHeadersNames = {},
+
+			// Default abort message
+			strAbort = "canceled",
+
+			// Fake xhr
+			jqXHR = {
+				readyState: 0,
+
+				// Builds headers hashtable if needed
+				getResponseHeader: function( key ) {
+					var match;
+					if ( completed ) {
+						if ( !responseHeaders ) {
+							responseHeaders = {};
+							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
+								responseHeaders[ match[ 1 ].toLowerCase() + " " ] =
+									( responseHeaders[ match[ 1 ].toLowerCase() + " " ] || [] )
+										.concat( match[ 2 ] );
+							}
+						}
+						match = responseHeaders[ key.toLowerCase() + " " ];
+					}
+					return match == null ? null : match.join( ", " );
+				},
+
+				// Raw string
+				getAllResponseHeaders: function() {
+					return completed ? responseHeadersString : null;
+				},
+
+				// Caches the header
+				setRequestHeader: function( name, value ) {
+					if ( completed == null ) {
+						name = requestHeadersNames[ name.toLowerCase() ] =
+							requestHeadersNames[ name.toLowerCase() ] || name;
+						requestHeaders[ name ] = value;
+					}
+					return this;
+				},
+
+				// Overrides response content-type header
+				overrideMimeType: function( type ) {
+					if ( completed == null ) {
+						s.mimeType = type;
+					}
+					return this;
+				},
+
+				// Status-dependent callbacks
+				statusCode: function( map ) {
+					var code;
+					if ( map ) {
+						if ( completed ) {
+
+							// Execute the appropriate callbacks
+							jqXHR.always( map[ jqXHR.status ] );
+						} else {
+
+							// Lazy-add the new callbacks in a way that preserves old ones
+							for ( code in map ) {
+								statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
+							}
+						}
+					}
+					return this;
+				},
+
+				// Cancel the request
+				abort: function( statusText ) {
+					var finalText = statusText || strAbort;
+					if ( transport ) {
+						transport.abort( finalText );
+					}
+					done( 0, finalText );
+					return this;
+				}
+			};
+
+		// Attach deferreds
+		deferred.promise( jqXHR );
+
+		// Add protocol if not provided (prefilters might expect it)
+		// Handle falsy url in the settings object (#10093: consistency with old signature)
+		// We also use the url parameter if available
+		s.url = ( ( url || s.url || location.href ) + "" )
+			.replace( rprotocol, location.protocol + "//" );
+
+		// Alias method option to type as per ticket #12004
+		s.type = options.method || options.type || s.method || s.type;
+
+		// Extract dataTypes list
+		s.dataTypes = ( s.dataType || "*" ).toLowerCase().match( rnothtmlwhite ) || [ "" ];
+
+		// A cross-domain request is in order when the origin doesn't match the current origin.
+		if ( s.crossDomain == null ) {
+			urlAnchor = document.createElement( "a" );
+
+			// Support: IE <=8 - 11, Edge 12 - 15
+			// IE throws exception on accessing the href property if url is malformed,
+			// e.g. http://example.com:80x/
+			try {
+				urlAnchor.href = s.url;
+
+				// Support: IE <=8 - 11 only
+				// Anchor's host property isn't correctly set when s.url is relative
+				urlAnchor.href = urlAnchor.href;
+				s.crossDomain = originAnchor.protocol + "//" + originAnchor.host !==
+					urlAnchor.protocol + "//" + urlAnchor.host;
+			} catch ( e ) {
+
+				// If there is an error parsing the URL, assume it is crossDomain,
+				// it can be rejected by the transport if it is invalid
+				s.crossDomain = true;
+			}
+		}
+
+		// Convert data if not already a string
+		if ( s.data && s.processData && typeof s.data !== "string" ) {
+			s.data = jQuery.param( s.data, s.traditional );
+		}
+
+		// Apply prefilters
+		inspectPrefiltersOrTransports( prefilters, s, options, jqXHR );
+
+		// If request was aborted inside a prefilter, stop there
+		if ( completed ) {
+			return jqXHR;
+		}
+
+		// We can fire global events as of now if asked to
+		// Don't fire events if jQuery.event is undefined in an AMD-usage scenario (#15118)
+		fireGlobals = jQuery.event && s.global;
+
+		// Watch for a new set of requests
+		if ( fireGlobals && jQuery.active++ === 0 ) {
+			jQuery.event.trigger( "ajaxStart" );
+		}
+
+		// Uppercase the type
+		s.type = s.type.toUpperCase();
+
+		// Determine if request has content
+		s.hasContent = !rnoContent.test( s.type );
+
+		// Save the URL in case we're toying with the If-Modified-Since
+		// and/or If-None-Match header later on
+		// Remove hash to simplify url manipulation
+		cacheURL = s.url.replace( rhash, "" );
+
+		// More options handling for requests with no content
+		if ( !s.hasContent ) {
+
+			// Remember the hash so we can put it back
+			uncached = s.url.slice( cacheURL.length );
+
+			// If data is available and should be processed, append data to url
+			if ( s.data && ( s.processData || typeof s.data === "string" ) ) {
+				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
+
+				// #9682: remove data so that it's not used in an eventual retry
+				delete s.data;
+			}
+
+			// Add or update anti-cache param if needed
+			if ( s.cache === false ) {
+				cacheURL = cacheURL.replace( rantiCache, "$1" );
+				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
+			}
+
+			// Put hash and anti-cache on the URL that will be requested (gh-1732)
+			s.url = cacheURL + uncached;
+
+		// Change '%20' to '+' if this is encoded form body content (gh-2658)
+		} else if ( s.data && s.processData &&
+			( s.contentType || "" ).indexOf( "application/x-www-form-urlencoded" ) === 0 ) {
+			s.data = s.data.replace( r20, "+" );
+		}
+
+		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
+		if ( s.ifModified ) {
+			if ( jQuery.lastModified[ cacheURL ] ) {
+				jqXHR.setRequestHeader( "If-Modified-Since", jQuery.lastModified[ cacheURL ] );
+			}
+			if ( jQuery.etag[ cacheURL ] ) {
+				jqXHR.setRequestHeader( "If-None-Match", jQuery.etag[ cacheURL ] );
+			}
+		}
+
+		// Set the correct header, if data is being sent
+		if ( s.data && s.hasContent && s.contentType !== false || options.contentType ) {
+			jqXHR.setRequestHeader( "Content-Type", s.contentType );
+		}
+
+		// Set the Accepts header for the server, depending on the dataType
+		jqXHR.setRequestHeader(
+			"Accept",
+			s.dataTypes[ 0 ] && s.accepts[ s.dataTypes[ 0 ] ] ?
+				s.accepts[ s.dataTypes[ 0 ] ] +
+					( s.dataTypes[ 0 ] !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
+				s.accepts[ "*" ]
+		);
+
+		// Check for headers option
+		for ( i in s.headers ) {
+			jqXHR.setRequestHeader( i, s.headers[ i ] );
+		}
+
+		// Allow custom headers/mimetypes and early abort
+		if ( s.beforeSend &&
+			( s.beforeSend.call( callbackContext, jqXHR, s ) === false || completed ) ) {
+
+			// Abort if not done already and return
+			return jqXHR.abort();
+		}
+
+		// Aborting is no longer a cancellation
+		strAbort = "abort";
+
+		// Install callbacks on deferreds
+		completeDeferred.add( s.complete );
+		jqXHR.done( s.success );
+		jqXHR.fail( s.error );
+
+		// Get transport
+		transport = inspectPrefiltersOrTransports( transports, s, options, jqXHR );
+
+		// If no transport, we auto-abort
+		if ( !transport ) {
+			done( -1, "No Transport" );
+		} else {
+			jqXHR.readyState = 1;
+
+			// Send global event
+			if ( fireGlobals ) {
+				globalEventContext.trigger( "ajaxSend", [ jqXHR, s ] );
+			}
+
+			// If request was aborted inside ajaxSend, stop there
+			if ( completed ) {
+				return jqXHR;
+			}
+
+			// Timeout
+			if ( s.async && s.timeout > 0 ) {
+				timeoutTimer = window.setTimeout( function() {
+					jqXHR.abort( "timeout" );
+				}, s.timeout );
+			}
+
+			try {
+				completed = false;
+				transport.send( requestHeaders, done );
+			} catch ( e ) {
+
+				// Rethrow post-completion exceptions
+				if ( completed ) {
+					throw e;
+				}
+
+				// Propagate others as results
+				done( -1, e );
+			}
+		}
+
+		// Callback for when everything is done
+		function done( status, nativeStatusText, responses, headers ) {
+			var isSuccess, success, error, response, modified,
+				statusText = nativeStatusText;
+
+			// Ignore repeat invocations
+			if ( completed ) {
+				return;
+			}
+
+			completed = true;
+
+			// Clear timeout if it exists
+			if ( timeoutTimer ) {
+				window.clearTimeout( timeoutTimer );
+			}
+
+			// Dereference transport for early garbage collection
+			// (no matter how long the jqXHR object will be used)
+			transport = undefined;
+
+			// Cache response headers
+			responseHeadersString = headers || "";
+
+			// Set readyState
+			jqXHR.readyState = status > 0 ? 4 : 0;
+
+			// Determine if successful
+			isSuccess = status >= 200 && status < 300 || status === 304;
+
+			// Get response data
+			if ( responses ) {
+				response = ajaxHandleResponses( s, jqXHR, responses );
+			}
+
+			// Convert no matter what (that way responseXXX fields are always set)
+			response = ajaxConvert( s, response, jqXHR, isSuccess );
+
+			// If successful, handle type chaining
+			if ( isSuccess ) {
+
+				// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
+				if ( s.ifModified ) {
+					modified = jqXHR.getResponseHeader( "Last-Modified" );
+					if ( modified ) {
+						jQuery.lastModified[ cacheURL ] = modified;
+					}
+					modified = jqXHR.getResponseHeader( "etag" );
+					if ( modified ) {
+						jQuery.etag[ cacheURL ] = modified;
+					}
+				}
+
+				// if no content
+				if ( status === 204 || s.type === "HEAD" ) {
+					statusText = "nocontent";
+
+				// if not modified
+				} else if ( status === 304 ) {
+					statusText = "notmodified";
+
+				// If we have data, let's convert it
+				} else {
+					statusText = response.state;
+					success = response.data;
+					error = response.error;
+					isSuccess = !error;
+				}
+			} else {
+
+				// Extract error from statusText and normalize for non-aborts
+				error = statusText;
+				if ( status || !statusText ) {
+					statusText = "error";
+					if ( status < 0 ) {
+						status = 0;
+					}
+				}
+			}
+
+			// Set data for the fake xhr object
+			jqXHR.status = status;
+			jqXHR.statusText = ( nativeStatusText || statusText ) + "";
+
+			// Success/Error
+			if ( isSuccess ) {
+				deferred.resolveWith( callbackContext, [ success, statusText, jqXHR ] );
+			} else {
+				deferred.rejectWith( callbackContext, [ jqXHR, statusText, error ] );
+			}
+
+			// Status-dependent callbacks
+			jqXHR.statusCode( statusCode );
+			statusCode = undefined;
+
+			if ( fireGlobals ) {
+				globalEventContext.trigger( isSuccess ? "ajaxSuccess" : "ajaxError",
+					[ jqXHR, s, isSuccess ? success : error ] );
+			}
+
+			// Complete
+			completeDeferred.fireWith( callbackContext, [ jqXHR, statusText ] );
+
+			if ( fireGlobals ) {
+				globalEventContext.trigger( "ajaxComplete", [ jqXHR, s ] );
+
+				// Handle the global AJAX counter
+				if ( !( --jQuery.active ) ) {
+					jQuery.event.trigger( "ajaxStop" );
+				}
+			}
+		}
+
+		return jqXHR;
+	},
+
+	getJSON: function( url, data, callback ) {
+		return jQuery.get( url, data, callback, "json" );
+	},
+
+	getScript: function( url, callback ) {
+		return jQuery.get( url, undefined, callback, "script" );
+	}
+} );
+
+jQuery.each( [ "get", "post" ], function( i, method ) {
+	jQuery[ method ] = function( url, data, callback, type ) {
+
+		// Shift arguments if data argument was omitted
+		if ( isFunction( data ) ) {
+			type = type || callback;
+			callback = data;
+			data = undefined;
+		}
+
+		// The url can be an options object (which then must have .url)
+		return jQuery.ajax( jQuery.extend( {
+			url: url,
+			type: method,
+			dataType: type,
+			data: data,
+			success: callback
+		}, jQuery.isPlainObject( url ) && url ) );
+	};
+} );
+
+
+jQuery._evalUrl = function( url, options ) {
+	return jQuery.ajax( {
+		url: url,
+
+		// Make this explicit, since user can override this through ajaxSetup (#11264)
+		type: "GET",
+		dataType: "script",
+		cache: true,
+		async: false,
+		global: false,
+
+		// Only evaluate the response if it is successful (gh-4126)
+		// dataFilter is not invoked for failure responses, so using it instead
+		// of the default converter is kludgy but it works.
+		converters: {
+			"text script": function() {}
+		},
+		dataFilter: function( response ) {
+			jQuery.globalEval( response, options );
+		}
+	} );
+};
+
+
+jQuery.fn.extend( {
+	wrapAll: function( html ) {
+		var wrap;
+
+		if ( this[ 0 ] ) {
+			if ( isFunction( html ) ) {
+				html = html.call( this[ 0 ] );
+			}
+
+			// The elements to wrap the target around
+			wrap = jQuery( html, this[ 0 ].ownerDocument ).eq( 0 ).clone( true );
+
+			if ( this[ 0 ].parentNode ) {
+				wrap.insertBefore( this[ 0 ] );
+			}
+
+			wrap.map( function() {
+				var elem = this;
+
+				while ( elem.firstElementChild ) {
+					elem = elem.firstElementChild;
+				}
+
+				return elem;
+			} ).append( this );
+		}
+
+		return this;
+	},
+
+	wrapInner: function( html ) {
+		if ( isFunction( html ) ) {
+			return this.each( function( i ) {
+				jQuery( this ).wrapInner( html.call( this, i ) );
+			} );
+		}
+
+		return this.each( function() {
+			var self = jQuery( this ),
+				contents = self.contents();
+
+			if ( contents.length ) {
+				contents.wrapAll( html );
+
+			} else {
+				self.append( html );
+			}
+		} );
+	},
+
+	wrap: function( html ) {
+		var htmlIsFunction = isFunction( html );
+
+		return this.each( function( i ) {
+			jQuery( this ).wrapAll( htmlIsFunction ? html.call( this, i ) : html );
+		} );
+	},
+
+	unwrap: function( selector ) {
+		this.parent( selector ).not( "body" ).each( function() {
+			jQuery( this ).replaceWith( this.childNodes );
+		} );
+		return this;
+	}
+} );
+
+
+jQuery.expr.pseudos.hidden = function( elem ) {
+	return !jQuery.expr.pseudos.visible( elem );
+};
+jQuery.expr.pseudos.visible = function( elem ) {
+	return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+};
+
+
+
+
+jQuery.ajaxSettings.xhr = function() {
+	try {
+		return new window.XMLHttpRequest();
+	} catch ( e ) {}
+};
+
+var xhrSuccessStatus = {
+
+		// File protocol always yields status code 0, assume 200
+		0: 200,
+
+		// Support: IE <=9 only
+		// #1450: sometimes IE returns 1223 when it should be 204
+		1223: 204
+	},
+	xhrSupported = jQuery.ajaxSettings.xhr();
+
+support.cors = !!xhrSupported && ( "withCredentials" in xhrSupported );
+support.ajax = xhrSupported = !!xhrSupported;
+
+jQuery.ajaxTransport( function( options ) {
+	var callback, errorCallback;
+
+	// Cross domain only allowed if supported through XMLHttpRequest
+	if ( support.cors || xhrSupported && !options.crossDomain ) {
+		return {
+			send: function( headers, complete ) {
+				var i,
+					xhr = options.xhr();
+
+				xhr.open(
+					options.type,
+					options.url,
+					options.async,
+					options.username,
+					options.password
+				);
+
+				// Apply custom fields if provided
+				if ( options.xhrFields ) {
+					for ( i in options.xhrFields ) {
+						xhr[ i ] = options.xhrFields[ i ];
+					}
+				}
+
+				// Override mime type if needed
+				if ( options.mimeType && xhr.overrideMimeType ) {
+					xhr.overrideMimeType( options.mimeType );
+				}
+
+				// X-Requested-With header
+				// For cross-domain requests, seeing as conditions for a preflight are
+				// akin to a jigsaw puzzle, we simply never set it to be sure.
+				// (it can always be set on a per-request basis or even using ajaxSetup)
+				// For same-domain requests, won't change header if already provided.
+				if ( !options.crossDomain && !headers[ "X-Requested-With" ] ) {
+					headers[ "X-Requested-With" ] = "XMLHttpRequest";
+				}
+
+				// Set headers
+				for ( i in headers ) {
+					xhr.setRequestHeader( i, headers[ i ] );
+				}
+
+				// Callback
+				callback = function( type ) {
+					return function() {
+						if ( callback ) {
+							callback = errorCallback = xhr.onload =
+								xhr.onerror = xhr.onabort = xhr.ontimeout =
+									xhr.onreadystatechange = null;
+
+							if ( type === "abort" ) {
+								xhr.abort();
+							} else if ( type === "error" ) {
+
+								// Support: IE <=9 only
+								// On a manual native abort, IE9 throws
+								// errors on any property access that is not readyState
+								if ( typeof xhr.status !== "number" ) {
+									complete( 0, "error" );
+								} else {
+									complete(
+
+										// File: protocol always yields status 0; see #8605, #14207
+										xhr.status,
+										xhr.statusText
+									);
+								}
+							} else {
+								complete(
+									xhrSuccessStatus[ xhr.status ] || xhr.status,
+									xhr.statusText,
+
+									// Support: IE <=9 only
+									// IE9 has no XHR2 but throws on binary (trac-11426)
+									// For XHR2 non-text, let the caller handle it (gh-2498)
+									( xhr.responseType || "text" ) !== "text"  ||
+									typeof xhr.responseText !== "string" ?
+										{ binary: xhr.response } :
+										{ text: xhr.responseText },
+									xhr.getAllResponseHeaders()
+								);
+							}
+						}
+					};
+				};
+
+				// Listen to events
+				xhr.onload = callback();
+				errorCallback = xhr.onerror = xhr.ontimeout = callback( "error" );
+
+				// Support: IE 9 only
+				// Use onreadystatechange to replace onabort
+				// to handle uncaught aborts
+				if ( xhr.onabort !== undefined ) {
+					xhr.onabort = errorCallback;
+				} else {
+					xhr.onreadystatechange = function() {
+
+						// Check readyState before timeout as it changes
+						if ( xhr.readyState === 4 ) {
+
+							// Allow onerror to be called first,
+							// but that will not handle a native abort
+							// Also, save errorCallback to a variable
+							// as xhr.onerror cannot be accessed
+							window.setTimeout( function() {
+								if ( callback ) {
+									errorCallback();
+								}
+							} );
+						}
+					};
+				}
+
+				// Create the abort callback
+				callback = callback( "abort" );
+
+				try {
+
+					// Do send the request (this may raise an exception)
+					xhr.send( options.hasContent && options.data || null );
+				} catch ( e ) {
+
+					// #14683: Only rethrow if this hasn't been notified as an error yet
+					if ( callback ) {
+						throw e;
+					}
+				}
+			},
+
+			abort: function() {
+				if ( callback ) {
+					callback();
+				}
+			}
+		};
+	}
+} );
+
+
+
+
+// Prevent auto-execution of scripts when no explicit dataType was provided (See gh-2432)
+jQuery.ajaxPrefilter( function( s ) {
+	if ( s.crossDomain ) {
+		s.contents.script = false;
+	}
+} );
+
+// Install script dataType
+jQuery.ajaxSetup( {
+	accepts: {
+		script: "text/javascript, application/javascript, " +
+			"application/ecmascript, application/x-ecmascript"
+	},
+	contents: {
+		script: /\b(?:java|ecma)script\b/
+	},
+	converters: {
+		"text script": function( text ) {
+			jQuery.globalEval( text );
+			return text;
+		}
+	}
+} );
+
+// Handle cache's special case and crossDomain
+jQuery.ajaxPrefilter( "script", function( s ) {
+	if ( s.cache === undefined ) {
+		s.cache = false;
+	}
+	if ( s.crossDomain ) {
+		s.type = "GET";
+	}
+} );
+
+// Bind script tag hack transport
+jQuery.ajaxTransport( "script", function( s ) {
+
+	// This transport only deals with cross domain or forced-by-attrs requests
+	if ( s.crossDomain || s.scriptAttrs ) {
+		var script, callback;
+		return {
+			send: function( _, complete ) {
+				script = jQuery( "<script>" )
+					.attr( s.scriptAttrs || {} )
+					.prop( { charset: s.scriptCharset, src: s.url } )
+					.on( "load error", callback = function( evt ) {
+						script.remove();
+						callback = null;
+						if ( evt ) {
+							complete( evt.type === "error" ? 404 : 200, evt.type );
+						}
+					} );
+
+				// Use native DOM manipulation to avoid our domManip AJAX trickery
+				document.head.appendChild( script[ 0 ] );
+			},
+			abort: function() {
+				if ( callback ) {
+					callback();
+				}
+			}
+		};
+	}
+} );
+
+
+
+
+var oldCallbacks = [],
+	rjsonp = /(=)\?(?=&|$)|\?\?/;
+
+// Default jsonp settings
+jQuery.ajaxSetup( {
+	jsonp: "callback",
+	jsonpCallback: function() {
+		var callback = oldCallbacks.pop() || ( jQuery.expando + "_" + ( nonce++ ) );
+		this[ callback ] = true;
+		return callback;
+	}
+} );
+
+// Detect, normalize options and install callbacks for jsonp requests
+jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
+
+	var callbackName, overwritten, responseContainer,
+		jsonProp = s.jsonp !== false && ( rjsonp.test( s.url ) ?
+			"url" :
+			typeof s.data === "string" &&
+				( s.contentType || "" )
+					.indexOf( "application/x-www-form-urlencoded" ) === 0 &&
+				rjsonp.test( s.data ) && "data"
+		);
+
+	// Handle iff the expected data type is "jsonp" or we have a parameter to set
+	if ( jsonProp || s.dataTypes[ 0 ] === "jsonp" ) {
+
+		// Get callback name, remembering preexisting value associated with it
+		callbackName = s.jsonpCallback = isFunction( s.jsonpCallback ) ?
+			s.jsonpCallback() :
+			s.jsonpCallback;
+
+		// Insert callback into url or form data
+		if ( jsonProp ) {
+			s[ jsonProp ] = s[ jsonProp ].replace( rjsonp, "$1" + callbackName );
+		} else if ( s.jsonp !== false ) {
+			s.url += ( rquery.test( s.url ) ? "&" : "?" ) + s.jsonp + "=" + callbackName;
+		}
+
+		// Use data converter to retrieve json after script execution
+		s.converters[ "script json" ] = function() {
+			if ( !responseContainer ) {
+				jQuery.error( callbackName + " was not called" );
+			}
+			return responseContainer[ 0 ];
+		};
+
+		// Force json dataType
+		s.dataTypes[ 0 ] = "json";
+
+		// Install callback
+		overwritten = window[ callbackName ];
+		window[ callbackName ] = function() {
+			responseContainer = arguments;
+		};
+
+		// Clean-up function (fires after converters)
+		jqXHR.always( function() {
+
+			// If previous value didn't exist - remove it
+			if ( overwritten === undefined ) {
+				jQuery( window ).removeProp( callbackName );
+
+			// Otherwise restore preexisting value
+			} else {
+				window[ callbackName ] = overwritten;
+			}
+
+			// Save back as free
+			if ( s[ callbackName ] ) {
+
+				// Make sure that re-using the options doesn't screw things around
+				s.jsonpCallback = originalSettings.jsonpCallback;
+
+				// Save the callback name for future use
+				oldCallbacks.push( callbackName );
+			}
+
+			// Call if it was a function and we have a response
+			if ( responseContainer && isFunction( overwritten ) ) {
+				overwritten( responseContainer[ 0 ] );
+			}
+
+			responseContainer = overwritten = undefined;
+		} );
+
+		// Delegate to script
+		return "script";
+	}
+} );
+
+
+
+
+// Support: Safari 8 only
+// In Safari 8 documents created via document.implementation.createHTMLDocument
+// collapse sibling forms: the second one becomes a child of the first one.
+// Because of that, this security measure has to be disabled in Safari 8.
+// https://bugs.webkit.org/show_bug.cgi?id=137337
+support.createHTMLDocument = ( function() {
+	var body = document.implementation.createHTMLDocument( "" ).body;
+	body.innerHTML = "<form></form><form></form>";
+	return body.childNodes.length === 2;
+} )();
+
+
+// Argument "data" should be string of html
+// context (optional): If specified, the fragment will be created in this context,
+// defaults to document
+// keepScripts (optional): If true, will include scripts passed in the html string
+jQuery.parseHTML = function( data, context, keepScripts ) {
+	if ( typeof data !== "string" ) {
+		return [];
+	}
+	if ( typeof context === "boolean" ) {
+		keepScripts = context;
+		context = false;
+	}
+
+	var base, parsed, scripts;
+
+	if ( !context ) {
+
+		// Stop scripts or inline event handlers from being executed immediately
+		// by using document.implementation
+		if ( support.createHTMLDocument ) {
+			context = document.implementation.createHTMLDocument( "" );
+
+			// Set the base href for the created document
+			// so any parsed elements with URLs
+			// are based on the document's URL (gh-2965)
+			base = context.createElement( "base" );
+			base.href = document.location.href;
+			context.head.appendChild( base );
+		} else {
+			context = document;
+		}
+	}
+
+	parsed = rsingleTag.exec( data );
+	scripts = !keepScripts && [];
+
+	// Single tag
+	if ( parsed ) {
+		return [ context.createElement( parsed[ 1 ] ) ];
+	}
+
+	parsed = buildFragment( [ data ], context, scripts );
+
+	if ( scripts && scripts.length ) {
+		jQuery( scripts ).remove();
+	}
+
+	return jQuery.merge( [], parsed.childNodes );
+};
+
+
+/**
+ * Load a url into a page
+ */
+jQuery.fn.load = function( url, params, callback ) {
+	var selector, type, response,
+		self = this,
+		off = url.indexOf( " " );
+
+	if ( off > -1 ) {
+		selector = stripAndCollapse( url.slice( off ) );
+		url = url.slice( 0, off );
+	}
+
+	// If it's a function
+	if ( isFunction( params ) ) {
+
+		// We assume that it's the callback
+		callback = params;
+		params = undefined;
+
+	// Otherwise, build a param string
+	} else if ( params && typeof params === "object" ) {
+		type = "POST";
+	}
+
+	// If we have elements to modify, make the request
+	if ( self.length > 0 ) {
+		jQuery.ajax( {
+			url: url,
+
+			// If "type" variable is undefined, then "GET" method will be used.
+			// Make value of this field explicit since
+			// user can override it through ajaxSetup method
+			type: type || "GET",
+			dataType: "html",
+			data: params
+		} ).done( function( responseText ) {
+
+			// Save response for use in complete callback
+			response = arguments;
+
+			self.html( selector ?
+
+				// If a selector was specified, locate the right elements in a dummy div
+				// Exclude scripts to avoid IE 'Permission Denied' errors
+				jQuery( "<div>" ).append( jQuery.parseHTML( responseText ) ).find( selector ) :
+
+				// Otherwise use the full result
+				responseText );
+
+		// If the request succeeds, this function gets "data", "status", "jqXHR"
+		// but they are ignored because response was set above.
+		// If it fails, this function gets "jqXHR", "status", "error"
+		} ).always( callback && function( jqXHR, status ) {
+			self.each( function() {
+				callback.apply( this, response || [ jqXHR.responseText, status, jqXHR ] );
+			} );
+		} );
+	}
+
+	return this;
+};
+
+
+
+
+// Attach a bunch of functions for handling common AJAX events
+jQuery.each( [
+	"ajaxStart",
+	"ajaxStop",
+	"ajaxComplete",
+	"ajaxError",
+	"ajaxSuccess",
+	"ajaxSend"
+], function( i, type ) {
+	jQuery.fn[ type ] = function( fn ) {
+		return this.on( type, fn );
+	};
+} );
+
+
+
+
+jQuery.expr.pseudos.animated = function( elem ) {
+	return jQuery.grep( jQuery.timers, function( fn ) {
+		return elem === fn.elem;
+	} ).length;
+};
+
+
+
+
+jQuery.offset = {
+	setOffset: function( elem, options, i ) {
+		var curPosition, curLeft, curCSSTop, curTop, curOffset, curCSSLeft, calculatePosition,
+			position = jQuery.css( elem, "position" ),
+			curElem = jQuery( elem ),
+			props = {};
+
+		// Set position first, in-case top/left are set even on static elem
+		if ( position === "static" ) {
+			elem.style.position = "relative";
+		}
+
+		curOffset = curElem.offset();
+		curCSSTop = jQuery.css( elem, "top" );
+		curCSSLeft = jQuery.css( elem, "left" );
+		calculatePosition = ( position === "absolute" || position === "fixed" ) &&
+			( curCSSTop + curCSSLeft ).indexOf( "auto" ) > -1;
+
+		// Need to be able to calculate position if either
+		// top or left is auto and position is either absolute or fixed
+		if ( calculatePosition ) {
+			curPosition = curElem.position();
+			curTop = curPosition.top;
+			curLeft = curPosition.left;
+
+		} else {
+			curTop = parseFloat( curCSSTop ) || 0;
+			curLeft = parseFloat( curCSSLeft ) || 0;
+		}
+
+		if ( isFunction( options ) ) {
+
+			// Use jQuery.extend here to allow modification of coordinates argument (gh-1848)
+			options = options.call( elem, i, jQuery.extend( {}, curOffset ) );
+		}
+
+		if ( options.top != null ) {
+			props.top = ( options.top - curOffset.top ) + curTop;
+		}
+		if ( options.left != null ) {
+			props.left = ( options.left - curOffset.left ) + curLeft;
+		}
+
+		if ( "using" in options ) {
+			options.using.call( elem, props );
+
+		} else {
+			curElem.css( props );
+		}
+	}
+};
+
+jQuery.fn.extend( {
+
+	// offset() relates an element's border box to the document origin
+	offset: function( options ) {
+
+		// Preserve chaining for setter
+		if ( arguments.length ) {
+			return options === undefined ?
+				this :
+				this.each( function( i ) {
+					jQuery.offset.setOffset( this, options, i );
+				} );
+		}
+
+		var rect, win,
+			elem = this[ 0 ];
+
+		if ( !elem ) {
+			return;
+		}
+
+		// Return zeros for disconnected and hidden (display: none) elements (gh-2310)
+		// Support: IE <=11 only
+		// Running getBoundingClientRect on a
+		// disconnected node in IE throws an error
+		if ( !elem.getClientRects().length ) {
+			return { top: 0, left: 0 };
+		}
+
+		// Get document-relative position by adding viewport scroll to viewport-relative gBCR
+		rect = elem.getBoundingClientRect();
+		win = elem.ownerDocument.defaultView;
+		return {
+			top: rect.top + win.pageYOffset,
+			left: rect.left + win.pageXOffset
+		};
+	},
+
+	// position() relates an element's margin box to its offset parent's padding box
+	// This corresponds to the behavior of CSS absolute positioning
+	position: function() {
+		if ( !this[ 0 ] ) {
+			return;
+		}
+
+		var offsetParent, offset, doc,
+			elem = this[ 0 ],
+			parentOffset = { top: 0, left: 0 };
+
+		// position:fixed elements are offset from the viewport, which itself always has zero offset
+		if ( jQuery.css( elem, "position" ) === "fixed" ) {
+
+			// Assume position:fixed implies availability of getBoundingClientRect
+			offset = elem.getBoundingClientRect();
+
+		} else {
+			offset = this.offset();
+
+			// Account for the *real* offset parent, which can be the document or its root element
+			// when a statically positioned element is identified
+			doc = elem.ownerDocument;
+			offsetParent = elem.offsetParent || doc.documentElement;
+			while ( offsetParent &&
+				( offsetParent === doc.body || offsetParent === doc.documentElement ) &&
+				jQuery.css( offsetParent, "position" ) === "static" ) {
+
+				offsetParent = offsetParent.parentNode;
+			}
+			if ( offsetParent && offsetParent !== elem && offsetParent.nodeType === 1 ) {
+
+				// Incorporate borders into its offset, since they are outside its content origin
+				parentOffset = jQuery( offsetParent ).offset();
+				parentOffset.top += jQuery.css( offsetParent, "borderTopWidth", true );
+				parentOffset.left += jQuery.css( offsetParent, "borderLeftWidth", true );
+			}
+		}
+
+		// Subtract parent offsets and element margins
+		return {
+			top: offset.top - parentOffset.top - jQuery.css( elem, "marginTop", true ),
+			left: offset.left - parentOffset.left - jQuery.css( elem, "marginLeft", true )
+		};
+	},
+
+	// This method will return documentElement in the following cases:
+	// 1) For the element inside the iframe without offsetParent, this method will return
+	//    documentElement of the parent window
+	// 2) For the hidden or detached element
+	// 3) For body or html element, i.e. in case of the html node - it will return itself
+	//
+	// but those exceptions were never presented as a real life use-cases
+	// and might be considered as more preferable results.
+	//
+	// This logic, however, is not guaranteed and can change at any point in the future
+	offsetParent: function() {
+		return this.map( function() {
+			var offsetParent = this.offsetParent;
+
+			while ( offsetParent && jQuery.css( offsetParent, "position" ) === "static" ) {
+				offsetParent = offsetParent.offsetParent;
+			}
+
+			return offsetParent || documentElement;
+		} );
+	}
+} );
+
+// Create scrollLeft and scrollTop methods
+jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( method, prop ) {
+	var top = "pageYOffset" === prop;
+
+	jQuery.fn[ method ] = function( val ) {
+		return access( this, function( elem, method, val ) {
+
+			// Coalesce documents and windows
+			var win;
+			if ( isWindow( elem ) ) {
+				win = elem;
+			} else if ( elem.nodeType === 9 ) {
+				win = elem.defaultView;
+			}
+
+			if ( val === undefined ) {
+				return win ? win[ prop ] : elem[ method ];
+			}
+
+			if ( win ) {
+				win.scrollTo(
+					!top ? val : win.pageXOffset,
+					top ? val : win.pageYOffset
+				);
+
+			} else {
+				elem[ method ] = val;
+			}
+		}, method, val, arguments.length );
+	};
+} );
+
+// Support: Safari <=7 - 9.1, Chrome <=37 - 49
+// Add the top/left cssHooks using jQuery.fn.position
+// Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
+// Blink bug: https://bugs.chromium.org/p/chromium/issues/detail?id=589347
+// getComputedStyle returns percent when specified for top/left/bottom/right;
+// rather than make the css module depend on the offset module, just check for it here
+jQuery.each( [ "top", "left" ], function( i, prop ) {
+	jQuery.cssHooks[ prop ] = addGetHookIf( support.pixelPosition,
+		function( elem, computed ) {
+			if ( computed ) {
+				computed = curCSS( elem, prop );
+
+				// If curCSS returns percentage, fallback to offset
+				return rnumnonpx.test( computed ) ?
+					jQuery( elem ).position()[ prop ] + "px" :
+					computed;
+			}
+		}
+	);
+} );
+
+
+// Create innerHeight, innerWidth, height, width, outerHeight and outerWidth methods
+jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
+	jQuery.each( { padding: "inner" + name, content: type, "": "outer" + name },
+		function( defaultExtra, funcName ) {
+
+		// Margin is only for outerHeight, outerWidth
+		jQuery.fn[ funcName ] = function( margin, value ) {
+			var chainable = arguments.length && ( defaultExtra || typeof margin !== "boolean" ),
+				extra = defaultExtra || ( margin === true || value === true ? "margin" : "border" );
+
+			return access( this, function( elem, type, value ) {
+				var doc;
+
+				if ( isWindow( elem ) ) {
+
+					// $( window ).outerWidth/Height return w/h including scrollbars (gh-1729)
+					return funcName.indexOf( "outer" ) === 0 ?
+						elem[ "inner" + name ] :
+						elem.document.documentElement[ "client" + name ];
+				}
+
+				// Get document width or height
+				if ( elem.nodeType === 9 ) {
+					doc = elem.documentElement;
+
+					// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
+					// whichever is greatest
+					return Math.max(
+						elem.body[ "scroll" + name ], doc[ "scroll" + name ],
+						elem.body[ "offset" + name ], doc[ "offset" + name ],
+						doc[ "client" + name ]
+					);
+				}
+
+				return value === undefined ?
+
+					// Get width or height on the element, requesting but not forcing parseFloat
+					jQuery.css( elem, type, extra ) :
+
+					// Set width or height on the element
+					jQuery.style( elem, type, value, extra );
+			}, type, chainable ? margin : undefined, chainable );
+		};
+	} );
+} );
+
+
+jQuery.each( ( "blur focus focusin focusout resize scroll click dblclick " +
+	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
+	"change select submit keydown keypress keyup contextmenu" ).split( " " ),
+	function( i, name ) {
+
+	// Handle event binding
+	jQuery.fn[ name ] = function( data, fn ) {
+		return arguments.length > 0 ?
+			this.on( name, null, data, fn ) :
+			this.trigger( name );
+	};
+} );
+
+jQuery.fn.extend( {
+	hover: function( fnOver, fnOut ) {
+		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
+	}
+} );
+
+
+
+
+jQuery.fn.extend( {
+
+	bind: function( types, data, fn ) {
+		return this.on( types, null, data, fn );
+	},
+	unbind: function( types, fn ) {
+		return this.off( types, null, fn );
+	},
+
+	delegate: function( selector, types, data, fn ) {
+		return this.on( types, selector, data, fn );
+	},
+	undelegate: function( selector, types, fn ) {
+
+		// ( namespace ) or ( selector, types [, fn] )
+		return arguments.length === 1 ?
+			this.off( selector, "**" ) :
+			this.off( types, selector || "**", fn );
+	}
+} );
+
+// Bind a function to a context, optionally partially applying any
+// arguments.
+// jQuery.proxy is deprecated to promote standards (specifically Function#bind)
+// However, it is not slated for removal any time soon
+jQuery.proxy = function( fn, context ) {
+	var tmp, args, proxy;
+
+	if ( typeof context === "string" ) {
+		tmp = fn[ context ];
+		context = fn;
+		fn = tmp;
+	}
+
+	// Quick check to determine if target is callable, in the spec
+	// this throws a TypeError, but we will just return undefined.
+	if ( !isFunction( fn ) ) {
+		return undefined;
+	}
+
+	// Simulated bind
+	args = slice.call( arguments, 2 );
+	proxy = function() {
+		return fn.apply( context || this, args.concat( slice.call( arguments ) ) );
+	};
+
+	// Set the guid of unique handler to the same of original handler, so it can be removed
+	proxy.guid = fn.guid = fn.guid || jQuery.guid++;
+
+	return proxy;
+};
+
+jQuery.holdReady = function( hold ) {
+	if ( hold ) {
+		jQuery.readyWait++;
+	} else {
+		jQuery.ready( true );
+	}
+};
+jQuery.isArray = Array.isArray;
+jQuery.parseJSON = JSON.parse;
+jQuery.nodeName = nodeName;
+jQuery.isFunction = isFunction;
+jQuery.isWindow = isWindow;
+jQuery.camelCase = camelCase;
+jQuery.type = toType;
+
+jQuery.now = Date.now;
+
+jQuery.isNumeric = function( obj ) {
+
+	// As of jQuery 3.0, isNumeric is limited to
+	// strings and numbers (primitives or objects)
+	// that can be coerced to finite numbers (gh-2662)
+	var type = jQuery.type( obj );
+	return ( type === "number" || type === "string" ) &&
+
+		// parseFloat NaNs numeric-cast false positives ("")
+		// ...but misinterprets leading-number strings, particularly hex literals ("0x...")
+		// subtraction forces infinities to NaN
+		!isNaN( obj - parseFloat( obj ) );
+};
+
+
+
+
+// Register as a named AMD module, since jQuery can be concatenated with other
+// files that may use define, but not via a proper concatenation script that
+// understands anonymous AMD modules. A named AMD is safest and most robust
+// way to register. Lowercase jquery is used because AMD module names are
+// derived from file names, and jQuery is normally delivered in a lowercase
+// file name. Do this after creating the global so that if an AMD module wants
+// to call noConflict to hide this version of jQuery, it will work.
+
+// Note that for maximum portability, libraries that are not jQuery should
+// declare themselves as anonymous modules, and avoid setting a global if an
+// AMD loader is present. jQuery is a special case. For more information, see
+// https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#wiki-anon
+
+if ( typeof define === "function" && define.amd ) {
+	define( "jquery", [], function() {
+		return jQuery;
+	} );
+}
+
+
+
+
+var
+
+	// Map over jQuery in case of overwrite
+	_jQuery = window.jQuery,
+
+	// Map over the $ in case of overwrite
+	_$ = window.$;
+
+jQuery.noConflict = function( deep ) {
+	if ( window.$ === jQuery ) {
+		window.$ = _$;
+	}
+
+	if ( deep && window.jQuery === jQuery ) {
+		window.jQuery = _jQuery;
+	}
+
+	return jQuery;
+};
+
+// Expose jQuery and $ identifiers, even in AMD
+// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
+// and CommonJS for browser emulators (#13566)
+//if ( !noGlobal ) { [alain] noGlobal=true when using webpack/TS, yet we compile this in, not AMD load, so always expose
+	window.jQuery = window.$ = jQuery;
+//}
+
+
+
+
+return jQuery;
+} );

--- a/src/jqueryui-gridstack-dragdrop-plugin.ts
+++ b/src/jqueryui-gridstack-dragdrop-plugin.ts
@@ -1,0 +1,90 @@
+/** gridstack.js 1.0.0-rc - JQuery UI Drag&Drop plugin @preserve */
+/**
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+*/
+
+import { GridStack } from './gridstack';
+import { GridStackDragDropPlugin, DDOpts, DDKey } from './gridstack-dragdrop-plugin';
+import { GridStackElement } from './types';
+
+// TODO: TEMPORARY until can remove jquery-ui drag&drop and this class!
+// see https://stackoverflow.com/questions/35345760/importing-jqueryui-with-typescript-and-requirejs
+import $ from './jquery.js';
+import './jquery-ui.js';
+
+/**
+ * Jquery-ui based drag'n'drop plugin.
+ */
+export class JQueryUIGridStackDragDropPlugin extends GridStackDragDropPlugin {
+  public constructor(grid: GridStack) {
+    super(grid);
+  }
+
+  public resizable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    var $el = $(el);
+    if (opts === 'disable' || opts === 'enable') {
+        $el.resizable(opts);
+    } else if (opts === 'option') {
+      $el.resizable(opts, key, value);
+    } else {
+      var handles = $el.data('gs-resize-handles') ? $el.data('gs-resize-handles') : this.grid.opts.resizable.handles;
+      $el.resizable({...this.grid.opts.resizable, ...{handles: handles}, ...{ // was using $.extend()
+        start: opts.start || function() {},
+        stop: opts.stop || function() {},
+        resize: opts.resize || function() {}
+      }});
+    }
+    return this;
+  };
+
+  public draggable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    var $el = $(el);
+    if (opts === 'disable' || opts === 'enable') {
+      $el.draggable(opts);
+    } else {
+      $el.draggable({...this.grid.opts.draggable, ...{ // was using $.extend()
+        containment: (this.grid.opts._isNested && !this.grid.opts.dragOut) ?
+          $(this.grid.el).parent() : (this.grid.opts.draggable.containment || null),
+        start: opts.start || function() {},
+        stop: opts.stop || function() {},
+        drag: opts.drag || function() {}
+      }});
+    }
+    return this;
+  };
+
+  public droppable(el: GridStackElement, opts: DDOpts, key?: DDKey, value?): GridStackDragDropPlugin {
+    var $el = $(el);
+    $el.droppable(opts);
+    return this;
+  };
+
+  public isDroppable(el: GridStackElement): boolean {
+    var $el = $(el);
+    return Boolean($el.data('droppable'));
+  };
+
+  public on(el: GridStackElement, eventName: string, callback): GridStackDragDropPlugin {
+    $(el).on(eventName, callback);
+    return this;
+  };
+}
+
+// finally register ourself
+GridStackDragDropPlugin.registerPlugin(JQueryUIGridStackDragDropPlugin);
+
+/* OLD code for reference 
+function JQueryUIGridStackDragDropPlugin(grid) {
+  GridStack.DragDropPlugin.call(this, grid);
+}
+
+GridStack.DragDropPlugin.registerPlugin(JQueryUIGridStackDragDropPlugin);
+
+JQueryUIGridStackDragDropPlugin.prototype = Object.create(GridStack.DragDropPlugin.prototype);
+JQueryUIGridStackDragDropPlugin.prototype.constructor = JQueryUIGridStackDragDropPlugin;
+....
+scope.JQueryUIGridStackDragDropPlugin = JQueryUIGridStackDragDropPlugin;
+return JQueryUIGridStackDragDropPlugin;
+*/

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,203 @@
+/** types.ts 1.0.0-rc
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+ * @preserve
+*/
+
+export type numberOrString = number | string;
+export type GridStackElement = string | HTMLElement | GridItemHTMLElement;
+export interface GridItemHTMLElement extends HTMLElement {
+  gridstackNode?: GridStackNode; // grid items point back to node
+  /** @internal */
+  _gridstackNodeOrig?: GridStackNode;
+}
+
+/**
+ * Defines the options for a Grid
+ */
+export interface GridstackOptions {
+  /**
+   * accept widgets dragged from other grids or from outside (default: `false`). Can be:
+   * `true` (uses `'.grid-stack-item'` class filter) or `false`,
+   * string for explicit class name,
+   * function returning a boolean. See [example](http://gridstack.github.io/gridstack.js/demo/two.html)
+   */
+  acceptWidgets?: boolean | string | ((i: number, element: Element) => boolean);
+
+  /** if true the resizing handles are shown even if the user is not hovering over the widget (default?: false) */
+  alwaysShowResizeHandle?: boolean;
+
+  /** turns animation on (default?: true) */
+  animate?: boolean;
+
+  /** if false gridstack will not initialize existing items (default?: true) */
+  auto?: boolean;
+
+  /**
+   * one cell height (default?: 60). Can be:
+   *  an integer (px)
+   *  a string (ex: '100px', '10em', '10rem', '10%')
+   *  0 or null, in which case the library will not generate styles for rows. Everything must be defined in CSS files.
+   *  'auto' - height will be calculated to match cell width (initial square grid).
+   */
+  cellHeight?: numberOrString;
+
+  /** (internal) unit for cellHeight (default? 'px') which is set when a string cellHeight with a unit is passed (ex: '10rem') */
+  cellHeightUnit?: string;
+
+  /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns */
+  column?: number;
+
+  /** class that implement drag'n'drop functionality for gridstack. If false grid will be static.
+   * (default?: null - first available plugin will be used)
+   */
+  ddPlugin?: false | null | any;
+
+  /** disallows dragging of widgets (default?: false) */
+  disableDrag?: boolean;
+
+  /** disables the onColumnMode when the window width is less than minWidth (default?: false) */
+  disableOneColumnMode?: boolean;
+
+  /** disallows resizing of widgets (default?: false). */
+  disableResize?: boolean;
+
+  /** allows to override UI draggable options. (default?: { handle?: '.grid-stack-item-content', scroll?: true, appendTo?: 'body', containment: null }) */
+  draggable?: {} | any;
+
+  /** let user drag nested grid items out of a parent or not (default false) */
+  dragOut?: boolean;
+
+  /** enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html) */
+  float?: boolean;
+
+  /** draggable handle selector (default?: '.grid-stack-item-content') */
+  handle?: string;
+
+  /** draggable handle class (e.g. 'grid-stack-item-content'). If set 'handle' is ignored (default?: null) */
+  handleClass?: string;
+
+  /** widget class (default?: 'grid-stack-item') */
+  itemClass?: string;
+
+  /** maximum rows amount. Default? is 0 which means no maximum rows */
+  maxRow?: number;
+
+  /** minimal width. If window width is less, grid will be shown in one column mode (default?: 768) */
+  minWidth?: number;
+
+  /**
+   * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column 
+   * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
+   */
+  oneColumnModeDomSort?: boolean;
+
+  /** class for placeholder (default?: 'grid-stack-placeholder') */
+  placeholderClass?: string;
+
+  /** placeholder default content (default?: '') */
+  placeholderText?: string;
+
+  /** allows to override UI resizable options. (default?: { autoHide?: true, handles?: 'se' }) */
+  resizable?: {} | any;
+
+  /**
+   * if true widgets could be removed by dragging outside of the grid. It could also be a selector string,
+   * in this case widgets will be removed by dropping them there (default?: false)
+   * See example (http://gridstack.github.io/gridstack.js/demo/two.html)
+   */
+  removable?: boolean | string;
+
+  /** allows to override UI removable options. (default?: { accept: '.' + opts.itemClass }) */
+  removableOptions?: {};
+
+  /** time in milliseconds before widget is being removed while dragging outside of the grid. (default?: 2000) */
+  removeTimeout?: number;
+
+  /**
+   * if true turns grid to RTL. Possible values are true, false, 'auto' (default?: 'auto')
+   * See [example](http://gridstack.github.io/gridstack.js/demo/rtl.html)
+   */
+  rtl?: boolean | 'auto';
+
+  /**
+   * makes grid static (default?: false). If `true` widgets are not movable/resizable.
+   * You don't even need draggable/resizable. A CSS class
+   * 'grid-stack-static' is also added to the element.
+   */
+  staticGrid?: boolean;
+
+  /**
+   * vertical gap size (default?: 20). Can be:
+   *  an integer (px)
+   *  a string (ex: '2em', '20px', '2rem')
+   */
+  verticalMargin?: numberOrString;
+
+  /** (internal) unit for verticalMargin (default? 'px') set when `verticalMargin` is set as string with unit (ex: 2rem') */
+  verticalMarginUnit?: string;
+
+  /** @internal */
+  _isNested?: boolean;
+  /** @internal */
+  _class?: string;
+}
+
+
+/**
+ * Gridstack Widget creation options
+ */
+export interface GridstackWidget {
+  /** widget position x (default?: 0) */
+  x?: number;
+  /** widget position y (default?: 0) */
+  y?: number;
+  /** widget dimension width (default?: 1) */
+  width?: number;
+  /** widget dimension height (default?: 1) */
+  height?: number;
+  /** if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) */
+  autoPosition?: boolean;
+  /** minimum width allowed during resize/creation (default?: undefined = un-constrained) */
+  minWidth?: number;
+  /** maximum width allowed during resize/creation (default?: undefined = un-constrained) */
+  maxWidth?: number;
+  /** minimum height allowed during resize/creation (default?: undefined = un-constrained) */
+  minHeight?: number;
+  /** maximum height allowed during resize/creation (default?: undefined = un-constrained) */
+  maxHeight?: number;
+  /** prevent resizing (default?: undefined = un-constrained) */
+  noResize?: boolean;
+  /** prevents moving (default?: undefined = un-constrained) */
+  noMove?: boolean;
+  /** prevents moving and resizing (default?: undefined = un-constrained) */
+  locked?: boolean;
+  /** widgets can have their own resize handles. For example 'e,w' will make the particular widget only resize east and west. */
+  resizeHandles?: string;
+  /** value for `data-gs-id` stored on the widget (default?: undefined) */
+  id?: numberOrString;
+}
+
+/**
+ * internal descriptions describing the items in the grid
+ */
+export interface GridStackNode extends GridstackWidget {
+  el?: GridItemHTMLElement;
+  /** @internal need to do that for each and use --stripInternal */
+  _id?: number;
+  _dirty?: boolean;
+  _updating?: boolean;
+  _added?: boolean;
+  _temporary?: boolean;
+  _isOutOfGrid?: boolean;
+  _origX?: number;
+  _origY?: number;
+  _packY?: number;
+  _origW?: number;
+  _origH?: number;
+  _lastTriedX?: number;
+  _lastTriedY?: number;
+  _lastTriedWidth?: number;
+  _lastTriedHeight?: number;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,251 @@
+/** utils.ts 1.0.0-rc
+ * https://gridstackjs.com/
+ * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
+ * gridstack.js may be freely distributed under the MIT license.
+ * @preserve
+*/
+
+import { GridstackWidget, GridStackNode, GridstackOptions, numberOrString } from './types';
+
+/** checks for obsolete method names */
+export function obsolete(f, oldName: string, newName: string, rev: string) {
+  var wrapper = function() {
+    console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
+    'with `' + newName + '`. It will be **completely** removed in v1.0');
+    return f.apply(this, arguments);
+  }
+  wrapper.prototype = f.prototype;
+  return wrapper;
+}
+
+/** checks for obsolete grid options (can be used for any fields, but msg is about options) */
+export function obsoleteOpts(opts: GridstackOptions, oldName: string, newName: string, rev: string) {
+  if (opts[oldName] !== undefined) {
+    opts[newName] = opts[oldName];
+    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
+      newName + '`. It will be **completely** removed in v1.0');
+  }
+}
+
+/** checks for obsolete grid options which are gone */
+export function obsoleteOptsDel(opts: GridstackOptions, oldName: string, rev: string, info: string) {
+  if (opts[oldName] !== undefined) {
+    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
+  }
+}
+
+/** checks for obsolete Jquery element attributes */
+export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, rev: string) {
+  var oldAttr = el.getAttribute(oldName);
+  if (oldAttr !== undefined) {
+    el.setAttribute(newName, oldAttr);
+    console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
+      newName + '`. It will be **completely** removed in v1.0');
+  }
+}
+
+
+/**
+ * Utility methods
+ */
+export namespace Utils {
+
+  /** returns true if a and b overlap */
+  export function isIntercepted(a: GridstackWidget, b: GridstackWidget): boolean {
+    return !(a.x + a.width <= b.x || b.x + b.width <= a.x || a.y + a.height <= b.y || b.y + b.height <= a.y);
+  }
+
+  /**
+   * Sorts array of nodes
+   * @param nodes array to sort
+   * @param dir 1 for asc, -1 for desc (optional)
+   * @param width width of the grid. If undefined the width will be calculated automatically (optional).
+   **/
+  export function sort(nodes: GridStackNode[], dir?: number, column?: number): GridStackNode[] {
+    if (!column) {
+      var widths = nodes.map(function (node) { return node.x + node.width; });
+      column = Math.max.apply(Math, widths);
+    }
+
+    if (dir === -1)
+      return sortBy(nodes, (n) => -(n.x + n.y * column));
+    else
+      return sortBy(nodes, (n) => (n.x + n.y * column));
+  }
+
+  export function createStylesheet(id: string, parent?: HTMLElement): CSSStyleSheet {
+    var style: HTMLStyleElement = document.createElement('style');
+    style.setAttribute('type', 'text/css');
+    style.setAttribute('data-gs-style-id', id);
+    if ((style as any).styleSheet) { // ??? only CSSImportRule have that and different beast...
+      (style as any).styleSheet.cssText = '';
+    } else {
+      style.appendChild(document.createTextNode('')); // WebKit hack
+    }
+    if (!parent) { parent = document.getElementsByTagName('head')[0]; } // default to head
+    parent.insertBefore(style, parent.firstChild);
+    return style.sheet as CSSStyleSheet;
+  }
+
+  export function removeStylesheet(id: string) {
+    var el = document.querySelector('STYLE[data-gs-style-id=' + id + ']');
+    if (!el) return;
+    el.parentNode.removeChild(el);
+  }
+
+  export function insertCSSRule(sheet: CSSStyleSheet, selector: string, rules: string, index: number) {
+    if (typeof sheet.insertRule === 'function') {
+      sheet.insertRule(selector + '{' + rules + '}', index);
+    } else if (typeof sheet.addRule === 'function') {
+      sheet.addRule(selector, rules, index);
+    }
+  }
+
+  export function toBool(v: any): boolean {
+    if (typeof v === 'boolean') {
+      return v;
+    }
+    if (typeof v === 'string') {
+      v = v.toLowerCase();
+      return !(v === '' || v === 'no' || v === 'false' || v === '0');
+    }
+    return Boolean(v);
+  }
+
+  export function parseHeight(val: numberOrString) {
+    var height: number;
+    var heightUnit = 'px';
+    if (typeof val === 'string') {
+      var match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
+      if (!match) {
+        throw new Error('Invalid height');
+      }
+      heightUnit = match[2] || 'px';
+      height = parseFloat(match[1]);
+    } else {
+      height = val;
+    }
+    return { height: height, unit: heightUnit }
+  }
+
+  export function without(array, item) {
+    var index = array.indexOf(item);
+
+    if (index !== -1) {
+      array = array.slice(0);
+      array.splice(index, 1);
+    }
+
+    return array;
+  }
+
+  export function sortBy(array, getter) {
+    return array.slice(0).sort(function (left, right) {
+      var valueLeft = getter(left);
+      var valueRight = getter(right);
+
+      if (valueRight === valueLeft) {
+        return 0;
+      }
+
+      return valueLeft > valueRight ? 1 : -1;
+    });
+  }
+
+  export function defaults(target, arg1) {
+    var sources = Array.prototype.slice.call(arguments, 1);
+
+    sources.forEach(function (source) {
+      for (var prop in source) {
+        if (source.hasOwnProperty(prop) && (!target.hasOwnProperty(prop) || target[prop] === undefined)) {
+          target[prop] = source[prop];
+        }
+      }
+    });
+
+    return target;
+  }
+
+  export function clone(target) {
+    return {...target}; // was $.extend({}, target)
+  }
+
+  export function throttle(callback, delay) {
+    var isWaiting = false;
+
+    return function () {
+      if (!isWaiting) {
+        callback.apply(this, arguments);
+        isWaiting = true;
+        setTimeout(function () { isWaiting = false; }, delay);
+      }
+    }
+  }
+
+  export function removePositioningStyles(el) {
+    var style = el[0].style;
+    if (style.position) {
+      style.removeProperty('position');
+    }
+    if (style.left) {
+      style.removeProperty('left');
+    }
+    if (style.top) {
+      style.removeProperty('top');
+    }
+    if (style.width) {
+      style.removeProperty('width');
+    }
+    if (style.height) {
+      style.removeProperty('height');
+    }
+  }
+
+  export function getScrollParent(el) {
+    var returnEl;
+    if (el === null) {
+      returnEl = null;
+    } else if (el.scrollHeight > el.clientHeight) {
+      returnEl = el;
+    } else {
+      returnEl = getScrollParent(el.parentNode);
+    }
+    return returnEl;
+  }
+
+  export function updateScrollPosition(el, ui, distance) {
+    // is widget in view?
+    var rect = el.getBoundingClientRect();
+    var innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
+    if (rect.top < 0 ||
+      rect.bottom > innerHeightOrClientHeight
+    ) {
+      // set scrollTop of first parent that scrolls
+      // if parent is larger than el, set as low as possible
+      // to get entire widget on screen
+      var offsetDiffDown = rect.bottom - innerHeightOrClientHeight;
+      var offsetDiffUp = rect.top;
+      var scrollEl = getScrollParent(el);
+      if (scrollEl !== null) {
+        var prevScroll = scrollEl.scrollTop;
+        if (rect.top < 0 && distance < 0) {
+          // moving up
+          if (el.offsetHeight > innerHeightOrClientHeight) {
+            scrollEl.scrollTop += distance;
+          } else {
+            scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
+          }
+        } else if (distance > 0) {
+          // moving down
+          if (el.offsetHeight > innerHeightOrClientHeight) {
+            scrollEl.scrollTop += distance;
+          } else {
+            scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
+          }
+        }
+        // move widget y by amount scrolled
+        ui.position.top += scrollEl.scrollTop - prevScroll;
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,20 @@
     traverse "^0.6.6"
     unified "^6.1.6"
 
+"@types/jquery@*", "@types/jquery@^3.3.32":
+  version "3.3.32"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.32.tgz#93e27fdc45dd38ee07f2f0acf34b59c1ccee036f"
+  integrity sha512-UKoof2mnV/X1/Ix2g+V2Ny5sgHjV8nK/UJbiYxuo4zPwzGyFlZ/mp4KaePb2VqQrqJctmcDQNA57buU84/2uIw==
+  dependencies:
+    "@types/sizzle" "*"
+
+"@types/jqueryui@^1.12.10":
+  version "1.12.10"
+  resolved "https://registry.yarnpkg.com/@types/jqueryui/-/jqueryui-1.12.10.tgz#39ebe4c391fb3b9f623521b4d803d9d4804883fa"
+  integrity sha512-T8sctslWIiLl/2EHEQQfKCB92S9bMKBaeE3+iBRbSERMK/1gzyfqjaIEksduB4eUEsKq+Ji0Y+qVbiXQwI2Mwg==
+  dependencies:
+    "@types/jquery" "*"
+
 "@types/q@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-0.0.32.tgz#bd284e57c84f1325da702babfc82a5328190c0c5"
@@ -29,6 +43,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/sizzle@*":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
+  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
 abbrev@1:
   version "1.1.1"
@@ -2744,11 +2763,6 @@ jasminewd2@^2.1.0:
   resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.2.0.tgz#e37cf0b17f199cce23bea71b2039395246b4ec4e"
   integrity sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=
 
-"jquery@^1.8 || 2 || 3":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 js-base64@^2.1.8:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
@@ -4883,6 +4897,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 uglify-js@^3.1.4, uglify-js@^3.5.0:
   version "3.6.7"


### PR DESCRIPTION
EARLY as I have NOT compiled/tested the TS files yet (need to change build system) but didn't want to loose 4+ days of work!
---------
BIG, BIG change
* converted all code to Typescript (still  some TODO)
* all calls/return take HTLMElement | string, not JQuery anymore
* the `change|removed|added|enable|disable` events are now using standard calls with CustomEvent
(rest are still JQ based) but all share basic same callback signature still.
* added grid.on(eventName, callback) / grid.off(eventName) to hide native JQ events mix
* updated all demos+doc to only plain DOM manipulation (only custom drag&drop jq UI remain)
* created how to upgrade to 1.0.0 section
* part of gridstack#1084

Also (API break)
* `setColumn(N)` is now `column(N)` and new `getColumn()`
* following getter had to change for TS `getCellHeight()`, `getVerticalMargin()`, `getFloat()`
* new `getRow()`

TODO:
* not compiling TS files yet (have to change build system) so work in progress..
* had to modify jquery and jquery-ui loading to work with webpack app, but only
gridstack.min.js gives me new error (.js is ok) so try to convert to TS and see...

RANT: I hate git... must have wasted half day doing a rebase from develop

### Description
Please explain the changes you made here. Include an example of what your changes fix or how to use the changes.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
