### PR TITLE
Enable the UMD behavior for bundlers compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,34 @@ npm install --save gridstack
 
 ## Include
 
-after you install:
+* Using webpack, you can now import the files:
 
 ```js
-import 'gridstack/dist/gridstack.all.js';
+import 'jquery';
+import 'jquery-ui';
+
+import 'gridstack/dist/gridstack-poly'; // optional IE support
+import GridStack from 'gridstack/dist/gridstack';
+import 'gridstack/dist/gridstack.jQueryUI';
 import 'gridstack/dist/gridstack.css';
 ```
+
+If your project doesn't make use of jQuery or jQueryUI and you don't want to include these libs,
+you can use the lightweight files provided by Gridstack instead of the official ones.
+
+For this you have to define an alias in your webpack configuration:
+```
+module.exports = {
+  ...
+  resolve: {
+    alias: {
+      'jquery': 'gridstack/dist/jquery.js',
+      'jquery-ui': 'gridstack/dist/jquery-ui.js',
+    }
+  }
+}
+```
+
 * alternatively in html
 
 ```html

--- a/src/gridstack.jQueryUI.js
+++ b/src/gridstack.jQueryUI.js
@@ -5,14 +5,13 @@
  * gridstack.js may be freely distributed under the MIT license.
 */
 (function(factory) {
-  /* we compile this in so no need for required loading
   if (typeof define === 'function' && define.amd) {
     define(['jquery', 'gridstack', 'exports'], factory);
   } else if (typeof exports !== 'undefined') {
     try { jQuery = require('jquery'); } catch (e) {}
     try { gridstack = require('gridstack'); } catch (e) {}
     factory(jQuery, gridstack.GridStack, exports);
-  } else */{
+  } else {
     factory(jQuery, GridStack, window);
   }
 })(function($, GridStack, scope) {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -6,7 +6,6 @@
  * @preserve
 */
 (function(factory) {
-  /* [alain] we compile jquery with our code, so no need to 'load' externally
   if (typeof define === 'function' && define.amd) {
     define(['jquery', 'exports'], factory);
   } else if (typeof exports !== 'undefined') {
@@ -15,7 +14,7 @@
     try { jQueryModule = require('jquery'); } catch (e) {}
 
     factory(jQueryModule || window.jQuery, exports);
-  } else */{
+  } else {
     factory(window.jQuery, window);
   }
 })(function($, scope) {

--- a/src/jquery-ui.js
+++ b/src/jquery-ui.js
@@ -4,12 +4,11 @@
 * Copyright jQuery Foundation and other contributors; Licensed MIT @preserve*/
 
 (function( factory ) {
-  /* [alain] we compile this in so no need to load with AMD
   if ( typeof define === "function" && define.amd ) {
 
     // AMD. Register as an anonymous module.
     define([ "jquery" ], factory );
-  } else */{
+  } else {
 
     // Browser globals
     factory( jQuery );


### PR DESCRIPTION
### Description
Since v1.0.0 the UMD code at the top of the files has been disabled, preventing someone using a bundler to provide jQuery via the module system. Therefore if one's not including the gridstack.all.js directly in HTML, it is mandatory to have jQuery accessible globally via the `window` object.

I propose to enable back the UMD code in order to be able to use a bundler like webpack with gridstack v1

I have also modified the Readme file in order to reflect this change : gridstack.all.js should not be used with a bundler, instead we just need the gridstack lib files. A reference to the Gridstack object is retrieved via the import of gristack.js.

Will probably fix #1243 (I couldn't test this with a vue.js stack)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
