### PR TITLE
Bug fix: Init with marginTop prop or other margin props will turn height to 1 when resize a grid

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1854,6 +1854,10 @@ export class GridStack {
       this.opts.marginLeft = data.height;
       delete this.opts.margin;
     }
+    
+    //without this.opts.margin, getMargin method will return undefined, and affect resize behavior
+    if(!this.opts.margin) this.opts.margin = Math.round((this.opts.marginTop + this.opts.marginBottom) / 2);
+    
     this.opts.marginUnit = data.unit; // in case side were spelled out, use those units instead...
     return this;
   }


### PR DESCRIPTION
### Description
Bug fix: Init with marginTop prop or other margin props will turn height to 1 when resize a grid

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
