### PR TITLE
added ui-XYZ-disable style back

### DIFF
--- a/demo/static.html
+++ b/demo/static.html
@@ -13,19 +13,20 @@
 <body>
   <div class="container-fluid">
     <h1>Static vs can move/drag Demo</h1>
+    <p>we start with a static grid (no drag&drop initialized) with button to make it editable.</p>
     <div>
       <a class="btn btn-primary" onClick="grid.setStatic(true)" href="#">Static</a>
       <a class="btn btn-primary" onclick="grid.setStatic(false)" id="float" href="#">Editable</a>
     </div>
     <br><br>
-    <div class="grid-stack"></div>
+    <div class="grid-stack" data-gs-static-grid="true"></div>
   </div>
   <script src="events.js"></script>
   <script type="text/javascript">
     let grid = GridStack.init({
       float: true,
       cellHeight: 70,
-      staticGrid: true
+      //staticGrid: true // same but testing data-gs above
     });
     addEvents(grid);
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -42,7 +42,8 @@ Change log
 
 ## 2.1.0-dev
 
-- TBD
+- fix `class="ui-draggable-disabled ui-resizable-disabled"` have been added back to static grid items, so existing CSS rule to style continue working [1435](https://github.com/gridstack/gridstack.js/issues/1435)
+- add `data-gs-staticGrid` attribute
 
 ## 2.1.0 (2020-10-28)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -117,7 +117,7 @@ gridstack.js API
 
 ## Grid attributes
 
-most of the above options are also available as HTML attributes using the `data-gs-` name prefix with standard dash lower case naming convention (ex: `data-gs-column`, `data-gs-min-row`, etc..).
+most of the above options are also available as HTML attributes using the `data-gs-` name prefix with standard dash lower case naming convention (ex: `data-gs-column`, `data-gs-min-row`, `data-gs-static-grid`, etc..).
 
 Extras:
 - `data-gs-current-row` - (internal) current rows amount. Set by the library only. Can be used by the CSS rules.

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1345,7 +1345,7 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       grid.locked('.grid-stack-item', true);
       $('.grid-stack-item').each(function (i,item) {
-        expect($(item).attr('data-gs-locked')).toBe('yes');
+        expect($(item).attr('data-gs-locked')).toBe('true');
       })
     });
     it('should unlock widgets', function() {


### PR DESCRIPTION
### Description
* fix for 1435
* `class="ui-draggable-disabled ui-resizable-disabled"` have been added back to static grid items, so existing CSS rule to style continue working
* add `data-gs-staticGrid` attribute

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
