### PR TITLE
`maxRow` now limit initial item placement

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -33,7 +33,8 @@ Change log
 
 ## 1.0.0-dev (upcoming)
 
--- fix [(1166)](https://github.com/gridstack/gridstack.js/issues/1166) resize not taking margin height into account
+- fix [(1166)](https://github.com/gridstack/gridstack.js/issues/1166) resize not taking margin height into account
+- fix [(1155)](https://github.com/gridstack/gridstack.js/issues/1155) `maxRow` now limit initial item placement if out of bound, preventing broken drag behavior
 
 ## v1.0.0 (2020-02-23)
 

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -828,7 +828,7 @@ describe('gridstack', function() {
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
-      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-auto-position')).toBe('true');
       expect($widget.attr('data-gs-min-width')).toBe(undefined);
       expect($widget.attr('data-gs-max-width')).toBe(undefined);
       expect($widget.attr('data-gs-min-height')).toBe(undefined);
@@ -843,7 +843,7 @@ describe('gridstack', function() {
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
-      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-auto-position')).toBe('true');
       expect($widget.attr('data-gs-min-width')).toBe(undefined);
       expect($widget.attr('data-gs-max-width')).toBe(undefined);
       expect($widget.attr('data-gs-min-height')).toBe(undefined);
@@ -858,7 +858,7 @@ describe('gridstack', function() {
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
-      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-auto-position')).toBe('true');
       expect($widget.attr('data-gs-min-width')).toBe(undefined);
       expect($widget.attr('data-gs-max-width')).toBe(undefined);
       expect($widget.attr('data-gs-min-height')).toBe(undefined);
@@ -873,7 +873,7 @@ describe('gridstack', function() {
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(2);
-      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-auto-position')).toBe('true');
       expect($widget.attr('data-gs-min-width')).toBe(undefined);
       expect($widget.attr('data-gs-max-width')).toBe(undefined);
       expect($widget.attr('data-gs-min-height')).toBe(undefined);
@@ -888,7 +888,7 @@ describe('gridstack', function() {
       expect(parseInt($widget.attr('data-gs-y'), 10)).toBe(0);
       expect(parseInt($widget.attr('data-gs-width'), 10)).toBe(1);
       expect(parseInt($widget.attr('data-gs-height'), 10)).toBe(1);
-      expect($widget.attr('data-gs-auto-position')).toBe(undefined);
+      expect($widget.attr('data-gs-auto-position')).toBe('true');
       expect($widget.attr('data-gs-min-width')).toBe(undefined);
       expect($widget.attr('data-gs-max-width')).toBe(undefined);
       expect($widget.attr('data-gs-min-height')).toBe(undefined);
@@ -1032,24 +1032,16 @@ describe('gridstack', function() {
     afterEach(function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
-    it('should do nothing and return node', function() {
-      var options = {
-        cellHeight: 80,
-        verticalMargin: 10
-      };
-      var grid = GridStack.init(options);
+    it('should do nothing and return NULL to mean nothing happened', function() {
+      var grid = GridStack.init();
       var items = $('.grid-stack-item');
       grid._updateElement(items[0], function(el, node) {
-        var newNode = grid.engine.moveNode(node);
-        expect(newNode).toBe(node);
+        var hasMoved = grid.engine.moveNode(node);
+        expect(hasMoved).toBe(null);
       });
     });
     it('should do nothing and return node', function() {
-      var options = {
-        cellHeight: 80,
-        verticalMargin: 10
-      };
-      var grid = GridStack.init(options);
+      var grid = GridStack.init();
       var items = $('.grid-stack-item');
       grid.minWidth(items[0], 1);
       grid.maxWidth(items[0], 2);


### PR DESCRIPTION
### Description
* it was possible before to `addWidget()` outside of a maxRow limit, causing the item to not be draggable
* had to be careful not to break knockout demos
* fix for #1155

### Checklist
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
