### PR TITLE
H5: resizing performance

### DIFF
--- a/src/dragdrop/dd-base-impl.ts
+++ b/src/dragdrop/dd-base-impl.ts
@@ -1,8 +1,7 @@
 // dd-base-impl.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 export type EventCallback = (event: Event) => boolean|void;
@@ -28,7 +27,7 @@ export abstract class DDBaseImplement {
   }
   triggerEvent(eventName: string, event: Event): boolean|void {
     if (this.disabled) { return; }
-    if (!this.eventRegister) {return; } // used when destory before triggerEvent fire
+    if (!this.eventRegister) {return; } // used when destroy before triggerEvent fire
     if (this.eventRegister[eventName]) {
       return this.eventRegister[eventName](event);
     }

--- a/src/dragdrop/dd-draggable.ts
+++ b/src/dragdrop/dd-draggable.ts
@@ -1,34 +1,33 @@
 // dd-draggable.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 import { DDManager } from './dd-manager';
 import { DDUtils } from './dd-utils';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 
-export interface DDDraggbleOpt {
+export interface DDDraggableOpt {
   appendTo?: string | HTMLElement;
-  containment?: string | HTMLElement; // TODO: not impleament yet
+  containment?: string | HTMLElement; // TODO: not implemented yet
   handle?: string;
-  revert?: string | boolean | unknown; // TODO: not impleament yet
+  revert?: string | boolean | unknown; // TODO: not implemented yet
   scroll?: boolean; // nature support by HTML5 drag drop, can't be switch to off actually
   helper?: string | ((event: Event) => HTMLElement);
-  basePosision?: 'fixed' | 'absolute';
+  basePosition?: 'fixed' | 'absolute';
   start?: (event?, ui?) => void;
   stop?: (event?, ui?) => void;
   drag?: (event?, ui?) => void;
 };
-export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<DDDraggbleOpt> {
+export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt<DDDraggableOpt> {
   static basePosition: 'fixed' | 'absolute' = 'absolute';
-  static dragEventListinerOption = DDUtils.isEventSupportPassiveOption ? { capture: true, passive: true } : true;
+  static dragEventListenerOption = DDUtils.isEventSupportPassiveOption ? { capture: true, passive: true } : true;
   static originStyleProp = ['transition', 'pointerEvents', 'position',
     'left', 'top', 'opacity', 'zIndex', 'width', 'height', 'willChange'];
   el: HTMLElement;
   helper: HTMLElement;
-  option: DDDraggbleOpt;
+  option: DDDraggableOpt;
   dragOffset: {
     left: number;
     top: number;
@@ -45,7 +44,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
   parentOriginStylePosition: string;
   helperContainment: HTMLElement;
 
-  constructor(el: HTMLElement, option: DDDraggbleOpt) {
+  constructor(el: HTMLElement, option: DDDraggableOpt) {
     super();
     this.el = el;
     this.option = option || {};
@@ -84,7 +83,6 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
     this.el.classList.add('ui-draggable');
     this.el.addEventListener('mousedown', this.mouseDown);
     this.el.addEventListener('dragstart', this.dragStart);
-    this.dragThrottle = DDUtils.throttle(this.drag, 100);
   }
 
   protected mouseDown = (event: MouseEvent) => {
@@ -119,17 +117,16 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
 
   protected setupDragFollowNodeNNotifyStart(ev) {
     this.setupHelperStyle();
-    document.addEventListener('dragover', this.dragThrottle, DDDraggble.dragEventListinerOption);
+    document.addEventListener('dragover', this.drag, DDDraggable.dragEventListenerOption);
     this.el.addEventListener('dragend', this.dragEnd);
     if (this.option.start) {
       this.option.start(ev, this.ui());
     }
-    this.triggerEvent('dragstart', ev);
     this.dragging = true;
     this.helper.classList.add('ui-draggable-dragging');
+    this.triggerEvent('dragstart', ev);
   }
 
-  protected dragThrottle: (event: DragEvent) => void;
   protected drag = (event: DragEvent) => {
     this.dragFollow(event);
     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'drag' });
@@ -148,7 +145,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
       if (this.paintTimer) {
         cancelAnimationFrame(this.paintTimer);
       }
-      document.removeEventListener('dragover', this.dragThrottle, DDDraggble.dragEventListinerOption);
+      document.removeEventListener('dragover', this.drag, DDDraggable.dragEventListenerOption);
       this.el.removeEventListener('dragend', this.dragEnd);
     }
     this.dragging = false;
@@ -181,7 +178,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
         : this.option.appendTo));
     }
     if (helper === this.el) {
-      this.dragElementOriginStyle = DDDraggble.originStyleProp.map(prop => this.el.style[prop]);
+      this.dragElementOriginStyle = DDDraggable.originStyleProp.map(prop => this.el.style[prop]);
     }
     return helper;
   }
@@ -191,8 +188,8 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
     this.helper.style.width = this.dragOffset.width + 'px';
     this.helper.style.height = this.dragOffset.height + 'px';
     this.helper.style['willChange'] = 'left, top';
-    this.helper.style.transition = 'none'; // show up instancely
-    this.helper.style.position = this.option.basePosision || DDDraggble.basePosition;
+    this.helper.style.transition = 'none'; // show up instantly
+    this.helper.style.position = this.option.basePosition || DDDraggable.basePosition;
     this.helper.style.zIndex = '1000';
     setTimeout(() => {
       if (this.helper) {
@@ -202,7 +199,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
   }
 
   private removeHelperStyle() {
-    DDDraggble.originStyleProp.forEach(prop => {
+    DDDraggable.originStyleProp.forEach(prop => {
       this.helper.style[prop] = this.dragElementOriginStyle[prop] || null;
     });
     this.dragElementOriginStyle = undefined;
@@ -227,7 +224,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
 
   private setupHelperContainmentStyle() {
     this.helperContainment = this.helper.parentElement;
-    if (this.option.basePosision !== 'fixed') {
+    if (this.option.basePosition !== 'fixed') {
       this.parentOriginStylePosition = this.helperContainment.style.position;
       if (window.getComputedStyle(this.helperContainment).position.match(/static/)) {
         this.helperContainment.style.position = 'relative';
@@ -255,7 +252,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
   }
 
   private getDragOffset(event: DragEvent, el: HTMLElement, attachedParent: HTMLElement) {
-    // in case ancestor has transform/perspective css properies that change the viewpoint
+    // in case ancestor has transform/perspective css properties that change the viewpoint
     const getViewPointFromParent = (parent) => {
       if (!parent) { return null; }
       const testEl = document.createElement('div');
@@ -293,9 +290,9 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
   }
   destroy() {
     if (this.dragging) {
-      // Destroy while draggging should remove dragend listener and manally trigger
-      // dragend, otherwise dragEnd can't perform dragstop becasue eventResistry is
-      // destoryed.
+      // Destroy while dragging should remove dragend listener and manually trigger
+      // dragend, otherwise dragEnd can't perform dragstop because eventRegistry is
+      // destroyed.
       this.dragEnd({} as DragEvent);
     }
     this.el.draggable = false;
@@ -317,7 +314,7 @@ export class DDDraggble extends DDBaseImplement implements HTMLElementExtendOpt<
         top: offset.top - containmentRect.top,
         left: offset.left - containmentRect.left
       }, //Current CSS position of the helper as { top, left } object
-      offset: { top: offset.top, left: offset.left }// Current offset position of the helper as { top, left } object.
+      offset: { top: offset.top, left: offset.left } // Current offset position of the helper as { top, left } object.
     };
   }
 }

--- a/src/dragdrop/dd-droppable.ts
+++ b/src/dragdrop/dd-droppable.ts
@@ -1,28 +1,27 @@
 // dd-droppable.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
-import { DDDraggble } from './dd-draggable';
+import { DDDraggable } from './dd-draggable';
 import { DDManager } from './dd-manager';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { DDUtils } from './dd-utils';
 
-export interface DDDropableOpt {
+export interface DDDroppableOpt {
   accept?: string | ((el: HTMLElement) => boolean);
   drop?: (event: DragEvent, ui) => void;
   over?: (event: DragEvent, ui) => void;
   out?: (event: DragEvent, ui) => void;
 };
-export class DDDropable extends DDBaseImplement implements HTMLElementExtendOpt<DDDropableOpt> {
+export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt<DDDroppableOpt> {
   accept: (el: HTMLElement) => boolean;
   el: HTMLElement;
-  option: DDDropableOpt;
+  option: DDDroppableOpt;
   private acceptable: boolean = null;
   private style;
-  constructor(el: HTMLElement, opts: DDDropableOpt) {
+  constructor(el: HTMLElement, opts: DDDroppableOpt) {
     super();
     this.el = el;
     this.option = opts || {};
@@ -152,10 +151,10 @@ export class DDDropable extends DDBaseImplement implements HTMLElementExtendOpt<
     super.destroy();
   }
 
-  ui(ddDraggble: DDDraggble) {
+  ui(DDDraggable: DDDraggable) {
     return {
-      draggable: ddDraggble.el,
-      ...ddDraggble.ui()
+      draggable: DDDraggable.el,
+      ...DDDraggable.ui()
     };
   }
 }

--- a/src/dragdrop/dd-element.ts
+++ b/src/dragdrop/dd-element.ts
@@ -1,14 +1,13 @@
 // dd-elements.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 import { DDResizable, DDResizableOpt } from './dd-resizable';
 import { GridItemHTMLElement } from './../types';
-import { DDDraggble, DDDraggbleOpt } from './dd-draggable';
-import { DDDropable, DDDropableOpt } from './dd-droppable';
+import { DDDraggable, DDDraggableOpt } from './dd-draggable';
+import { DDDroppable, DDDroppableOpt } from './dd-droppable';
 export interface DDElementHost extends GridItemHTMLElement {
   ddElement?: DDElement;
 }
@@ -18,8 +17,8 @@ export class DDElement {
     return el.ddElement;
   }
   el: DDElementHost;
-  ddDraggable?: DDDraggble;
-  ddDroppable?: DDDropable;
+  ddDraggable?: DDDraggable;
+  ddDroppable?: DDDroppable;
   ddResizable?: DDResizable;
   constructor(el: DDElementHost) {
     this.el = el;
@@ -54,9 +53,9 @@ export class DDElement {
     }
     return;
   }
-  setupDraggable(opts: DDDraggbleOpt) {
+  setupDraggable(opts: DDDraggableOpt) {
     if (!this.ddDraggable) {
-      this.ddDraggable = new DDDraggble(this.el, opts);
+      this.ddDraggable = new DDDraggable(this.el, opts);
     } else {
       this.ddDraggable.updateOption(opts);
     }
@@ -73,9 +72,9 @@ export class DDElement {
     this.ddDraggable.destroy();
     this.ddDraggable = undefined;
   }
-  setupDroppable(opts: DDDropableOpt) {
+  setupDroppable(opts: DDDroppableOpt) {
     if (!this.ddDroppable) {
-      this.ddDroppable = new DDDropable(this.el, opts);
+      this.ddDroppable = new DDDroppable(this.el, opts);
     } else {
       this.ddDroppable.updateOption(opts);
     }

--- a/src/dragdrop/dd-manager.ts
+++ b/src/dragdrop/dd-manager.ts
@@ -1,11 +1,10 @@
 // dd-manager.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
-import { DDDraggble } from './dd-draggable';
+import { DDDraggable } from './dd-draggable';
 export class DDManager {
-  static dragElement: DDDraggble;
+  static dragElement: DDDraggable;
 }

--- a/src/dragdrop/dd-resizable-handle.ts
+++ b/src/dragdrop/dd-resizable-handle.ts
@@ -1,12 +1,9 @@
 // dd-resizable-handle.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
-import { DDUtils } from "./dd-utils";
-
 export interface DDResizableHandleOpt {
   start?: (event) => void;
   move?: (event) => void;
@@ -37,17 +34,16 @@ export class DDResizableHandle {
     this.el = el;
     this.host.appendChild(this.el);
     this.el.addEventListener('mousedown', this.mouseDown);
-    this.mouseMoveThrottle = DDUtils.throttle(this.mouseMove, 100);
   }
 
   protected mouseDown = (event: MouseEvent) => {
     this.mouseDownEvent = event;
     setTimeout(() => {
-      document.addEventListener('mousemove', this.mouseMoveThrottle, true);
+      document.addEventListener('mousemove', this.mouseMove, true);
       document.addEventListener('mouseup', this.mouseUp);
       setTimeout(() => {
         if (!this.mouseMoving) {
-          document.removeEventListener('mousemove', this.mouseMoveThrottle, true);
+          document.removeEventListener('mousemove', this.mouseMove, true);
           document.removeEventListener('mouseup', this.mouseUp);
           this.mouseDownEvent = undefined;
         }
@@ -55,25 +51,24 @@ export class DDResizableHandle {
     }, 100);
   }
 
-  protected mouseMoveThrottle: (event: MouseEvent) => void;
   protected mouseMove = (event: MouseEvent) => {
     if (!this.started && !this.mouseMoving) {
       if (this.hasMoved(event, this.mouseDownEvent)) {
         this.mouseMoving = true;
-        this.triggleEvent('start', this.mouseDownEvent);
+        this.triggerEvent('start', this.mouseDownEvent);
         this.started = true;
       }
     }
     if (this.started) {
-      this.triggleEvent('move', event);
+      this.triggerEvent('move', event);
     }
   }
 
   protected mouseUp = (event: MouseEvent) => {
     if (this.mouseMoving) {
-      this.triggleEvent('stop', event);
+      this.triggerEvent('stop', event);
     }
-    document.removeEventListener('mousemove', this.mouseMoveThrottle, true);
+    document.removeEventListener('mousemove', this.mouseMove, true);
     document.removeEventListener('mouseup', this.mouseUp);
     this.mouseMoving = false;
     this.started = false;
@@ -97,11 +92,11 @@ export class DDResizableHandle {
     this.el.style.display = 'none';
   }
 
-  destory() {
+  destroy() {
     this.host.removeChild(this.el);
   }
 
-  triggleEvent(name: string, event: MouseEvent) {
+  triggerEvent(name: string, event: MouseEvent) {
     if (this.option[name]) {
       this.option[name](event);
     }

--- a/src/dragdrop/dd-resizable.ts
+++ b/src/dragdrop/dd-resizable.ts
@@ -1,8 +1,7 @@
 // dd-resizable.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 import { DDResizableHandle } from './dd-resizable-handle';
@@ -15,7 +14,7 @@ export interface DDResizableOpt {
   maxWidth?: number;
   minHeight?: number;
   minWidth?: number;
-  basePosision?: 'fixed' | 'absolute';
+  basePosition?: 'fixed' | 'absolute';
   start?: (event: MouseEvent, ui) => void;
   stop?: (event: MouseEvent, ui) => void;
   resize?: (event: MouseEvent, ui) => void;
@@ -131,6 +130,7 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     if (this.option.start) {
       this.option.start(ev, this.ui());
     }
+    this.el.classList.add('ui-resizable-resizing');
     this.triggerEvent('resizestart', ev);
   }
 
@@ -149,6 +149,7 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     if (this.option.stop) {
       this.option.stop(ev, this.ui());
     }
+    this.el.classList.remove('ui-resizable-resizing');
     this.triggerEvent('resizestop', ev);
     this.cleanHelper();
     this.startEvent = undefined;
@@ -162,7 +163,7 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     if (window.getComputedStyle(this.el.parentElement).position.match(/static/)) {
       this.el.parentElement.style.position = 'relative';
     }
-    this.el.style.position = this.option.basePosision || 'absolute'; // or 'fixed'
+    this.el.style.position = this.option.basePosition || 'absolute'; // or 'fixed'
     this.el.style.opacity = '0.8';
     this.el.style.zIndex = '1000';
   }
@@ -237,11 +238,11 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
   }
 
   protected removeHandlers() {
-    this.handlers.forEach(handle => handle.destory());
+    this.handlers.forEach(handle => handle.destroy());
     this.handlers = undefined;
   }
 
-  destory() {
+  destroy() {
     this.removeHandlers();
     if (this.option.autoHide) {
       this.el.removeEventListener('mouseover', this.showHandlers);
@@ -258,8 +259,8 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     const rect = this.temporalRect || this.originalRect;
     return {
       element: [this.el], // The object representing the element to be resized
-      helper: [], // TODO: not support yet // The object representing the helper that's being resized
-      originalElement: [this.el],// we dont wrap here, so simplify as this.el //The object representing the original element before it is wrapped
+      helper: [], // TODO: not support yet - The object representing the helper that's being resized
+      originalElement: [this.el],// we don't wrap here, so simplify as this.el //The object representing the original element before it is wrapped
       originalPosition: {
         left: this.originalRect.left - containmentRect.left,
         top: this.originalRect.top - containmentRect.top

--- a/src/dragdrop/dd-utils.ts
+++ b/src/dragdrop/dd-utils.ts
@@ -1,8 +1,7 @@
 // dd-utils.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 export class DDUtils {
@@ -44,17 +43,6 @@ export class DDUtils {
     }
   }
 
-  static throttle(callback: (...args) => void, delay: number) {
-    let isWaiting = false;
-
-    return (...args) => {
-      if (!isWaiting) {
-        callback(...args);
-        isWaiting = true;
-        setTimeout(() => isWaiting = false, delay);
-      }
-    }
-  }
   static addElStyles(el: HTMLElement, styles: { [prop: string]: string | string[] }) {
     if (styles instanceof Object) {
       for (const s in styles) {

--- a/src/dragdrop/gridstack-dd-native.ts
+++ b/src/dragdrop/gridstack-dd-native.ts
@@ -1,8 +1,7 @@
 // gridstack-dd-native.ts 2.0.2-dev @preserve
-
 /**
  * https://gridstackjs.com/
- * (c) 2020 Alain Dumesny, rhlin
+ * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
 import { DDManager } from './dd-manager';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,7 +184,7 @@ export class Utils {
     return Utils.closestByClass(el, name);
   }
 
-  /** @internal */
+  /** delay calling the given function by certain amount of time */
   static throttle(callback: () => void, delay: number) {
     let isWaiting = false;
 


### PR DESCRIPTION
### Description
* make sure to add .ui-resizable-resizing class while resizing, else we fall into CSS 300ms animation (grid default to animate)
resize is now fast like dragging
* removed drag/resize delay timeout - not needed and Util has routine anyway if we decide later
* fixed typos throughout H5 code
* changed credit order to give credit where credit is due (rhlin)
