### PR TITLE
fix to drag between 2 grids and back

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -45,6 +45,7 @@ Change log
 
 - we now have a React example, in addition to Vue - Angular is next!. thanks [@eloparco](https://github.com/eloparco)
 - fix placeholder not having custom `GridStackOptions.itemClass`. thanks [@pablosichert](https://github.com/pablosichert)
+- fix [1484](https://github.com/gridstack/gridstack.js/issues/1484) draging between 2 grids and back (regression in 2.0.1) 
 - del `ddPlugin` grid option as we only have one drag&drop plugin at runtime, which is defined by the include you use (HTML5 vs jquery vs none)
 
 ## 2.2.0 (2020-11-7)


### PR DESCRIPTION
### Description
* fix for #1484, introduced in 2.0.1
* make sure we reset _added flag when leaving other grid and we get back

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
