### PR TITLE
preserve attributes dragging between grids

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -44,6 +44,7 @@ Change log
 - fix remove window resize event when `grid.destroy()` [1369](https://github.com/gridstack/gridstack.js/issues/1369)
 - fix nested grid resize [1361](https://github.com/gridstack/gridstack.js/issues/1361)
 - fix resize with `cellHeight` '6rem' '6em' not working [1356](https://github.com/gridstack/gridstack.js/issues/1356)
+- fix preserve attributes (min/max/id/etc...) when dragging between grids [1367](https://github.com/gridstack/gridstack.js/issues/1367)
 
 ## 2.0.0 (2020-09-07)
 

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -187,6 +187,8 @@ export class GridStackEngine {
    */
   public prepareNode(node: GridStackNode, resizing?: boolean): GridStackNode {
     node = node || {};
+    node._id = node._id || GridStackEngine._idSeq++;
+
     // if we're missing position, have the grid position us automatically (before we set them to 0,0)
     if (node.x === undefined || node.y === undefined || node.x === null || node.y === null) {
       node.autoPosition = true;
@@ -286,8 +288,6 @@ export class GridStackEngine {
 
   public addNode(node: GridStackNode, triggerAddEvent = false): GridStackNode {
     node = this.prepareNode(node);
-
-    node._id = node._id || GridStackEngine._idSeq++;
 
     if (node.autoPosition) {
       this._sortNodes();


### PR DESCRIPTION
### Description
* fix for #1367
* we now copy all nodes attributes when moving between grids

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
