### PR TITLE
custom column re-layout callback

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -16,11 +16,12 @@
     <div><span>Number of Columns:</span> <span id="column-text">12</span></div>
     <div>
       <label>Choose re-layout:</label>
-      <select onchange="layout = this.value">
+      <select onchange="setLayout(this.value)">
         <option value="moveScale">move + scale</option>
         <option value="move">move</option>
         <option value="scale">scale</option>
         <option value="none">none</option>
+        <option value="custom">custom</option>
       </select>
     </div>
     <div>
@@ -90,6 +91,17 @@
       grid.opts.oneColumnModeDomSort = dom;
       grid.column(1, layout);
       text.innerHTML = dom ? '1 DOM' : '1';
+    }
+    // dummy test method that moves items to the right each new layout... grid engine will validate those values (can't be neg or out of bounds) anyway...
+    function columnLayout(column, oldColumn, nodes, oldNodes) {
+      oldNodes.forEach(n => {
+        n.x = n.x + 1;
+        nodes.push(n);
+      });
+      oldNodes.length = 0;
+    }
+    function setLayout(name) {
+      layout = name === 'custom' ? this.columnLayout : name;
     }
 
   </script>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -46,7 +46,8 @@ Also fixed JQ draggable warning if not initialized first [858](https://github.co
 - add `addWidget(opt)` now handles just passing a `GridStackWidget` which creates the default divs, simplifying your code. Old API still supported.
 - add `save(saveContent = true)` now lets you optionally save the HTML content in the node property, with load() restoring it [1418](https://github.com/gridstack/gridstack.js/issues/1418)
 - add `GridStackWidget.content` now lets you add any HTML content when calling `load()/save()` or `addWidget()` [1418](https://github.com/gridstack/gridstack.js/issues/1418)
-- add `LayoutOptions` to `column()` for multiple re-layout options, including 'none' that will preserve the x and width, until out of bound/overlap [1338](https://github.com/gridstack/gridstack.js/issues/1338)
+- add `ColumnOptions` to `column(n, options)` for multiple re-layout options, including 'none' that will preserve the x and width, until out of bound/overlap [1338](https://github.com/gridstack/gridstack.js/issues/1338)
+including a custom function for you to create the new layout [1332](https://github.com/gridstack/gridstack.js/issues/1332)
 
 ## 2.0.2 (2020-10-05)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,7 +27,7 @@ gridstack.js API
   - [cellHeight(val: number, update = true)](#cellheightval-number-update--true)
   - [cellWidth()](#cellwidth)
   - [commit()](#commit)
-  - [column(column: number, layout: LayoutOptions = 'moveScale')](#columncolumn-number-layout-layoutoptions--movescale)
+  - [column(column: number, layout: ColumnOptions = 'moveScale')](#columncolumn-number-layout-columnoptions--movescale)
   - [destroy([removeDOM])](#destroyremovedom)
   - [disable()](#disable)
   - [enable()](#enable)
@@ -298,7 +298,7 @@ Gets current cell width (grid width / # of columns).
 
 Ends batch updates. Updates DOM nodes. You must call it after `batchUpdate()`.
 
-### column(column: number, layout: LayoutOptions = 'moveScale')
+### column(column: number, layout: ColumnOptions = 'moveScale')
 
 set/get the number of columns in the grid. Will update existing widgets to conform to new number of columns,
 as well as cache the original layout so you can revert back to previous positions without loss.
@@ -308,7 +308,9 @@ else you will need to generate correct CSS (see https://github.com/gridstack/gri
 - `column` - Integer > 0 (default 12), if missing it will return the current count instead.
 - `layout` - specify the type of re-layout that will happen (position, size, etc...).
 Note: items will never be outside of the current column boundaries. default ('moveScale'). Ignored for 1 column.
-Possible values: 'moveScale' | 'move' | 'scale' | 'none'
+Possible values: 'moveScale' | 'move' | 'scale' | 'none' | (column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void.
+A custom function option takes new/old column count, and array of new/old positions.
+Note: new list may be partially already filled if we have a partial cache of the layout at that size (items were added later). If complete cache is present this won't get called at all.
 
 ### destroy([removeDOM])
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -8,7 +8,7 @@
 
 import { GridStackEngine } from './gridstack-engine';
 import { obsoleteOpts, obsoleteOptsDel, obsoleteAttr, obsolete, Utils } from './utils';
-import { GridItemHTMLElement, GridStackWidget, GridStackNode, GridStackOptions, numberOrString, LayoutOptions } from './types';
+import { GridItemHTMLElement, GridStackWidget, GridStackNode, GridStackOptions, numberOrString, ColumnOptions } from './types';
 import { GridStackDD } from './gridstack-dd';
 
 // export all dependent file as well to make it easier for users to just import the main file
@@ -516,7 +516,7 @@ export class GridStack {
    * @param layout specify the type of re-layout that will happen (position, size, etc...).
    * Note: items will never be outside of the current column boundaries. default (moveScale). Ignored for 1 column
    */
-  public column(column: number, layout: LayoutOptions = 'moveScale'): GridStack {
+  public column(column: number, layout: ColumnOptions = 'moveScale'): GridStack {
     if (this.opts.column === column) { return this; }
     let oldColumn = this.opts.column;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,12 @@ import { GridStack } from './gridstack';
 import { GridStackDD } from './gridstack-dd';
 
 
-/** different layout options when changing # of columns and other re-layouts */
-export type LayoutOptions = 'moveScale' | 'move' | 'scale' | 'none';
+/** different layout options when changing # of columns,
+ * including a custom function that takes new/old column count, and array of new/old positions
+ * Note: new list may be partially already filled if we have a cache of the layout at that size and new items were added later.
+ */
+export type ColumnOptions = 'moveScale' | 'move' | 'scale' | 'none' |
+  ((column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void);
 
 export type numberOrString = number | string;
 export interface GridItemHTMLElement extends HTMLElement {


### PR DESCRIPTION
### Description
* fix for #1332
* in addition to some pre-built method, you can now have your own callback that is given the column count and nodes for you to modify
* rest of the code will validate and place those items accordingly. you only need to focus on x,y,w,h locations.
* column.html was updated to show usage

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
