### PR TITLE
fix for static grid, enale dragging on fly

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,6 +17,7 @@
     <li><a href="responsive.html">Responsive</a></li>
     <li><a href="right-to-left(rtl).html">Right-To-Left (RTL)</a></li>
     <li><a href="serialization.html">Serialization</a></li>
+    <li><a href="static.html">Static</a></li>
     <li><a href="two.html">Two grids</a></li>
     <li><a href="vuej2s.html">Vue2.js</a></li>
     <li><a href="vuej3s.html">Vue3.js</a></li>

--- a/demo/static.html
+++ b/demo/static.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Static Grid</title>
+
+  <link rel="stylesheet" href="demo.css"/>
+  <script src="../dist/gridstack.all.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Static vs can move/drag Demo</h1>
+    <div>
+      <a class="btn btn-primary" onClick="grid.setStatic(true)" href="#">Static</a>
+      <a class="btn btn-primary" onclick="grid.setStatic(false)" id="float" href="#">Editable</a>
+    </div>
+    <br><br>
+    <div class="grid-stack"></div>
+  </div>
+  <script src="events.js"></script>
+  <script type="text/javascript">
+    let grid = GridStack.init({
+      float: true,
+      cellHeight: 70,
+      staticGrid: true
+    });
+    addEvents(grid);
+
+    let serializedData = [
+      {x: 0, y: 0, width: 2, height: 2, id: '0'},
+      {x: 3, y: 1, width: 1, height: 2, id: 'no_move', noMove: true, html: 'no move'},
+      {x: 4, y: 1, width: 1, height: 1, id: '2'},
+      {x: 2, y: 3, width: 3, height: 1, id: 'no_resize', noResize: true, html: 'no resize'},
+      {x: 1, y: 3, width: 1, height: 1, id: 'locked', locked: true, html: 'locked'}
+    ];
+    grid.load(serializedData, true);
+
+  </script>
+</body>
+</html>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -41,7 +41,9 @@ Change log
 
 ## 2.0.2-dev
 
-- TBD
+- fix grid `static: true` to no longer add any drag&drop (even disabled) which should speed things up, and `setStatic(T/F)` will now correctly add it back/delete for items that need it only. 
+Also fixed JQ draggable warning if not initialized first [858](https://github.com/gridstack/gridstack.js/issues/858)
+- add `GridStackWidget.html` now lets you add any HTML content when calling `grid.load()`
 
 ## 2.0.2 (2020-10-05)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -137,6 +137,7 @@ You need to add `noResize` and `noMove` attributes to completely lock the widget
 - `noMove` - disable element moving
 - `resizeHandles` - sets resize handles for a specific widget.
 - `id`- (number | string) good for quick identification (for example in change event)
+- `html` - (string) html content to be added when calling `grid.load()` as content inside the item
 
 ## Item attributes
 

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -46,6 +46,15 @@ export class GridStackDD {
     this.grid = grid;
   }
 
+  /** removes any drag&drop present (called during destroy) */
+  public remove(el: GridItemHTMLElement): GridStackDD {
+    this.draggable(el, 'destroy').resizable(el, 'destroy');
+    if (el.gridstackNode) {
+      delete el.gridstackNode._initDD; // reset our DD init flag
+    }
+    return this;
+  }
+
   public resizable(el: GridItemHTMLElement, opts: DDOpts, key?: DDKey, value?: DDValue): GridStackDD {
     return this;
   }

--- a/src/jq/gridstack-dd-jqueryui.ts
+++ b/src/jq/gridstack-dd-jqueryui.ts
@@ -26,9 +26,9 @@ export class GridStackDDJQueryUI extends GridStackDD {
 
   public resizable(el: GridItemHTMLElement, opts: DDOpts, key?: DDKey, value?: DDValue): GridStackDD {
     let $el: JQuery = $(el);
-    if (opts === 'disable' || opts === 'enable') {
-      $el.resizable(opts);
-    } else if (opts === 'destroy') {
+    if (opts === 'enable') {
+      $el.resizable().resizable(opts);
+    } else if (opts === 'disable' || opts === 'destroy') {
       if ($el.data('ui-resizable')) { // error to call destroy if not there
         $el.resizable(opts);
       }
@@ -47,9 +47,9 @@ export class GridStackDDJQueryUI extends GridStackDD {
 
   public draggable(el: GridItemHTMLElement, opts: DDOpts, key?: DDKey, value?: DDValue): GridStackDD {
     let $el: JQuery = $(el);
-    if (opts === 'disable' || opts === 'enable') {
-      $el.draggable(opts);
-    } else if (opts === 'destroy') {
+    if (opts === 'enable') {
+      $el.draggable().draggable('enable');
+    } else if (opts === 'disable' || opts === 'destroy') {
       if ($el.data('ui-draggable')) { // error to call destroy if not there
         $el.draggable(opts);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,8 @@ export interface GridStackWidget {
   resizeHandles?: string;
   /** value for `data-gs-id` stored on the widget (default?: undefined) */
   id?: numberOrString;
+  /** html to append inside the content */
+  html?: string;
 }
 
 /** Drag&Drop resize options */
@@ -291,4 +293,6 @@ export interface GridStackNode extends GridStackWidget {
   _prevYPix?: number;
   /** @internal */
   _temporaryRemoved?: boolean;
+  /** @internal */
+  _initDD?: boolean;
 }


### PR DESCRIPTION
### Description
* more complete fix for #858, and #1412
* grid `static: true` to no longer add any drag&drop (even disabled) which should speed things up, and `setStatic(T/F)` will now correctly add it back/delete for items that need it only.
* fixed JQ draggable warning if not initialized
* add `GridStackWidget.html` now lets you add any HTML content when calling `grid.load()`
* added demo showing static/non-static switch for debugging/info

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
