### PR TITLE
partial IE11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ v2.x is a Typescript rewrite of 1.x, removing all jquery events, using classes a
 
 3. `oneColumnMode` would trigger when `window.width` < 768px by default. We now check for grid width instead (more correct and supports nesting). You might need to adjust grid `minWidth` or `disableOneColumnMode`.
 
+**Note:** 2.x no longer support legacy IE11 and older due to using more compact ES6 output and typecsript native code. You will need to stay at 1.x
+
 Changes
 =====
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -63,6 +63,7 @@ You can now have perfect square cells (default) [723](https://github.com/gridsta
 - fix [1299](https://github.com/gridstack/gridstack.js/pull/1299) many columns round-off error
 - fix [1102](https://github.com/gridstack/gridstack.js/issues/1102) loose functionality when they are moved to a new grid
 - add optional params to `removeWidget()` to have quiet mode (no callbacks)
+- drop support for IE11 due to more compact ES6 output and newer TS code
 
 ## 1.2.1 (2020-09-04)
 

--- a/src/gridstack-poly.js
+++ b/src/gridstack-poly.js
@@ -123,3 +123,86 @@ if (!Array.prototype.findIndex) {
     writable: true
   });
 }
+
+// Source: https://github.com/jserz/js_piece/blob/master/DOM/ParentNode/append()/append().md
+(function (arr) {
+  arr.forEach(function (item) {
+    if (item.hasOwnProperty('append')) {
+      return;
+    }
+    Object.defineProperty(item, 'append', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function append() {
+        var argArr = Array.prototype.slice.call(arguments),
+          docFrag = document.createDocumentFragment();
+
+        argArr.forEach(function (argItem) {
+          var isNode = argItem instanceof Node;
+          docFrag.appendChild(isNode ? argItem : document.createTextNode(String(argItem)));
+        });
+
+        this.appendChild(docFrag);
+      }
+    });
+  });
+})([Element.prototype, Document.prototype, DocumentFragment.prototype]);
+
+// Production steps of ECMA-262, Edition 5, 15.4.4.18
+// Reference: http://es5.github.io/#x15.4.4.18
+
+if (!Array.prototype['forEach']) {
+
+  Array.prototype.forEach = function(callback, thisArg) {
+
+    if (this == null) { throw new TypeError('Array.prototype.forEach called on null or undefined'); }
+
+    var T, k;
+    // 1. Let O be the result of calling toObject() passing the
+    // |this| value as the argument.
+    var O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get() internal
+    // method of O with the argument "length".
+    // 3. Let len be toUint32(lenValue).
+    var len = O.length >>> 0;
+
+    // 4. If isCallable(callback) is false, throw a TypeError exception. 
+    // See: http://es5.github.com/#x9.11
+    if (typeof callback !== "function") { throw new TypeError(callback + ' is not a function'); }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let
+    // T be undefined.
+    if (arguments.length > 1) { T = thisArg; }
+
+    // 6. Let k be 0
+    k = 0;
+
+    // 7. Repeat, while k < len
+    while (k < len) {
+
+      var kValue;
+
+      // a. Let Pk be ToString(k).
+      //    This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty
+      //    internal method of O with argument Pk.
+      //    This step can be combined with c
+      // c. If kPresent is true, then
+      if (k in O) {
+
+        // i. Let kValue be the result of calling the Get internal
+        // method of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Call the Call internal method of callback with T as
+        // the this value and argument list containing kValue, k, and O.
+        callback.call(T, kValue, k, O);
+      }
+      // d. Increase k by 1.
+      k++;
+    }
+    // 8. return undefined
+  };
+}

--- a/src/index-html5.ts
+++ b/src/index-html5.ts
@@ -1,6 +1,6 @@
 // index.html5.ts 2.0.1-dev - everything you need for a Grid that uses HTML5 native drag&drop (work in progress) @preserve
 
-import './gridstack-poly.js';
+// import './gridstack-poly.js';
 
 export * from './types';
 export * from './utils';

--- a/src/index-jq.ts
+++ b/src/index-jq.ts
@@ -1,6 +1,6 @@
 // index.jq.ts 2.0.1-dev - everything you need for a Grid that uses Jquery-ui drag&drop (original, full feature) @preserve
 
-import './gridstack-poly.js';
+// import './gridstack-poly.js';
 
 export * from './types';
 export * from './utils';

--- a/src/index-static.ts
+++ b/src/index-static.ts
@@ -1,6 +1,6 @@
 // index.static.ts 2.0.1-dev - everything you need for a static Grid (non draggable) @preserve
 
-import './gridstack-poly.js';
+// import './gridstack-poly.js';
 
 export * from './types';
 export * from './utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "./dist",
     "sourceMap": true,
     "strict": false,
-    "target": "ES5"
+    "target": "ES6"
   }, 
   "exclude": [
     "./src/**/*.spec.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "./dist",
     "sourceMap": true,
     "strict": false,
-    "target": "ES6"
+    "target": "ES5"
   }, 
   "exclude": [
     "./src/**/*.spec.ts",


### PR DESCRIPTION
### Description

#1389

* changing webpack to target ES5 (instead of ES6)
(186k -> 192k)
* adding couple polyfills helps go further along
BUT still complains
> SCRIPT438: Object doesn't support property or method 'forEach'
target.querySelectorAll('.grid-stack').forEach()

even tough I added Array.forEach (because it's a NodeListOf<E> ?)

**Note**: I am gonna punt on this mark IE11 no longer supported, but wanted to check this in case we go back.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
