### PR TITLE
save() will now optionally save grid HTML content

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ creating items dynamically...
 
 // ...in your script
 var grid = GridStack.init();
-grid.addWidget('<div><div class="grid-stack-item-content">Item 1</div></div>', {width: 2});
+grid.addWidget({width: 2, content: 'item 1'});
 ```
 
 ... or creating from list
@@ -121,8 +121,8 @@ grid.addWidget('<div><div class="grid-stack-item-content">Item 1</div></div>', {
 // using serialize data instead of .addWidget()
 const serializedData = [
   {x: 0, y: 0, width: 2, height: 2},
-  {x: 2, y: 3, width: 3, height: 1},
-  {x: 1, y: 3, width: 1, height: 1}
+  {x: 2, y: 3, width: 3, content: 'item 2'},
+  {x: 1, y: 3}
 ];
 
 grid.load(serializedData);
@@ -370,12 +370,13 @@ v2.x is a Typescript rewrite of 1.x, removing all jquery events, using classes a
 
 1. In general methods that used no args (getter) vs setter can't be used in TS when the arguments differ (set/get are also not function calls so API would have changed). Instead we decided to have <b>all set methods return</b> `GridStack` to they can be chain-able (ex: `grid.float(true).cellHeight(10).column(6)`). Also legacy methods that used to take many parameters will now take a single object (typically `GridStackOptions` or `GridStackWidget`).
 
-```
+```js
 `addWidget(el, x, y, width, height)` --> `addWidget(el, {with: 2})`
-`float()` to get value --> `getFloat()`
-'cellHeight()` to get value --> `getCellHeight()`
-'verticalMargin' is now 'margin' grid options and API that applies to all 4 sides.
-'verticalMargin()` to get value --> `getMargin()`
+// Note: in 2.1.x you can now just do addWidget({with: 2, content: "text"})
+`float()` --> `getFloat()` // to get value
+`cellHeight()` --> `getCellHeight()` // to get value
+`verticalMargin` --> `margin` // grid options and API that applies to all 4 sides.
+`verticalMargin()` --> `getMargin()` // to get value
 ```
 
 2. event signatures are generic and not jquery-ui dependent anymore. `gsresizestop` has been removed as `resizestop|dragstop` are now called **after** the DOM attributes have been updated.

--- a/demo/advance.html
+++ b/demo/advance.html
@@ -20,7 +20,6 @@
       opacity: 0.8;
       filter: blur(5px);
     }
-
     #trash {
       background: rgba(255, 0, 0, 0.4);
     }
@@ -51,57 +50,12 @@
       </div>
     </div>
     <div class="col-sm-12 col-md-10">
-      <div class="grid-stack" data-gs-animate="yes">
-        <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2">
-          <div class="grid-stack-item-content">1</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4"
-          data-gs-no-move="yes" data-gs-no-resize="yes" data-gs-locked="yes">
-          <div class="grid-stack-item-content">I can't be moved or dragged!
-            <br>
-            <ion-icon name="ios-lock" style="font-size:300%"></ion-icon>
-          </div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="8" data-gs-y="0" data-gs-width="2" data-gs-height="2"
-          data-gs-min-width="2" data-gs-no-resize="yes">
-          <div class="grid-stack-item-content" style="overflow: hidden">
-            <p class="card-text text-center" style="margin-bottom: 0">
-              Drag me!
-              <p class="card-text text-center" style="margin-bottom: 0">
-                <ion-icon name="hand" style="font-size: 300%"></ion-icon>
-                <p class="card-text text-center" style="margin-bottom: 0">
-                  ...but don't resize me!
-          </div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="10" data-gs-y="0" data-gs-width="2" data-gs-height="2">
-          <div class="grid-stack-item-content"> 4</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="0" data-gs-y="2" data-gs-width="2" data-gs-height="2">
-          <div class="grid-stack-item-content">5</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="2" data-gs-y="2" data-gs-width="2" data-gs-height="4">
-          <div class="grid-stack-item-content">6</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="8" data-gs-y="2" data-gs-width="4" data-gs-height="2">
-          <div class="grid-stack-item-content">7</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="0" data-gs-y="4" data-gs-width="2" data-gs-height="2">
-          <div class="grid-stack-item-content">8</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="4" data-gs-y="4" data-gs-width="4" data-gs-height="2">
-          <div class="grid-stack-item-content">9</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="8" data-gs-y="4" data-gs-width="2" data-gs-height="2">
-          <div class="grid-stack-item-content">10</div>
-        </div>
-        <div class="grid-stack-item" data-gs-x="10" data-gs-y="4" data-gs-width="2" data-gs-height="2">
-          <div class="grid-stack-item-content">11</div>
-        </div>
-      </div>
+      <div class="grid-stack"></div>
     </div>
   </div>
 
   <script type="text/javascript">
+
     let grid = GridStack.init({
       alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
         navigator.userAgent
@@ -116,6 +70,21 @@
       removeTimeout: 100,
     });
 
+    let items = [
+      {x: 0, y: 0, width: 4, height: 2, content: '1'},
+      {x: 4, y: 0, width: 4, height: 4, noMove: true, noResize: true, locked: true, content: 'I can\'t be moved or dragged!<br><ion-icon name="ios-lock" style="font-size:300%"></ion-icon>'},
+      {x: 8, y: 0, width: 2, height: 2, minWidth: 2, noResize: true, content: '<p class="card-text text-center" style="margin-bottom: 0">Drag me!<p class="card-text text-center"style="margin-bottom: 0"><ion-icon name="hand" style="font-size: 300%"></ion-icon><p class="card-text text-center" style="margin-bottom: 0">...but don\'t resize me!'},
+      {x: 10, y: 0, width: 2, height: 2, content: '4'},
+      {x: 0, y: 2, width: 2, height: 2, content: '5'},
+      {x: 2, y: 2, width: 2, height: 4, content: '6'},
+      {x: 8, y: 2, width: 4, height: 2, content: '7'},
+      {x: 0, y: 4, width: 2, height: 2, content: '8'},
+      {x: 4, y: 4, width: 4, height: 2, content: '9'},
+      {x: 8, y: 4, width: 2, height: 2, content: '10'},
+      {x: 10, y: 4, width: 2, height: 2, content: '11'},
+    ];
+    grid.load(items);
+    
     grid.on('added removed change', function(e, items) {
       let str = '';
       items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });

--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -38,7 +38,7 @@
     });
 
     function addWidget() {
-      grid.addWidget('<div><div class="grid-stack-item-content"></div></div>', {width: Math.floor(1 + 3 * Math.random()), height: Math.floor(1 + 3 * Math.random())});
+      grid.addWidget({width: Math.floor(1 + 3 * Math.random()), height: Math.floor(1 + 3 * Math.random())});
     };
 
     let animationHelper = AniJS.getHelper();

--- a/demo/column.html
+++ b/demo/column.html
@@ -68,8 +68,8 @@
         width: Math.round(1 + 3 * Math.random()),
         height: Math.round(1 + 3 * Math.random())
       };
-      grid.addWidget('<div><div class="grid-stack-item-content"><button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>'
-        + count++ + (n.text ? n.text : '') + '</div></div>', n);
+      n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
+      grid.addWidget(n);
     };
 
     function column(n) {

--- a/demo/float.html
+++ b/demo/float.html
@@ -35,13 +35,14 @@
     let count = 0;
 
     addNewWidget = function() {
-      let node = items[count] || {
+      let n = items[count] || {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
         width: Math.round(1 + 3 * Math.random()),
         height: Math.round(1 + 3 * Math.random())
       };
-      grid.addWidget('<div><div class="grid-stack-item-content">' + count++ + '</div></div>', node);
+      n.content = String(count++);
+      grid.addWidget(n);
     };
 
     toggleFloat = function() {

--- a/demo/locked.html
+++ b/demo/locked.html
@@ -46,7 +46,8 @@
         width: Math.round(1 + 3 * Math.random()),
         height: Math.round(1 + 3 * Math.random())
       };
-      grid.addWidget('<div><div class="grid-stack-item-content">' + (n.text ? n.text : count) + '</div></div>', n);
+      n.content = n.text ? n.text : String(count);
+      grid.addWidget(n);
       count++
     };
 

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -73,6 +73,7 @@
         width: Math.round(1 + 3 * Math.random()),
         height: Math.round(1 + 3 * Math.random())
       };
+      // Note: we have additional style .sub here so add the HTML passed directly...
       grid.addWidget('<div class="grid-stack-item sub"><div class="grid-stack-item-content">' + count++ + '</div></div>', node);
       return false;
     };

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -45,18 +45,14 @@
     };
     
     let items = [
-      {x: 0, y: 0, width: 2, height: 2},
-      {x: 2, y: 0, width: 2, height: 1},
-      {x: 5, y: 0, width: 1, height: 1},
-      {x: 1, y: 3, width: 4, height: 1},
-      {x: 5, y: 2, width: 2, height: 1},
-      {x: 0, y: 4, width: 12, height: 1}
+      {x: 0, y: 0, width: 2, height: 2, content: '0'},
+      {x: 2, y: 0, width: 2, content: '1'},
+      {x: 5, y: 0, content: '2'},
+      {x: 1, y: 3, width: 4, content: '3'},
+      {x: 5, y: 2, width: 2, content: '4'},
+      {x: 0, y: 4, width: 12, content: '5'}
     ];
-    grid.batchUpdate();
-    items.forEach(function(node, index) {
-      grid.addWidget('<div><div class="grid-stack-item-content">' + index + '</div></div>', node);
-    });
-    grid.commit();
+    grid.load(items);
     resizeGrid();
 
     window.addEventListener('resize', function() {resizeGrid()});

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -33,8 +33,8 @@
     });
 
     let serializedData = [
-      {x: 0, y: 0, width: 2, height: 2, id: '0'},
-      {x: 3, y: 1, width: 1, height: 2, id: '1'},
+      {x: 0, y: 0, width: 2, height: 2, id: '0', content: "big 2x2"},
+      {x: 3, y: 1, width: 1, height: 2, id: '1', content: "<button onclick=\"alert('clicked!')\">Press me</button>"},
       {x: 4, y: 1, width: 1, height: 1, id: '2'},
       {x: 2, y: 3, width: 3, height: 1, id: '3'},
       {x: 1, y: 3, width: 1, height: 1, id: '4'}
@@ -59,7 +59,7 @@
       if (grid.engine.nodes.length === 0) {
         // load from empty
         items.forEach(function (item) {
-          grid.addWidget('<div><div class="grid-stack-item-content">' + item.id + '</div></div>', item);
+          grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">' + item.id + '</div></div>', item);
         });
       } else {
         // else update existing nodes (instead of calling grid.removeAll())

--- a/demo/two.html
+++ b/demo/two.html
@@ -101,18 +101,14 @@
     let items = [
       {x: 0, y: 0, width: 2, height: 2},
       {x: 3, y: 1, width: 1, height: 2},
-      {x: 4, y: 1, width: 1, height: 1},
-      {x: 2, y: 3, width: 3, height: 1, maxWidth: 3, id: 'special', text: 'has maxWidth=3'},
-      {x: 2, y: 5, width: 1, height: 1}
+      {x: 4, y: 1, width: 1},
+      {x: 2, y: 3, width: 3, maxWidth: 3, id: 'special', content: 'has maxWidth=3'},
+      {x: 2, y: 5, width: 1}
     ];
 
     grids.forEach(function (grid, i) {
       addEvents(grid, i);
-      grid.batchUpdate();
-      items.forEach(function (node) {
-        grid.addWidget('<div><div class="grid-stack-item-content">' + (node.text? node.text : '') + '</div></div>', node);
-      });
-      grid.commit();
+      grid.load(items);
     });
 
     function toggleFloat(button, i) {

--- a/demo/vue2js.html
+++ b/demo/vue2js.html
@@ -41,11 +41,11 @@
           timerId: undefined,
         },
         items: [
-          { x: 2, y: 1, width: 1, height: 2 },
-          { x: 2, y: 4, width: 3, height: 1 },
-          { x: 4, y: 2, width: 1, height: 1 },
-          { x: 3, y: 1, width: 1, height: 2 },
-          { x: 0, y: 6, width: 2, height: 2 },
+          { x: 2, y: 1, height: 2 },
+          { x: 2, y: 4, width: 3},
+          { x: 4, y: 2, width: 1},
+          { x: 3, y: 1, height: 2 },
+          { x: 0, y: 6, width: 2, height: 2 }
         ],
         watch: {
           /**
@@ -79,11 +79,8 @@
               width: Math.round(1 + 3 * Math.random()),
               height: Math.round(1 + 3 * Math.random()),
             };
-            this.count++;
-            this.grid.addWidget(
-              `<div><div class="grid-stack-item-content">${this.count}</div></div>`,
-              { id: this.count, ...node }
-            );
+            node.id = node.content = String(this.count++);
+            this.grid.addWidget(node);
           },
         },
       });

--- a/demo/vue3js.html
+++ b/demo/vue3js.html
@@ -39,11 +39,11 @@
           };
         },
         items: [
-          { x: 2, y: 1, width: 1, height: 2 },
-          { x: 2, y: 4, width: 3, height: 1 },
-          { x: 4, y: 2, width: 1, height: 1 },
-          { x: 3, y: 1, width: 1, height: 2 },
-          { x: 0, y: 6, width: 2, height: 2 },
+          { x: 2, y: 1, height: 2 },
+          { x: 2, y: 4, width: 3},
+          { x: 4, y: 2, width: 1},
+          { x: 3, y: 1, height: 2 },
+          { x: 0, y: 6, width: 2, height: 2 }
         ],
         watch: {
           /**
@@ -77,11 +77,8 @@
               width: Math.round(1 + 3 * Math.random()),
               height: Math.round(1 + 3 * Math.random()),
             };
-            this.count++;
-            this.grid.addWidget(
-              `<div><div class="grid-stack-item-content">${this.count}</div></div>`,
-              { id: this.count, ...node }
-            );
+            node.id = node.content = String(this.count++);
+            this.grid.addWidget(node);
           },
         },
       }).mount("#app");

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -43,7 +43,9 @@ Change log
 
 - fix grid `static: true` to no longer add any drag&drop (even disabled) which should speed things up, and `setStatic(T/F)` will now correctly add it back/delete for items that need it only. 
 Also fixed JQ draggable warning if not initialized first [858](https://github.com/gridstack/gridstack.js/issues/858)
-- add `GridStackWidget.html` now lets you add any HTML content when calling `grid.load()`
+- add `addWidget(opt)` now handles just passing a `GridStackWidget` which creates the default divs, simplifying your code. Old API still supported.
+- add `save(saveContent = true)` now lets you optionally save the HTML content in the node property, with load() restoring it [1418](https://github.com/gridstack/gridstack.js/issues/1418)
+- add `GridStackWidget.content` now lets you add any HTML content when calling `load()/save()` or `addWidget()` [1418](https://github.com/gridstack/gridstack.js/issues/1418)
 
 ## 2.0.2 (2020-10-05)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -137,7 +137,7 @@ You need to add `noResize` and `noMove` attributes to completely lock the widget
 - `noMove` - disable element moving
 - `resizeHandles` - sets resize handles for a specific widget.
 - `id`- (number | string) good for quick identification (for example in change event)
-- `html` - (string) html content to be added when calling `grid.load()` as content inside the item
+- `content` - (string) html content to be added when calling `grid.load()/addWidget()` as content inside the item
 
 ## Item attributes
 
@@ -254,21 +254,23 @@ grid.on('resizestop', function(event: Event, el: GridItemHTMLElement) {
 
 ## API
 
-### addWidget(el, [options])
+### addWidget(el?: GridStackWidget | GridStackElement, options?: GridStackWidget)
 
 Creates new widget and returns it. Options is an object containing the fields x,y,width,height,etc...
 
 Parameters:
 
-- `el` - html element or string definition to add
-- `options` widget position/size options (optional) - see GridStackWidget
+- `el`: GridStackWidget | GridStackElement -  html element, or string definition, or GridStackWidget (which can have content string as well) to add
+- `options`: GridStackWidget - widget position/size options (optional, and ignore if first param is already option) - see GridStackWidget
 
 Widget will be always placed even if result height is more than actual grid height. You need to use `willItFit` method
 before calling `addWidget` for additional check.
 
 ```js
 let grid = GridStack.init();
-grid.addWidget('<div><div class="grid-stack-item-content">hello</div></div>', {width: 3});
+grid.addWidget({width: 3, content: 'hello'});
+// or
+grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">hello</div></div>', {width: 3});
 ```
 
 ### batchUpdate()
@@ -499,9 +501,9 @@ Enables/Disables resizing.
 - `el` - widget to modify
 - `val` - if `true` widget will be resizable.
 
-### save(): GridStackWidget[]
+### save(saveContent = true): GridStackWidget[]
 
-- returns the layout of the grid that can be serialized (list of item non default attributes, not just w,y,x,y but also min/max and id). See `load()`
+- returns the layout of the grid (and optionally the html content as well) that can be serialized (list of item non default attributes, not just w,y,x,y but also min/max and id). See `load()`
 - see [example](http://gridstackjs.com/demo/serialization.html)
 
 ### setAnimation(doAnimate)

--- a/spec/e2e/html/1155-max-row.html
+++ b/spec/e2e/html/1155-max-row.html
@@ -17,19 +17,11 @@
 
   <script type="text/javascript">
     let grid = GridStack.init({float: true, maxRow: 3});
-
     let items = [
-      {x: 0, y: 1, width: 1, height: 2},
-      {x: 1, y: 3, width: 2, height: 1, text: 'Y=3 out of bound should align'}
+      {x: 0, y: 1, width: 1, height: 2, content: '0'},
+      {x: 1, y: 3, width: 2, height: 1, content: 'Y=3 out of bound should align'}
     ];
-    let count = 0;
-
-    grid.batchUpdate();
-    items.forEach(function (node) {
-      node.id = count++;
-      grid.addWidget('<div><div class="grid-stack-item-content">' + (node.text? node.text : node.id) +'</div></div>', node);
-    });
-    grid.commit();
+    grid.load(items);
   </script>
 </body>
 </html>

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -31,8 +31,7 @@
     let grid = GridStack.init(options);
 
     addNewWidget = function() {
-      grid.addWidget('<div><div class="grid-stack-item-content">' + count + '</div></div>', {id: count});
-      count++
+      grid.addWidget({content: String(count++)});
     };
 
     grid.batchUpdate();

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -8,10 +8,10 @@ describe('gridstack', function() {
   let gridHTML =
   '<div class="grid-stack">' +
   '  <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2" data-gs-id="item1" id="item1">' +
-  '    <div class="grid-stack-item-content">item 1</div>' +
+  '    <div class="grid-stack-item-content">item 1 text</div>' +
   '  </div>' +
   '  <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4" data-gs-id="item2" id="item2">' +
-  '    <div class="grid-stack-item-content">item 2</div>' +
+  '    <div class="grid-stack-item-content">item 2 text</div>' +
   '  </div>' +
   '</div>';
   let gridstackHTML =
@@ -301,7 +301,7 @@ describe('gridstack', function() {
       expect(parseInt(el2.attr('data-gs-height'))).toBe(4);
 
       // add default 1x1 item to the end (1 column)
-      let el3 = $(grid.addWidget(widgetHTML));
+      let el3 = $(grid.addWidget());
       expect(el3).not.toBe(null);
       expect(parseInt(el3.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(6);
@@ -400,9 +400,9 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       grid.batchUpdate();
       grid.batchUpdate();
-      let el1 = $(grid.addWidget(widgetHTML, {width:1, height:1}));
-      let el2 = $(grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1}));
-      let el3 = $(grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2}));
+      let el1 = $(grid.addWidget({width:1, height:1}));
+      let el2 = $(grid.addWidget({x:2, y:0, width:2, height:1}));
+      let el3 = $(grid.addWidget({x:1, y:0, width:1, height:2}));
       grid.commit();
       grid.commit();
       
@@ -446,9 +446,9 @@ describe('gridstack', function() {
         float: true
       };
       let grid = GridStack.init(options);
-      let el1 = $(grid.addWidget(widgetHTML, {width:1, height:1}));
-      let el2 = $(grid.addWidget(widgetHTML, {x:2, y:0, width:2, height:1}));
-      let el3 = $(grid.addWidget(widgetHTML, {x:1, y:0, width:1, height:2}));
+      let el1 = $(grid.addWidget({width:1, height:1}));
+      let el2 = $(grid.addWidget({x:2, y:0, width:2, height:1}));
+      let el3 = $(grid.addWidget({x:1, y:0, width:1, height:2}));
 
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
@@ -572,7 +572,7 @@ describe('gridstack', function() {
       expect(grid.getRow()).toBe(4);
       expect(grid.opts.minRow).toBe(4);
       expect(grid.opts.maxRow).toBe(4);
-      grid.addWidget(widgetHTML, {height: 6});
+      grid.addWidget({height: 6});
       expect(grid.engine.getRow()).toBe(4);
       expect(grid.getRow()).toBe(4);
     });
@@ -756,7 +756,7 @@ describe('gridstack', function() {
     });
     it('should keep all widget options the same (autoPosition off', function() {
       let grid = GridStack.init({float: true});;
-      let widget = grid.addWidget(widgetHTML, {x: 6, y:7, width:2, height:3, autoPosition:false,
+      let widget = grid.addWidget({x: 6, y:7, width:2, height:3, autoPosition:false,
         minWidth:1, maxWidth:4, minHeight:2, maxHeight:5, id:'coolWidget'});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(6);
@@ -810,7 +810,7 @@ describe('gridstack', function() {
     });
     it('should change x, y coordinates for widgets.', function() {
       let grid = GridStack.init({float: true});
-      let widget = grid.addWidget(widgetHTML, {x:9, y:7, width:2, height:3, autoPosition:true});
+      let widget = grid.addWidget({x:9, y:7, width:2, height:3, autoPosition:true});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).not.toBe(9);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).not.toBe(7);
@@ -826,7 +826,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing X,Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({height: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -841,7 +841,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing X)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {y: 9, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({y: 9, height: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -856,7 +856,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {x: 9, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({x: 9, height: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -871,7 +871,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (correct X, missing Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {x: 8, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({x: 8, height: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -886,7 +886,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (empty options)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {});
+      let widget = grid.addWidget();
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -910,7 +910,7 @@ describe('gridstack', function() {
     });
     it('bad string options should use default', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget(widgetHTML, {x: 'foo', y: null, width: 'bar', height: ''} as any);
+      let widget = grid.addWidget({x: 'foo', y: null, width: 'bar', height: ''} as any);
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
@@ -919,16 +919,16 @@ describe('gridstack', function() {
     });
     it('null options should clear x position', function() {
       let grid = GridStack.init({float: true});
-      let widgetHTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
-      let widget = grid.addWidget(widgetHTML, {x:null, y:null, width:undefined});
+      let HTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
+      let widget = grid.addWidget(HTML, {x:null, y:null, width:undefined});
       
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
     });
     it('width attr should be retained', function() { // #1276
       let grid = GridStack.init({float: true});
-      let widgetHTML = '<div class="grid-stack-item" data-gs-width="3" data-gs-max-width="4" data-gs-id="foo"><div class="grid-stack-item-content"></div></div>';
-      let widget = grid.addWidget(widgetHTML, {x: 1, y: 5});
+      let HTML = '<div class="grid-stack-item" data-gs-width="3" data-gs-max-width="4" data-gs-id="foo"><div class="grid-stack-item-content"></div></div>';
+      let widget = grid.addWidget(HTML, {x: 1, y: 5});
       expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(1);
       expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(5);
       expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(3);
@@ -1392,7 +1392,7 @@ describe('gridstack', function() {
     it('should move all 3 items to top-left with no space', function() {
       let grid = GridStack.init({float: true});
 
-      let el3 = $(grid.addWidget(widgetHTML, {x: 3, y: 5}));
+      let el3 = $(grid.addWidget({x: 3, y: 5}));
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
 
@@ -1403,7 +1403,7 @@ describe('gridstack', function() {
     it('not move locked item', function() {
       let grid = GridStack.init({float: true});
 
-      let el3 = $(grid.addWidget(widgetHTML, {x: 3, y: 5, locked: true, noMove: true}));
+      let el3 = $(grid.addWidget({x: 3, y: 5, locked: true, noMove: true}));
       expect(parseInt(el3.attr('data-gs-x'))).toBe(3);
       expect(parseInt(el3.attr('data-gs-y'))).toBe(5);
 
@@ -1422,11 +1422,11 @@ describe('gridstack', function() {
     });
     it('not move locked item, size down added one', function() {
       let grid = GridStack.init();
-      let el1 = $(grid.addWidget(widgetHTML, {x: 0, y: 1, width: 12, height: 1, locked: true}));
+      let el1 = $(grid.addWidget({x: 0, y: 1, width: 12, height: 1, locked: true}));
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(1);
 
-      let el2 = $(grid.addWidget(widgetHTML, {x: 2, y: 0, height: 3}));
+      let el2 = $(grid.addWidget({x: 2, y: 0, height: 3}));
       expect(parseInt(el1.attr('data-gs-x'))).toBe(0);
       expect(parseInt(el1.attr('data-gs-y'))).toBe(1);
       expect(parseInt(el2.attr('data-gs-x'))).toBe(2);
@@ -1541,31 +1541,35 @@ describe('gridstack', function() {
     });
     it('save layout', function() {
       let grid = GridStack.init();
-      let layout = grid.save();
+      let layout = grid.save(false);
       expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'item1'}, {x:4, y:0, width:4, height:4, id:'item2'}]);
+      layout = grid.save();
+      expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'item1', content:'item 1 text'}, {x:4, y:0, width:4, height:4, id:'item2', content:'item 2 text'}]);
+      layout = grid.save(true);
+      expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'item1', content:'item 1 text'}, {x:4, y:0, width:4, height:4, id:'item2', content:'item 2 text'}]);
     });
     it('load move 1 item, delete others', function() {
       let grid = GridStack.init();
       grid.load([{x:2, height:1, id:'item2'}]);
-      let layout = grid.save();
+      let layout = grid.save(false);
       expect(layout).toEqual([{x:2, y:0, width:4, height:1, id:'item2'}]);
     });
     it('load add new, delete others', function() {
       let grid = GridStack.init();
       grid.load([{width:2, height:1, id:'item3'}], true);
-      let layout = grid.save();
+      let layout = grid.save(false);
       expect(layout).toEqual([{x:0, y:0, width:2, height:1, id:'item3'}]);
     });
     it('load size 1 item only', function() {
       let grid = GridStack.init();
       grid.load([{height:3, id:'item1'}], false);
-      let layout = grid.save();
+      let layout = grid.save(false);
       expect(layout).toEqual([{x:0, y:0, width:4, height:3, id:'item1'}, {x:4, y:0, width:4, height:4, id:'item2'}]);
     });
     it('load size 1 item only with callback', function() {
       let grid = GridStack.init();
       grid.load([{height:3, id:'item1'}], () => {});
-      let layout = grid.save();
+      let layout = grid.save(false);
       expect(layout).toEqual([{x:0, y:0, width:4, height:3, id:'item1'}, {x:4, y:0, width:4, height:4, id:'item2'}]);
     });
   });

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -471,14 +471,14 @@ export class GridStackEngine {
   }
 
   /** saves the current layout returning a list of widgets for serialization */
-  public save(): GridStackWidget[] {
-    let widgets: GridStackWidget[] = [];
+  public save(saveElement = true): GridStackNode[] {
+    let widgets: GridStackNode[] = [];
     Utils.sort(this.nodes);
     this.nodes.forEach(n => {
       let w: GridStackNode = {};
       for (let key in n) { if (key[0] !== '_' && n[key] !== null && n[key] !== undefined ) w[key] = n[key]; }
       // delete other internals
-      delete w.el;
+      if (!saveElement) delete w.el;
       delete w.grid;
       // delete default values (will be re-created on read)
       if (!w.autoPosition) delete w.autoPosition;

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,8 +204,8 @@ export interface GridStackWidget {
   resizeHandles?: string;
   /** value for `data-gs-id` stored on the widget (default?: undefined) */
   id?: numberOrString;
-  /** html to append inside the content */
-  html?: string;
+  /** html to append inside as content */
+  content?: string;
 }
 
 /** Drag&Drop resize options */


### PR DESCRIPTION
### Description
fix for #1418
* `save(saveContent = true)` now lets you optionally save the HTML content in the node property, with load() restoring it
* `addWidget(opt)` now handles just passing a `GridStackWidget` which creates the default divs, simplifying your code. Old API still supported.
* fixed all demos and test case to use newer API

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
