### PR TITLE
correctly remove window resize event

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -41,6 +41,7 @@ Change log
 
 - fix `minWidth()`, `minHeight()`, `maxHeight()` to set node value as well [1359](https://github.com/gridstack/gridstack.js/issues/1359)
 - fix `GridStackOptions` spelling [1359](https://github.com/gridstack/gridstack.js/issues/1359)
+- fix remove window resize event when `grid.destroy()` [1369](https://github.com/gridstack/gridstack.js/issues/1369)
 
 ## 2.0.0 (2020-09-07)
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -302,7 +302,8 @@ export class GridStack {
 
     this._updateContainerHeight();
 
-    window.addEventListener('resize', this._onResizeHandler.bind(this));
+    this._onResizeHandler = this._onResizeHandler.bind(this); // so we can properly remove later
+    window.addEventListener('resize', this._onResizeHandler);
     this._onResizeHandler();
 
     this._setupDragIn();


### PR DESCRIPTION
### Description
fix #1369, we now remove resize event correctly in destroy()

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
