### PR TITLE
h5: drag&drop code cleanup

### DIFF
--- a/src/dragdrop/dd-base-impl.ts
+++ b/src/dragdrop/dd-base-impl.ts
@@ -7,26 +7,32 @@
 */
 export type EventCallback = (event: Event) => boolean|void;
 export abstract class DDBaseImplement {
-  disabled = false;
+  protected disabled = false;
   private eventRegister: {
     [eventName: string]: EventCallback;
   } = {};
-  on(event: string, callback: EventCallback): void {
+
+  public on(event: string, callback: EventCallback): void {
     this.eventRegister[event] = callback;
   }
-  off(event: string) {
+
+  public off(event: string): void {
     delete this.eventRegister[event];
   }
-  enable(): void {
+
+  public enable(): void {
     this.disabled = false;
   }
-  disable(): void {
+
+  public disable(): void {
     this.disabled = true;
   }
-  destroy() {
-    this.eventRegister = undefined;
+
+  public destroy(): void {
+    delete this.eventRegister;
   }
-  triggerEvent(eventName: string, event: Event): boolean|void {
+
+  public triggerEvent(eventName: string, event: Event): boolean|void {
     if (this.disabled) { return; }
     if (!this.eventRegister) {return; } // used when destroy before triggerEvent fire
     if (this.eventRegister[eventName]) {
@@ -38,5 +44,5 @@ export abstract class DDBaseImplement {
 export interface HTMLElementExtendOpt<T> {
   el: HTMLElement;
   option: T;
-  updateOption(T): void;
+  updateOption(T): DDBaseImplement;
 }

--- a/src/dragdrop/dd-element.ts
+++ b/src/dragdrop/dd-element.ts
@@ -9,85 +9,97 @@ import { DDResizable, DDResizableOpt } from './dd-resizable';
 import { GridItemHTMLElement } from './../types';
 import { DDDraggable, DDDraggableOpt } from './dd-draggable';
 import { DDDroppable, DDDroppableOpt } from './dd-droppable';
+
 export interface DDElementHost extends GridItemHTMLElement {
   ddElement?: DDElement;
 }
+
 export class DDElement {
-  static init(el) {
-    el.ddElement = new DDElement(el);
+
+  static init(el: DDElementHost): DDElement {
+    if (!el.ddElement) { el.ddElement = new DDElement(el); }
     return el.ddElement;
   }
-  el: DDElementHost;
-  ddDraggable?: DDDraggable;
-  ddDroppable?: DDDroppable;
-  ddResizable?: DDResizable;
+
+  public el: DDElementHost;
+  public ddDraggable?: DDDraggable;
+  public ddDroppable?: DDDroppable;
+  public ddResizable?: DDResizable;
+
   constructor(el: DDElementHost) {
     this.el = el;
   }
-  on(eventName: string, callback: (event: MouseEvent) => void) {
+
+  public on(eventName: string, callback: (event: MouseEvent) => void): DDElement {
     if (this.ddDraggable && ['drag', 'dragstart', 'dragstop'].indexOf(eventName) > -1) {
       this.ddDraggable.on(eventName as 'drag' | 'dragstart' | 'dragstop', callback);
-      return;
-    }
-    if (this.ddDroppable && ['drop', 'dropover', 'dropout'].indexOf(eventName) > -1) {
+    } else if (this.ddDroppable && ['drop', 'dropover', 'dropout'].indexOf(eventName) > -1) {
       this.ddDroppable.on(eventName as 'drop' | 'dropover' | 'dropout', callback);
-      return;
-    }
-    if (this.ddResizable && ['resizestart', 'resize', 'resizestop'].indexOf(eventName) > -1) {
+    } else if (this.ddResizable && ['resizestart', 'resize', 'resizestop'].indexOf(eventName) > -1) {
       this.ddResizable.on(eventName as 'resizestart' | 'resize' | 'resizestop', callback);
-      return;
     }
-    return;
+    return this;
   }
-  off(eventName: string) {
+
+  public off(eventName: string): DDElement {
     if (this.ddDraggable && ['drag', 'dragstart', 'dragstop'].indexOf(eventName) > -1) {
       this.ddDraggable.off(eventName as 'drag' | 'dragstart' | 'dragstop');
-      return;
-    }
-    if (this.ddDroppable && ['drop', 'dropover', 'dropout'].indexOf(eventName) > -1) {
+    } else if (this.ddDroppable && ['drop', 'dropover', 'dropout'].indexOf(eventName) > -1) {
       this.ddDroppable.off(eventName as 'drop' | 'dropover' | 'dropout');
-      return;
-    }
-    if (this.ddResizable && ['resizestart', 'resize', 'resizestop'].indexOf(eventName) > -1) {
+    } else if (this.ddResizable && ['resizestart', 'resize', 'resizestop'].indexOf(eventName) > -1) {
       this.ddResizable.off(eventName as 'resizestart' | 'resize' | 'resizestop');
-      return;
     }
-    return;
+    return this;
   }
-  setupDraggable(opts: DDDraggableOpt) {
+
+  public setupDraggable(opts: DDDraggableOpt): DDElement {
     if (!this.ddDraggable) {
       this.ddDraggable = new DDDraggable(this.el, opts);
     } else {
       this.ddDraggable.updateOption(opts);
     }
+    return this;
   }
-  setupResizable(opts: DDResizableOpt) {
+
+  public cleanDraggable(): DDElement {
+    if (this.ddDraggable) {
+      this.ddDraggable.destroy();
+      delete this.ddDraggable;
+    }
+    return this;
+  }
+
+  public setupResizable(opts: DDResizableOpt): DDElement {
     if (!this.ddResizable) {
       this.ddResizable = new DDResizable(this.el, opts);
     } else {
       this.ddResizable.updateOption(opts);
     }
+    return this;
   }
-  cleanDraggable() {
-    if (!this.ddDraggable) { return; }
-    this.ddDraggable.destroy();
-    this.ddDraggable = undefined;
+
+  public cleanResizable(): DDElement {
+    if (this.ddResizable) {
+      this.ddResizable.destroy();
+      delete this.ddResizable;
+    }
+    return this;
   }
-  setupDroppable(opts: DDDroppableOpt) {
+
+  public setupDroppable(opts: DDDroppableOpt): DDElement {
     if (!this.ddDroppable) {
       this.ddDroppable = new DDDroppable(this.el, opts);
     } else {
       this.ddDroppable.updateOption(opts);
     }
+    return this;
   }
-  cleanDroppable() {
-    if (!this.ddDroppable) { return; }
-    this.ddDroppable.destroy();
-    this.ddDroppable = undefined;
-  }
-  cleanResizable() {
-    if (!this.cleanResizable) { return; }
-    this.ddResizable.destroy();
-    this.ddResizable = undefined;
+
+  public cleanDroppable(): DDElement {
+    if (this.ddDroppable) {
+      this.ddDroppable.destroy();
+      delete this.ddDroppable;
+    }
+    return this;
   }
 }

--- a/src/dragdrop/dd-manager.ts
+++ b/src/dragdrop/dd-manager.ts
@@ -6,6 +6,7 @@
  * gridstack.js may be freely distributed under the MIT license.
 */
 import { DDDraggable } from './dd-draggable';
+
 export class DDManager {
   static dragElement: DDDraggable;
 }

--- a/src/dragdrop/dd-resizable-handle.ts
+++ b/src/dragdrop/dd-resizable-handle.ts
@@ -10,15 +10,17 @@ export interface DDResizableHandleOpt {
   move?: (event) => void;
   stop?: (event) => void;
 }
+
 export class DDResizableHandle {
-  static prefix = 'ui-resizable-';
-  el: HTMLElement;
-  host: HTMLElement;
-  option: DDResizableHandleOpt;
-  dir: string;
+  public el: HTMLElement;
+  public host: HTMLElement;
+  public option: DDResizableHandleOpt;
+  public dir: string;
   private mouseMoving = false;
   private started = false;
   private mouseDownEvent: MouseEvent;
+  private static prefix = 'ui-resizable-';
+
   constructor(host: HTMLElement, direction: string, option: DDResizableHandleOpt) {
     this.host = host;
     this.dir = direction;
@@ -26,7 +28,7 @@ export class DDResizableHandle {
     this.init();
   }
 
-  init() {
+  public init(): DDResizableHandle {
     const el = document.createElement('div');
     el.classList.add('ui-resizable-handle');
     el.classList.add(`${DDResizableHandle.prefix}${this.dir}`);
@@ -35,9 +37,10 @@ export class DDResizableHandle {
     this.el = el;
     this.host.appendChild(this.el);
     this.el.addEventListener('mousedown', this.mouseDown);
+    return this;
   }
 
-  protected mouseDown = (event: MouseEvent) => {
+  private mouseDown = (event: MouseEvent): void => {
     this.mouseDownEvent = event;
     setTimeout(() => {
       document.addEventListener('mousemove', this.mouseMove, true);
@@ -46,13 +49,13 @@ export class DDResizableHandle {
         if (!this.mouseMoving) {
           document.removeEventListener('mousemove', this.mouseMove, true);
           document.removeEventListener('mouseup', this.mouseUp);
-          this.mouseDownEvent = undefined;
+          delete this.mouseDownEvent;
         }
       }, 300);
     }, 100);
   }
 
-  protected mouseMove = (event: MouseEvent) => {
+  private mouseMove = (event: MouseEvent): void => {
     if (!this.started && !this.mouseMoving) {
       if (this.hasMoved(event, this.mouseDownEvent)) {
         this.mouseMoving = true;
@@ -65,7 +68,7 @@ export class DDResizableHandle {
     }
   }
 
-  protected mouseUp = (event: MouseEvent) => {
+  private mouseUp = (event: MouseEvent): void => {
     if (this.mouseMoving) {
       this.triggerEvent('stop', event);
     }
@@ -73,10 +76,10 @@ export class DDResizableHandle {
     document.removeEventListener('mouseup', this.mouseUp);
     this.mouseMoving = false;
     this.started = false;
-    this.mouseDownEvent = undefined;
+    delete this.mouseDownEvent;
   }
 
-  private hasMoved(event: MouseEvent, oEvent: MouseEvent) {
+  private hasMoved(event: MouseEvent, oEvent: MouseEvent): boolean {
     const { clientX, clientY } = event;
     const { clientX: oClientX, clientY: oClientY } = oEvent;
     return (
@@ -85,22 +88,15 @@ export class DDResizableHandle {
     );
   }
 
-  show() {
-    this.el.style.display = 'block';
-  }
-
-  hide() {
-    this.el.style.display = 'none';
-  }
-
-  destroy() {
+  public destroy(): DDResizableHandle {
     this.host.removeChild(this.el);
+    return this;
   }
 
-  triggerEvent(name: string, event: MouseEvent) {
+  private triggerEvent(name: string, event: MouseEvent): DDResizableHandle {
     if (this.option[name]) {
       this.option[name](event);
     }
+    return this;
   }
-
 }

--- a/src/dragdrop/dd-utils.ts
+++ b/src/dragdrop/dd-utils.ts
@@ -5,8 +5,10 @@
  * (c) 2020 rhlin, Alain Dumesny
  * gridstack.js may be freely distributed under the MIT license.
 */
+
 export class DDUtils {
-  static isEventSupportPassiveOption = ((() => {
+
+  public static isEventSupportPassiveOption = ((() => {
     let supportsPassive = false;
     let passiveTest = () => {
       // do nothing
@@ -21,13 +23,13 @@ export class DDUtils {
     return supportsPassive;
   })());
 
-  static clone(el: HTMLElement): HTMLElement {
+  public static clone(el: HTMLElement): HTMLElement {
     const node = el.cloneNode(true) as HTMLElement;
     node.removeAttribute('id');
     return node;
   }
 
-  static appendTo(el: HTMLElement, parent: string | HTMLElement | Node) {
+  public static appendTo(el: HTMLElement, parent: string | HTMLElement | Node): void {
     let parentNode: HTMLElement;
     if (typeof parent === 'string') {
       parentNode = document.querySelector(parent as string);
@@ -38,13 +40,14 @@ export class DDUtils {
       parentNode.append(el);
     }
   }
-  static setPositionRelative(el) {
+
+  public static setPositionRelative(el): void {
     if (!(/^(?:r|a|f)/).test(window.getComputedStyle(el).position)) {
       el.style.position = "relative";
     }
   }
 
-  static addElStyles(el: HTMLElement, styles: { [prop: string]: string | string[] }) {
+  public static addElStyles(el: HTMLElement, styles: { [prop: string]: string | string[] }): void {
     if (styles instanceof Object) {
       for (const s in styles) {
         if (styles.hasOwnProperty(s)) {
@@ -60,14 +63,8 @@ export class DDUtils {
       }
     }
   }
-  static copyProps(dst, src, props) {
-    for (let i = 0; i < props.length; i++) {
-      const p = props[i];
-      dst[p] = src[p];
-    }
-  }
 
-  static initEvent<T>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }) {
+  public static initEvent<T>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }): T {
     const kbdProps = 'altKey,ctrlKey,metaKey,shiftKey'.split(',');
     const ptProps = 'pageX,pageY,clientX,clientY,screenX,screenY'.split(',');
     const evt = { type: info.type };
@@ -87,5 +84,12 @@ export class DDUtils {
     DDUtils.copyProps(evt, e, ptProps);
     DDUtils.copyProps(evt, obj, Object.keys(obj));
     return evt as unknown as T;
+  }
+
+  private static copyProps(dst: unknown, src: unknown, props: string[]): void {
+    for (let i = 0; i < props.length; i++) {
+      const p = props[i];
+      dst[p] = src[p];
+    }
   }
 }

--- a/src/dragdrop/gridstack-dd-native.ts
+++ b/src/dragdrop/gridstack-dd-native.ts
@@ -123,6 +123,7 @@ export class GridStackDDNative extends GridStackDD {
     dEl.off(name);
     return this;
   }
+
   private getGridStackDDElement(el: GridStackElement): DDElement {
     let dEl;
     if (typeof el === 'string') {

--- a/src/jq/gridstack-dd-jqueryui.ts
+++ b/src/jq/gridstack-dd-jqueryui.ts
@@ -38,11 +38,15 @@ export class GridStackDDJQueryUI extends GridStackDD {
       $el.resizable(opts, key, value);
     } else {
       let handles = $el.data('gs-resize-handles') ? $el.data('gs-resize-handles') : this.grid.opts.resizable.handles;
-      $el.resizable({...this.grid.opts.resizable, ...{handles: handles}, ...{ // was using $.extend()
-        start: opts.start, // || function() {},
-        stop: opts.stop, // || function() {},
-        resize: opts.resize // || function() {}
-      }});
+      $el.resizable({
+        ...this.grid.opts.resizable,
+        ...{ handles: handles },
+        ...{
+          start: opts.start, // || function() {},
+          stop: opts.stop, // || function() {},
+          resize: opts.resize // || function() {}
+        }
+      });
     }
     return this;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,30 @@ export interface DDDragInOpt extends DDDragOpt {
     helper?: string | ((event: Event) => HTMLElement);
 }
 
+export interface Size {
+  width: number;
+  height: number;
+}
+export interface Position {
+  top: number;
+  left: number;
+}
+export interface Rect extends Size, Position {}
+
+/** data that is passed during drag and resizing callbacks */
+export interface DDUIData {
+  position?: Position;
+  size?: Size;
+  /* fields not used by GridStack but sent by jq ? leave in case we go back to them...
+  originalPosition? : Position;
+  offset?: Position;
+  originalSize?: Size;
+  element?: HTMLElement[];
+  helper?: HTMLElement[];
+  originalElement?: HTMLElement[];
+  */
+}
+
 /**
  * internal descriptions describing the items in the grid
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   mode: 'production', // production vs development
   devtool: 'source-map',
-  // devtool: 'use eval-source-map', // for best (large .js) debugging. see https://survivejs.com/webpack/building/source-maps/
+  // devtool: 'eval-source-map', // for best (large .js) debugging. see https://survivejs.com/webpack/building/source-maps/
   module: {
     rules: [
       {
@@ -30,6 +30,6 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     library: 'GridStack',
     libraryExport: 'GridStack',
-    libraryTarget: 'umd', // "var" | "assign" | "this" | "window" | "self" | "global" | "commonjs" | "commonjs2" | "commonjs-module" | "amd" | "amd-require" | "umd" | "umd2" | "jsonp" | "system"
+    libraryTarget: 'umd', // var|assign|this|window|self|global|commonjs|commonjs2|commonjs-module|amd|amd-require|umd|umd2|jsonp|system
   }
 };


### PR DESCRIPTION
### Description
* went through new code for DD and made sure we have a type for everything
* cleanup to match lib style (public vs private)
* made all routines return 'this' for chainable calls. Abstract DDBaseImplement still return :void
otherwise had to do
`return this as unknown as DDBaseImplement`
for all sub-classes which is annoying.
* created DDUIData to hold what we need for callback data. Commented out part we don't use today...
