### PR TITLE
destroy drag&drop when removing node(s)

### DIFF
--- a/demo/float.html
+++ b/demo/float.html
@@ -24,9 +24,14 @@
     <div class="grid-stack"></div>
   </div>
 
-
   <script type="text/javascript">
     var grid = GridStack.init({float: true});
+
+    grid.on('added removed change', function(e, items) {
+      var str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(e.type + ' ' + items.length + ' items:' + str );
+    });
 
     var items = [
       {x: 2, y: 1, width: 1, height: 1},

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -35,6 +35,7 @@ Change log
 ## 1.1.0-dev (upcoming)
 
 - fix [1187](https://github.com/gridstack/gridstack.js/issues/1187) IE support for `CustomEvent` polyfill - thanks [@phil-blais](https://github.com/phil-blais)
+- fix [1204](https://github.com/gridstack/gridstack.js/issues/1204) destroy drag&drop when removing node(s) instead of just disabling it.
 - include SASS source files to npm package again [1193](https://github.com/gridstack/gridstack.js/pull/1193)
 
 ## 1.1.0 (2020-02-29)

--- a/src/gridstack.jQueryUI.js
+++ b/src/gridstack.jQueryUI.js
@@ -31,7 +31,7 @@
 
   JQueryUIGridStackDragDropPlugin.prototype.resizable = function(el, opts) {
     el = $(el);
-    if (opts === 'disable' || opts === 'enable') {
+    if (opts === 'disable' || opts === 'enable' || opts === 'destroy') {
       el.resizable(opts);
     } else if (opts === 'option') {
       var key = arguments[2];
@@ -53,7 +53,7 @@
 
   JQueryUIGridStackDragDropPlugin.prototype.draggable = function(el, opts) {
     el = $(el);
-    if (opts === 'disable' || opts === 'enable') {
+    if (opts === 'disable' || opts === 'enable' || opts === 'destroy') {
       el.draggable(opts);
     } else {
       el.draggable($.extend({}, this.grid.opts.draggable, {


### PR DESCRIPTION
### Description
* calling `grid.destroy(false)` will clean things and let you init() again.
* removing an item will now nuke  jquery drag&drop using `draggable('destroy')` instead of just disabling.
This also removes all JQ styles added if you keep DOM element around.
* also removes extra grid style left behind
* fix for #1204

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
