### PR TITLE
h5: del `ddPlugin` grid option

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -43,7 +43,7 @@ Change log
 
 ## 2.2.0-dev
 
-- TBD
+- del `ddPlugin` grid option as we only have one drag&drop plugin at runtime, which is defined by the include you use (HTML5 vs jquery vs none)
 
 ## 2.2.0 (2020-11-7)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -82,7 +82,6 @@ gridstack.js API
   * 0 or null, in which case the library will not generate styles for rows. Everything must be defined in CSS files.
   * `'auto'` - height will be square cells initially.
 - `column` - number of columns (default: `12`) which can change on the fly with `column(N)` as well. See [example](http://gridstackjs.com/demo/column.html)
-- `ddPlugin` - class that implement drag'n'drop functionality for gridstack. If `false` grid will be static. (default: `null` - first available plugin will be used)
 - `disableDrag` - disallows dragging of widgets (default: `false`).
 - `disableOneColumnMode` - disables the onColumnMode when the grid width is less than minWidth (default: 'false')
 - `disableResize` - disallows resizing of widgets (default: `false`).

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1634,6 +1634,7 @@ describe('gridstack', function() {
     });
   });
 
+  /*
   describe('ddPlugin option', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
@@ -1652,7 +1653,8 @@ describe('gridstack', function() {
       expect(grid.dd.isDroppable()).toBe(false);
     });
   });
-
+  */
+ 
   describe('grid.on events', function() {
     beforeEach(function() {
       document.body.insertAdjacentHTML('afterbegin', gridstackHTML);

--- a/src/dragdrop/gridstack-dd-native.ts
+++ b/src/dragdrop/gridstack-dd-native.ts
@@ -8,7 +8,7 @@
 import { DDManager } from './dd-manager';
 import { DDElement } from './dd-element';
 
-import { GridStack, GridStackElement } from '../gridstack';
+import { GridStackElement } from '../gridstack';
 import { GridStackDD, DDOpts, DDKey, DDDropOpt, DDCallback, DDValue } from '../gridstack-dd';
 import { GridItemHTMLElement, DDDragInOpt } from '../types';
 
@@ -16,9 +16,6 @@ import { GridItemHTMLElement, DDDragInOpt } from '../types';
  * HTML 5 Native DragDrop based drag'n'drop plugin.
  */
 export class GridStackDDNative extends GridStackDD {
-  public constructor(grid: GridStack) {
-    super(grid);
-  }
 
   public resizable(el: GridItemHTMLElement, opts: DDOpts, key?: DDKey, value?: DDValue): GridStackDDNative {
     let dEl = this.getGridStackDDElement(el);
@@ -31,9 +28,10 @@ export class GridStackDDNative extends GridStackDD {
     } else if (opts === 'option') {
       dEl.setupResizable({ [key]: value });
     } else {
-      let handles = dEl.el.getAttribute('gs-resize-handles') ? dEl.el.getAttribute('gs-resize-handles') : this.grid.opts.resizable.handles;
+      const grid = el.gridstackNode.grid;
+      let handles = dEl.el.getAttribute('gs-resize-handles') ? dEl.el.getAttribute('gs-resize-handles') : grid.opts.resizable.handles;
       dEl.setupResizable({
-        ...this.grid.opts.resizable,
+        ...grid.opts.resizable,
         ...{ handles: handles },
         ...{
           start: opts.start,
@@ -56,12 +54,13 @@ export class GridStackDDNative extends GridStackDD {
     } else if (opts === 'option') {
       dEl.setupDraggable({ [key]: value });
     } else {
+      const grid = el.gridstackNode.grid;
       dEl.setupDraggable({
-        ...this.grid.opts.draggable,
+        ...grid.opts.draggable,
         ...{
-          containment: (this.grid.opts._isNested && !this.grid.opts.dragOut)
-            ? this.grid.el.parentElement
-            : (this.grid.opts.draggable.containment || null),
+          containment: (grid.opts._isNested && !grid.opts.dragOut)
+            ? grid.el.parentElement
+            : (grid.opts.draggable.containment || null),
           start: opts.start,
           stop: opts.stop,
           drag: opts.drag

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -7,7 +7,7 @@
 */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { GridStack, GridStackElement } from './gridstack';
+import { GridStackElement } from './gridstack';
 import { GridItemHTMLElement, DDDragInOpt } from './types';
 
 /** Drag&Drop drop options */
@@ -29,7 +29,6 @@ export type DDCallback = (event: Event, arg2: GridItemHTMLElement, helper?: Grid
  * Base class for drag'n'drop plugin.
  */
 export class GridStackDD {
-  protected grid: GridStack;
   static registeredPlugins: typeof GridStackDD;
 
   /** call this method to register your plugin instead of the default no-op one */
@@ -40,10 +39,6 @@ export class GridStackDD {
   /** get the current registered plugin to use */
   static get(): typeof GridStackDD {
     return GridStackDD.registeredPlugins || GridStackDD;
-  }
-
-  public constructor(grid: GridStack) {
-    this.grid = grid;
   }
 
   /** removes any drag&drop present (called during destroy) */

--- a/src/jq/gridstack-dd-jqueryui.ts
+++ b/src/jq/gridstack-dd-jqueryui.ts
@@ -6,7 +6,7 @@
  * gridstack.js may be freely distributed under the MIT license.
 */
 
-import { GridStack, GridStackElement } from '../gridstack';
+import { GridStackElement } from '../gridstack';
 import { GridStackDD, DDOpts, DDKey, DDDropOpt, DDCallback, DDValue } from '../gridstack-dd';
 import { GridItemHTMLElement, DDDragInOpt } from '../types';
 
@@ -22,9 +22,6 @@ import './jquery-ui';
  * legacy Jquery-ui based drag'n'drop plugin.
  */
 export class GridStackDDJQueryUI extends GridStackDD {
-  public constructor(grid: GridStack) {
-    super(grid);
-  }
 
   public resizable(el: GridItemHTMLElement, opts: DDOpts, key?: DDKey, value?: DDValue): GridStackDD {
     let $el: JQuery = $(el);
@@ -37,9 +34,10 @@ export class GridStackDDJQueryUI extends GridStackDD {
     } else if (opts === 'option') {
       $el.resizable(opts, key, value);
     } else {
-      let handles = $el.data('gs-resize-handles') ? $el.data('gs-resize-handles') : this.grid.opts.resizable.handles;
+      const grid = el.gridstackNode.grid;
+      let handles = $el.data('gs-resize-handles') ? $el.data('gs-resize-handles') : grid.opts.resizable.handles;
       $el.resizable({
-        ...this.grid.opts.resizable,
+        ...grid.opts.resizable,
         ...{ handles: handles },
         ...{
           start: opts.start, // || function() {},
@@ -62,9 +60,10 @@ export class GridStackDDJQueryUI extends GridStackDD {
     } else if (opts === 'option') {
       $el.draggable(opts, key, value);
     } else {
-      $el.draggable({...this.grid.opts.draggable, ...{ // was using $.extend()
-        containment: (this.grid.opts._isNested && !this.grid.opts.dragOut) ?
-          $(this.grid.el).parent() : (this.grid.opts.draggable.containment || null),
+      const grid = el.gridstackNode.grid;
+      $el.draggable({...grid.opts.draggable, ...{ // was using $.extend()
+        containment: (grid.opts._isNested && !grid.opts.dragOut) ?
+          $(grid.el).parent() : (grid.opts.draggable.containment || null),
         start: opts.start, // || function() {},
         stop: opts.stop, // || function() {},
         drag: opts.drag // || function() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@
 */
 
 import { GridStack } from './gridstack';
-import { GridStackDD } from './gridstack-dd';
 
 
 /** different layout options when changing # of columns,
@@ -60,11 +59,6 @@ export interface GridStackOptions {
 
   /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns */
   column?: number;
-
-  /** class that implement drag'n'drop functionality for gridstack. If false grid will be static.
-   * (default?: undefined - first available plugin will be used)
-   */
-  ddPlugin?: false | typeof GridStackDD;
 
   /** disallows dragging of widgets (default?: false) */
   disableDrag?: boolean;


### PR DESCRIPTION
### Description
* always thought it was weird to have a (per) grid option when we had a list of D&D
plugins but last one won.
* now we only have a global static DD that is shared. Grid instance can be infered by element
for any needed options.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
