### PR TITLE
update(el, opts) re-write to take all options

### DIFF
--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -33,12 +33,14 @@
     });
 
     let serializedData = [
-      {x: 0, y: 0, width: 2, height: 2, id: '0', content: "big 2x2"},
+      {x: 0, y: 0, width: 2, height: 2, id: '0'},
       {x: 3, y: 1, width: 1, height: 2, id: '1', content: "<button onclick=\"alert('clicked!')\">Press me</button>"},
       {x: 4, y: 1, width: 1, height: 1, id: '2'},
       {x: 2, y: 3, width: 3, height: 1, id: '3'},
       {x: 1, y: 3, width: 1, height: 1, id: '4'}
     ];
+    serializedData.forEach((n, i) =>
+      n.content = `<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br> ${i}<br> ${n.content ? n.content : ''}`);
 
     // NEW 2.x method
     loadGrid = function() {
@@ -65,7 +67,7 @@
         // else update existing nodes (instead of calling grid.removeAll())
         grid.engine.nodes.forEach(function (node) {
           let item = items.find(function(e) { return e.id === node.id});
-          grid.update(node.el, item.x, item.y, item.width, item.height);
+          grid.move(node.el, item.x, item.y, item.width, item.height);
         });
       }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -47,6 +47,8 @@ Change log
 - fix placeholder not having custom `GridStackOptions.itemClass`. thanks [@pablosichert](https://github.com/pablosichert)
 - fix [1484](https://github.com/gridstack/gridstack.js/issues/1484) dragging between 2 grids and back (regression in 2.0.1) 
 - fix [1471](https://github.com/gridstack/gridstack.js/issues/1471) `load()` into 1 column mode doesn't resize back to 12 correctly
+- fix [1235](https://github.com/gridstack/gridstack.js/issues/1235) `update(el, opts)` re-write to take all `GridStackWidget` options (not just x,y,width,height) and do everything efficiently.
+Fixed `locked()`, `move()`, `resize()`, `minWidth()`,etc... to call update() instead which does all the constrain, not just update attributes!
 - del `ddPlugin` grid option as we only have one drag&drop plugin at runtime, which is defined by the include you use (HTML5 vs jquery vs none)
 
 ## 2.2.0 (2020-11-7)

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -299,6 +299,8 @@ GridStack.prototype._setupDragIn = function():  GridStack {
 
 /** @internal prepares the element for drag&drop **/
 GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): GridStack {
+  let el = node.el;
+
   // check for disabled grid first
   if (this.opts.staticGrid || node.locked ||
     ((node.noMove || this.opts.disableDrag) && (node.noResize || this.opts.disableResize))) {
@@ -311,6 +313,13 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
   }
   // check if init already done
   if (node._initDD) {
+    // fine tune drag vs move by disabling any part...
+    if (node.noMove || this.opts.disableDrag) {
+      GridStackDD.get().draggable(el, 'disable');
+    }
+    if (node.noResize || this.opts.disableResize) {
+      GridStackDD.get().resizable(el, 'disable');
+    }
     return this;
   }
 
@@ -320,7 +329,6 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
   // variables used/cashed between the 3 start/move/end methods, in addition to node passed above
   let cellWidth: number;
   let cellHeight: number;
-  let el = node.el;
 
   /** called when item starts moving/resizing */
   let onStartMoving = (event: Event, ui: DDUIData): void => {


### PR DESCRIPTION
### Description
* fix #1235
* `update(el, opts)` re-write to take all `GridStackWidget` options
(not just x,y,width,height) and do everything efficiently.
* Fixed `locked()`, `move()`, `resize()`, `minWidth()`,etc...
to call update() instead which does all the constrain,
not just update attributes!
* update spec to test, and serialize demo to show improved feature
* OLD api to pass 4 params will work for now (console warning)

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
