### PR TITLE
prevent removing another grid's item

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -37,6 +37,7 @@ Change log
 
 - fix [1229](https://github.com/gridstack/gridstack.js/issues/1229) `staticGrid` no longer disable oneColumnMode
 - fix [1195](https://github.com/gridstack/gridstack.js/issues/1195) options broken with ember hash helper - thanks [@btecu](https://github.com/btecu)
+- fix [1250](https://github.com/gridstack/gridstack.js/issues/1250) don't remove item from another grid
 
 ## 1.1.1 (2020-03-17)
 

--- a/spec/gridstack-spec.js
+++ b/spec/gridstack-spec.js
@@ -1329,6 +1329,42 @@ describe('gridstack', function() {
     });
   });
 
+  describe('two grids', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('should not remove incorrect child', function() {
+      let grids = GridStack.initAll();
+      expect(grids.length).toBe(2);
+      expect(grids[0].engine.nodes.length).toBe(2);
+      expect(grids[1].engine.nodes.length).toBe(2);
+      // should do nothing
+      grids[0].removeWidget( grids[1].engine.nodes[0].el );
+      expect(grids[0].engine.nodes.length).toBe(2);
+      expect(grids[0].el.children.length).toBe(2);
+      expect(grids[1].engine.nodes.length).toBe(2);
+      expect(grids[1].el.children.length).toBe(2);
+      // should empty with no errors
+      grids[1].removeAll();
+      expect(grids[0].engine.nodes.length).toBe(2);
+      expect(grids[0].el.children.length).toBe(2);
+      expect(grids[1].engine.nodes.length).toBe(0);
+      expect(grids[1].el.children.length).toBe(0);
+    });
+    it('should remove 1 child', function() {
+      let grids = GridStack.initAll();
+      grids[1].removeWidget( grids[1].engine.nodes[0].el );
+      expect(grids[0].engine.nodes.length).toBe(2);
+      expect(grids[0].el.children.length).toBe(2);
+      expect(grids[1].engine.nodes.length).toBe(1);
+      expect(grids[1].el.children.length).toBe(1);
+    });
+  });
+
   describe('grid.compact', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1517,6 +1517,7 @@
     if (!node) {
       node = this.engine.getNodeDataByDOMEl(el.get(0));
     }
+    if (!node || node.el.parentElement !== this.el) return; // not our child!
     // remove our DOM data (circular link) and drag&drop permanently
     el.removeData('_gridstack_node');
     this.dd.draggable(el, 'destroy').resizable(el, 'destroy');


### PR DESCRIPTION
fix #1250

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
