### PR TITLE
load() in 1 column mode layout fix

### DIFF
--- a/demo/react.html
+++ b/demo/react.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gridstack.js React integration example</title>
     <link rel="stylesheet" href="demo.css" />
-    <script src="../dist/gridstack.all.js"></script>
+    <script src="../dist/gridstack-h5.js"></script>
 
     <!-- Scripts to use react inside html -->
     <script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -45,7 +45,8 @@ Change log
 
 - we now have a React example, in addition to Vue - Angular is next!. thanks [@eloparco](https://github.com/eloparco)
 - fix placeholder not having custom `GridStackOptions.itemClass`. thanks [@pablosichert](https://github.com/pablosichert)
-- fix [1484](https://github.com/gridstack/gridstack.js/issues/1484) draging between 2 grids and back (regression in 2.0.1) 
+- fix [1484](https://github.com/gridstack/gridstack.js/issues/1484) dragging between 2 grids and back (regression in 2.0.1) 
+- fix [1471](https://github.com/gridstack/gridstack.js/issues/1471) `load()` into 1 column mode doesn't resize back to 12 correctly
 - del `ddPlugin` grid option as we only have one drag&drop plugin at runtime, which is defined by the include you use (HTML5 vs jquery vs none)
 
 ## 2.2.0 (2020-11-7)

--- a/spec/e2e/html/1471-load-column1.html
+++ b/spec/e2e/html/1471-load-column1.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>load() 1 column</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-h5.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>load() 1 column</h1>
+    <p>resize to below 768px, reload, then expand up to check 12 column</p>
+    <div>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
+      <a class="btn btn-primary" onclick="toggleFloat()" id="float" href="#">float: true</a>
+    </div>
+    <br><br>
+    <div class="grid-stack"></div>
+  </div>
+  <script src="../../../demo/events.js"></script>
+  <script type="text/javascript">
+    let grid = GridStack.init({float: true});
+    addEvents(grid);
+
+    let items = [
+      {x: 1, y: 0, width: 2, height: 1, content: '0'},
+      {x: 3, y: 1, width: 1, height: 2, content: '1'},
+      {x: 4, y: 1, width: 1, height: 1, content: '2'},
+      {x: 2, y: 3, width: 3, height: 1, content: '3'},
+      {x: 0, y: 6, width: 2, height: 2, content: '4'}
+    ];
+    grid.load(items);
+
+    addNewWidget = function() {
+      let n = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        width: Math.round(1 + 3 * Math.random()),
+        height: Math.round(1 + 3 * Math.random())
+      };
+      n.content = String(count++);
+      grid.addWidget(n);
+    };
+
+    toggleFloat = function() {
+      grid.float(! grid.getFloat());
+      document.querySelector('#float').innerHTML = 'float: ' + grid.getFloat();
+    };
+  </script>
+</body>
+</html>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,8 +172,8 @@ export class Utils {
     return Boolean(v);
   }
 
-  static toNumber(value: null | string): number | null {
-    return (value === null || value.length === 0) ? null : Number(value);
+  static toNumber(value: null | string): number {
+    return (value === null || value.length === 0) ? undefined : Number(value);
   }
 
   static parseHeight(val: numberOrString): HeightData {
@@ -209,6 +209,18 @@ export class Utils {
     });
 
     return target;
+  }
+
+  /** given 2 objects return true if they have the same values. Checks for Object {} having same fields and values (just 1 level down) */
+  static same(a: unknown, b: unknown): boolean {
+    if (typeof a !== 'object')  { return a == b; }
+    if (typeof a !== typeof b) { return false; }
+    // else we have object, check just 1 level deep for being same things...
+    if (Object.keys(a).length !== Object.keys(b).length) { return false; }
+    for (const key in a) {
+      if (a[key] !== b[key]) { return false; }
+    }
+    return true;
   }
 
   /** makes a shallow copy of the passed json struct */


### PR DESCRIPTION
### Description
* fix for #1471
* when `load()` is called into a grid that is 1 column mode due to
small area, we now cache the original 12 column layout to restore correctly
* added sample code. Had to change more code than expected.

* Also optimized loading to not re-do some items (re-writing attr multiple times)
* Also fixed react sample

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
