### PR TITLE
Update gridstack-extra.css section in README to point to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ GridStack.init( {column: N} );
 
 2) include `gridstack-extra.css` if **N < 12** (else custom CSS - see next). Without these, things will not render/work correctly.
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@1.1.2/dist/gridstack-extra.css"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@2.0.0/dist/gridstack-extra.css"/>
 
 <div class="grid-stack grid-stack-N">...</div>
 ```


### PR DESCRIPTION
### Description

Documentation change only.

Updates the section about using `gridstack-extra.css`, so it points to the `2.0.0` version, to make it consistent with the rest of the README.

### Checklist

- [x] ~Created tests which fail without the change (if possible)~
- [x] ~All tests passing (`yarn test`)~
- [x] Extended the README / documentation, if necessary
