### PR TITLE
h5: prevent no-drop cursor when moving items

### DIFF
--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -110,7 +110,7 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
       accept: (el: GridItemHTMLElement) => {
         let node: GridStackNode = el.gridstackNode;
         if (node && node.grid === this) {
-          return false;
+          return true; // set accept drop to true on ourself (which we ignore) so we don't get "can't drop" icon in HTML5 mode while moving
         }
         if (typeof this.opts.acceptWidgets === 'function') {
           return this.opts.acceptWidgets(el);
@@ -120,9 +120,11 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
       }
     })
     .on(this.el, 'dropover', (event, el: GridItemHTMLElement) => {
+      // ignore dropping on ourself, and prevent parent from receiving event
+      let node = el.gridstackNode || {};
+      if (node.grid === this) { return false; }
 
       // see if we already have a node with widget/height and check for attributes
-      let node = el.gridstackNode || {};
       if (el.getAttribute && (!node.width || !node.height)) {
         let w = parseInt(el.getAttribute('data-gs-width'));
         if (w > 0) { node.width = w; }
@@ -166,6 +168,10 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
       return false; // prevent parent from receiving msg (which may be grid as well)
     })
     .on(this.el, 'drop', (event, el: GridItemHTMLElement, helper: GridItemHTMLElement) => {
+      let node = el.gridstackNode;
+      // ignore drop on ourself from ourself - dragend will handle the simple move instead
+      if (node && node.grid === this) { return false; }
+
       this.placeholder.remove();
 
       // notify previous grid of removal
@@ -179,7 +185,7 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
         oGrid._triggerRemoveEvent();
       }
 
-      let node = el.gridstackNode; // use existing placeholder node as it's already in our list with drop location
+      // use existing placeholder node as it's already in our list with drop location
       if (!node) { return false; }
       const _id = node._id;
       this.engine.cleanupNode(node); // removes all internal _xyz values (including the _id so add that back)


### PR DESCRIPTION
### Description
* to support html5 D&D we now allow ourself to e a drop target when moving
item around, otherwise we get a 'no drop' cursor the entire move
* we ignore the 'dropover' & 'drop' event so regular 'dragend' will do the right thing.
* tested html5 and JQ version - no apparent side effect
* Note: we still get a very quick flicker to 'no-drop' initially (until
accept routine is called ? not sure how to prevent that.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
