### PR TITLE
fix two drop shadows

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -45,6 +45,7 @@ Change log
 - fix nested grid resize [1361](https://github.com/gridstack/gridstack.js/issues/1361)
 - fix resize with `cellHeight` '6rem' '6em' not working [1356](https://github.com/gridstack/gridstack.js/issues/1356)
 - fix preserve attributes (min/max/id/etc...) when dragging between grids [1367](https://github.com/gridstack/gridstack.js/issues/1367)
+- fix 2 drop shadows when dragging between grids [393](https://github.com/gridstack/gridstack.js/issues/393)
 
 ## 2.0.0 (2020-09-07)
 


### PR DESCRIPTION
### Description
* fix for #393 having 2 shadows when dragging long items between 2 grids
* when dragging an item into a grid, we now mark that it was added
for the old grid to detect and temporary remove the item.

always wanted to fix that...

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
