### PR TITLE
TS: fix for #810 many columns roundoff error

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -40,6 +40,7 @@ Change log
 - add `getGridItems()` to return list of HTML grid items
 - add `{dragIn | dragInOptions}` grid attributes to handle external drag&drop items
 - add `save()` and `restore()` to serialize grids from JSON, saving all attributes (not just w,h,x,y) [1286](https://github.com/gridstack/gridstack.js/issues/1286)
+- fix [1299](https://github.com/gridstack/gridstack.js/pull/1299) many columns round-off error
 
 ## 1.1.2 (2020-05-17)
 

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -8,11 +8,7 @@
 
   <link rel="stylesheet" href="../../../demo/demo.css"/>
   <link rel="stylesheet" href="810-many-columns.css"/>
-
-  <script src="../../../dist/jquery.min.js"></script>
-  <script src="../../../dist/jquery-ui.min.js"></script>
-  <script src="../../../src/gridstack.js"></script>
-  <script src="../../../src/gridstack.jQueryUI.js"></script>
+  <script src="../../../dist/gridstack.all.js"></script>
 </head>
 <body>
   <div class="container-fluid">
@@ -30,8 +26,7 @@
     let count = 0;
     let options = {
       column: COLUMNS,
-      cellHeight: 'auto',
-      float: false
+      cellHeight: 'auto'
     };
     let grid = GridStack.init(options);
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -424,7 +424,7 @@ export class GridStack {
    */
   public cellWidth(): number {
     // TODO: take margin into account (horizontal_padding in .scss) to make cellHeight='auto' square ? (see 810-many-columns.html)
-    return Math.round(this.el.offsetWidth / this.opts.column);
+    return this.el.offsetWidth / this.opts.column;
   }
 
   /**


### PR DESCRIPTION
### Description
* cellWidth() no longer round things off
(I was able to see issue with 60 columns and dragging itelf on right and would not relocate unless moved a lot further).
