### PR TITLE
Fix placeholder not carrying base item class

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -298,7 +298,7 @@ export class GridStack {
     placeholderChild.className = 'placeholder-content';
     placeholderChild.innerHTML = this.opts.placeholderText;
     this.placeholder = document.createElement('div');
-    this.placeholder.classList.add(this.opts.placeholderClass, this.opts.itemClass);
+    this.placeholder.classList.add(this.opts.placeholderClass, defaults.itemClass, this.opts.itemClass);
     this.placeholder.appendChild(placeholderChild);
 
     this._updateContainerHeight();


### PR DESCRIPTION
Hey there,

this PR fixes a bug when using the `itemClass` option and dragging an item. The placeholder also needs the default `itemClass` (to be consistent with the behavior of items placed on the grid).