### PR TITLE
Fix for issue #1217

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -2112,7 +2112,7 @@
     var grids = [];
     $(selector).each(function(index, el) {
       if (!el.gridstack) {
-        el.gridstack = new GridStack(el, opts);
+        el.gridstack = new GridStack(el, JSON.parse(JSON.stringify(opts)));
       }
       grids.push(el.gridstack);
     });

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -2112,7 +2112,7 @@
     var grids = [];
     $(selector).each(function(index, el) {
       if (!el.gridstack) {
-        el.gridstack = new GridStack(el, JSON.parse(JSON.stringify(opts)));
+        el.gridstack = new GridStack(el, Utils.clone(opts));
       }
       grids.push(el.gridstack);
     });


### PR DESCRIPTION
### Description
I made the `Gridstack.initAll()` function use a deep copy of the `opts` object by using `JSON.parse(JSON.stringify(opts))`(Simplest method I found, that fixes our issue).

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
