### PR TITLE
better window resize handler fix

### DIFF
--- a/demo/nested.html
+++ b/demo/nested.html
@@ -60,7 +60,7 @@
       disableOneColumnMode: true, // nested are small, but still want N columns
       margin: 1
     };
-    GridStack.init({cellHeight: 70}, '.grid-stack.top');
+    let grid0 = GridStack.init({cellHeight: 70}, '.grid-stack.top');
     let grid1 = GridStack.init(nestOptions, '.grid-stack.nested1');
     nestOptions.dragOut = false;
     let grid2 = GridStack.init(nestOptions, '.grid-stack.nested2');


### PR DESCRIPTION
### Description
better fix for #1369
* `private _onResizeHandler()` is now `onParentResize()` as client might want to manually call this
(when dome div above resizes)
* we now store the event binding method to we can not just remove the handler
BUT also delete it to free class pointer
(else GridStack classs will likely not free up)
* also only top grid now register size event, children get it through parent (which happens during cell resize as well)
* only register window resize if we need to as well

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
