### PR TITLE
'data-gs-min-width' to 'gs-min-w' attr rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Join us on Slack: https://gridstackjs.troolee.com
   - [Migrating to v0.6](#migrating-to-v06)
   - [Migrating to v1](#migrating-to-v1)
   - [Migrating to v2](#migrating-to-v2)
+  - [Migrating to v3](#migrating-to-v3)
 - [jQuery Application](#jquery-application)
 - [Changes](#changes)
 - [The Team](#the-team)
@@ -115,7 +116,7 @@ grid.load(serializedData);
   <div class="grid-stack-item">
     <div class="grid-stack-item-content">Item 1</div>
   </div>
-  <div class="grid-stack-item" data-gs-width="2">
+  <div class="grid-stack-item" gs-w="2">
     <div class="grid-stack-item-content">Item 2 wider</div>
   </div>
 </div>
@@ -173,30 +174,30 @@ See example: [2 grids demo](http://gridstack.github.io/gridstack.js/demo/two.htm
 
 ## Custom columns CSS
 
-If you need > 12 columns or want to generate the CSS manually you will need to generate CSS rules for `.grid-stack-item[data-gs-width="X"]` and `.grid-stack-item[data-gs-x="X"]`.
+If you need > 12 columns or want to generate the CSS manually you will need to generate CSS rules for `.grid-stack-item[gs-w="X"]` and `.grid-stack-item[gs-x="X"]`.
 
 For instance for 3-column grid you need to rewrite CSS to be:
 
 ```css
-.grid-stack-item[data-gs-width="3"]  { width: 100% }
-.grid-stack-item[data-gs-width="2"]  { width: 66.66666667% }
-.grid-stack-item[data-gs-width="1"]  { width: 33.33333333% }
+.grid-stack-item[gs-w="3"]  { width: 100% }
+.grid-stack-item[gs-w="2"]  { width: 66.66666667% }
+.grid-stack-item[gs-w="1"]  { width: 33.33333333% }
 
-.grid-stack-item[data-gs-x="2"]  { left: 66.66666667% }
-.grid-stack-item[data-gs-x="1"]  { left: 33.33333333% }
+.grid-stack-item[gs-x="2"]  { left: 66.66666667% }
+.grid-stack-item[gs-x="1"]  { left: 33.33333333% }
 ```
 
 For 4-column grid it should be:
 
 ```css
-.grid-stack-item[data-gs-width="4"]  { width: 100% }
-.grid-stack-item[data-gs-width="3"]  { width: 75% }
-.grid-stack-item[data-gs-width="2"]  { width: 50% }
-.grid-stack-item[data-gs-width="1"]  { width: 25% }
+.grid-stack-item[gs-w="4"]  { width: 100% }
+.grid-stack-item[gs-w="3"]  { width: 75% }
+.grid-stack-item[gs-w="2"]  { width: 50% }
+.grid-stack-item[gs-w="1"]  { width: 25% }
 
-.grid-stack-item[data-gs-x="3"]  { left: 75% }
-.grid-stack-item[data-gs-x="2"]  { left: 50% }
-.grid-stack-item[data-gs-x="1"]  { left: 25% }
+.grid-stack-item[gs-x="3"]  { left: 75% }
+.grid-stack-item[gs-x="2"]  { left: 50% }
+.grid-stack-item[gs-x="1"]  { left: 25% }
 ```
 
 and so on.
@@ -211,10 +212,10 @@ Better yet, here is a SASS code snippet which can make life much easier (Thanks 
   min-width: (100% / $gridstack-columns);
 
   @for $i from 1 through $gridstack-columns {
-    &[data-gs-width='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
-    &[data-gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
-    &[data-gs-min-width='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
-    &[data-gs-max-width='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
+    &[gs-w='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
+    &[gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
+    &[gs-min-w='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
+    &[gs-max-w='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
   }
 }
 ```
@@ -356,6 +357,20 @@ v2 is a Typescript rewrite of 1.x, removing all jquery events, using classes and
 3. `oneColumnMode` would trigger when `window.width` < 768px by default. We now check for grid width instead (more correct and supports nesting). You might need to adjust grid `minWidth` or `disableOneColumnMode`.
 
 **Note:** 2.x no longer support legacy IE11 and older due to using more compact ES6 output and typecsript native code. You will need to stay at 1.x
+
+## Migrating to v3
+
+make sure to read v2 migration first!
+
+v3 has a new HTML5 drag&drop plugging (65k total, all native code), while still allowing you to use the legacy jquery-ui version (188k), or a new static grid version (35k, no user drag&drop but full API support). You will need to decide which version to use as `gridstack.all.js` no longer exist (same as `gridstack-jq.js`) - see include info at top.
+
+Some breaking changes:
+
+1. include (as mentioned) need to change
+
+2. `GridStack.update(el, opt)` now takes `GridStackWidget` options instead, BUT legacy call in JS will continue working the same for now
+
+3. item attribute like `data-gs-min-width` is now `gs-min-w`. We removed 'data-' from all attributes, and shorten 'width|height' to just 'w|h' to require typing and more efficient.
 
 # jQuery Application
 

--- a/demo/events.js
+++ b/demo/events.js
@@ -14,15 +14,15 @@ function addEvents(grid, id) {
 
   grid.on('dragstart', function(event, el) {
     let node = el.gridstackNode;
-    let x = el.getAttribute('data-gs-x');
-    let y= el.getAttribute('data-gs-y');
+    let x = el.getAttribute('gs-x');
+    let y= el.getAttribute('gs-y');
     console.log(g + 'dragstart ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') vs (' + x + ',' + y + ')');
   });
 
   grid.on('dragstop', function(event, el) {
     let node = el.gridstackNode;
-    let x = el.getAttribute('data-gs-x');
-    let y= el.getAttribute('data-gs-y');
+    let x = el.getAttribute('gs-x');
+    let y= el.getAttribute('gs-y');
     console.log(g + 'dragstop ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') vs (' + x + ',' + y + ')');
   });
 
@@ -41,14 +41,14 @@ function addEvents(grid, id) {
   });
 
   grid.on('resizestart', function(event, el) {
-    let w = el.getAttribute('data-gs-width');
-    let h = el.getAttribute('data-gs-height');
+    let w = el.getAttribute('gs-w');
+    let h = el.getAttribute('gs-h');
     console.log(g + 'resizestart ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
   });
 
   grid.on('resizestop', function(event, el) {
-    let w = el.getAttribute('data-gs-width');
-    let h = el.getAttribute('data-gs-height');
+    let w = el.getAttribute('gs-w');
+    let h = el.getAttribute('gs-h');
     console.log(g + 'resizestop ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
   });
 }

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -49,7 +49,7 @@
       template:
         [
           '<div class="grid-stack" data-bind="foreach: {data: widgets, afterRender: afterAddWidget}">',
-          '   <div class="grid-stack-item" data-bind="attr: {\'data-gs-x\': $data.x, \'data-gs-y\': $data.y, \'data-gs-width\': $data.width, \'data-gs-height\': $data.height, \'data-gs-auto-position\': $data.auto_position, \'data-gs-id\': $data.id}">',
+          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.width, \'gs-h\': $data.height, \'gs-auto-position\': $data.auto_position, \'gs-id\': $data.id}">',
           '     <div class="grid-stack-item-content"><button data-bind="click: $root.deleteWidget">Delete me</button></div>',
           '   </div>',
           '</div> '

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -26,28 +26,28 @@
     <br><br>
 
     <div class="grid-stack top">
-      <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="1" data-gs-height="1">
+      <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="1">
         <div class="grid-stack-item-content">regular item</div>
       </div>
-      <div class="grid-stack-item" data-gs-x="1" data-gs-y="0" data-gs-width="4" data-gs-height="4">
+      <div class="grid-stack-item" gs-x="1" gs-y="0" gs-w="4" gs-h="4">
         <div class="grid-stack-item-content">
           nested 1 - can drag items out
           <div class="grid-stack nested1">
-            <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">1</div></div>
-            <div class="grid-stack-item sub" data-gs-x="3" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">2</div></div>
-            <div class="grid-stack-item sub" data-gs-x="6" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">3</div></div>
-            <div class="grid-stack-item sub" data-gs-x="9" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">4</div></div>
-            <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="1" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">5</div></div>
-            <div class="grid-stack-item sub" data-gs-x="3" data-gs-y="1" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">6</div></div>
+            <div class="grid-stack-item sub" gs-x="0" gs-y="0" gs-w="3"><div class="grid-stack-item-content">1</div></div>
+            <div class="grid-stack-item sub" gs-x="3" gs-y="0" gs-w="3"><div class="grid-stack-item-content">2</div></div>
+            <div class="grid-stack-item sub" gs-x="6" gs-y="0" gs-w="3"><div class="grid-stack-item-content">3</div></div>
+            <div class="grid-stack-item sub" gs-x="9" gs-y="0" gs-w="3"><div class="grid-stack-item-content">4</div></div>
+            <div class="grid-stack-item sub" gs-x="0" gs-y="1" gs-w="3"><div class="grid-stack-item-content">5</div></div>
+            <div class="grid-stack-item sub" gs-x="3" gs-y="1" gs-w="3"><div class="grid-stack-item-content">6</div></div>
           </div>
         </div>
     </div>
-    <div class="grid-stack-item" data-gs-x="5" data-gs-y="0" data-gs-width="3" data-gs-height="4">
+    <div class="grid-stack-item" gs-x="5" gs-y="0" gs-w="3" gs-h="4">
       <div class="grid-stack-item-content">
         nested 2 - constrained to parent (default)
         <div class="grid-stack nested2">
-          <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">7</div></div>
-          <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="3" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">8</div></div>
+          <div class="grid-stack-item sub" gs-x="0" gs-y="0" gs-w="3"><div class="grid-stack-item-content">7</div></div>
+          <div class="grid-stack-item sub" gs-x="0" gs-y="3" gs-w="3"><div class="grid-stack-item-content">8</div></div>
         </div>
       </div>
     </div>

--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -54,7 +54,7 @@
       template:
         [
           '<div class="grid-stack" data-bind="foreach: {data: widgets, afterRender: afterAddWidget}">',
-          '   <div class="grid-stack-item" data-bind="attr: {\'data-gs-x\': $data.x, \'data-gs-y\': $data.y, \'data-gs-width\': $data.width, \'data-gs-height\': $data.height, \'data-gs-auto-position\': $data.auto_position}">',
+          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.width, \'gs-h\': $data.height, \'gs-auto-position\': $data.auto_position}">',
           '     <div class="grid-stack-item-content"><center><button data-bind="click: $root.deleteWidget">Delete me</button><br><h5 data-bind="text: index" /></center><br><p>lorem ipsum</p></div>',
           '   </div>',
           '</div> '

--- a/demo/static.html
+++ b/demo/static.html
@@ -19,14 +19,14 @@
       <a class="btn btn-primary" onclick="grid.setStatic(false)" id="float" href="#">Editable</a>
     </div>
     <br><br>
-    <div class="grid-stack" data-gs-static-grid="true"></div>
+    <div class="grid-stack" gs-static="true"></div>
   </div>
   <script src="events.js"></script>
   <script type="text/javascript">
     let grid = GridStack.init({
       float: true,
       cellHeight: 70,
-      //staticGrid: true // same but testing data-gs above
+      //staticGrid: true // same but testing gs above
     });
     addEvents(grid);
 

--- a/demo/two-jq.html
+++ b/demo/two-jq.html
@@ -56,7 +56,7 @@
             <div class="grid-stack-item-content">Drag me</div>
           </div>
           <!-- manually force a drop size of 2x1 -->
-          <div class="grid-stack-item" data-gs-width="2" data-gs-height="1">
+          <div class="grid-stack-item" gs-w="2" gs-h="1">
             <div class="grid-stack-item-content">Drag me 2x1</div>
           </div>
 

--- a/demo/two.html
+++ b/demo/two.html
@@ -56,7 +56,7 @@
             <div class="grid-stack-item-content">Drag me</div>
           </div>
           <!-- manually force a drop size of 2x1 -->
-          <div class="grid-stack-item" data-gs-width="2" data-gs-height="1">
+          <div class="grid-stack-item" gs-w="2" gs-h="1">
             <div class="grid-stack-item-content">Drag me 2x1</div>
           </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -50,6 +50,7 @@ Change log
 - fix [1235](https://github.com/gridstack/gridstack.js/issues/1235) `update(el, opts)` re-write to take all `GridStackWidget` options (not just x,y,width,height) and do everything efficiently.
 Hiding `locked()`, `move()`, `resize()`, `minWidth()`, etc... as they just simply call update() which does all the constrain now as well!
 - del `ddPlugin` grid option as we only have one drag&drop plugin at runtime, which is defined by the include you use (HTML5 vs jquery vs none)
+-  change attribute like `data-gs-min-width` is now `gs-min-w`. We removed 'data-' from all attributes, and shorten 'width|height' to just 'w|h' to require typing and more efficient [1491](https://github.com/gridstack/gridstack.js/pull/1491)
 
 ## 2.2.0 (2020-11-7)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -109,10 +109,10 @@ gridstack.js API
 
 ## Grid attributes
 
-most of the above options are also available as HTML attributes using the `data-gs-` name prefix with standard dash lower case naming convention (ex: `data-gs-column`, `data-gs-min-row`, `data-gs-static-grid`, etc..).
+most of the above options are also available as HTML attributes using the `gs-` name prefix with standard dash lower case naming convention (ex: `gs-column`, `gs-min-row`, `gs-static`, etc..).
 
 Extras:
-- `data-gs-current-row` - (internal) current rows amount. Set by the library only. Can be used by the CSS rules.
+- `gs-current-row` - (internal) current rows amount. Set by the library only. Can be used by the CSS rules.
 
 ## Item Options
 
@@ -133,7 +133,7 @@ You need to add `noResize` and `noMove` attributes to completely lock the widget
 
 ## Item attributes
 
-all item options are also available as HTML attributes using the `data-gs-` name prefix with standard dash lower case naming convention (ex: `data-gs-x`, `data-gs-min-width`, etc..).
+all item options are also available as HTML attributes using the `gs-` name prefix with standard dash lower case naming convention (ex: `gs-x`, `gs-min-w`, etc..).
 
 ## Events
 
@@ -187,7 +187,7 @@ called after the user is done moving the item, with updated DOM attributes.
 
 ```js
 grid.on('dragstop', function(event: Event, el: GridItemHTMLElement) {
-  let x = parseInt(el.getAttribute('data-gs-x')) || 0;
+  let x = parseInt(el.getAttribute('gs-x')) || 0;
   // or all values...
   let node: GridStackNode = el.gridstackNode; // {x, y, width, height, id, ....}
 });
@@ -237,7 +237,7 @@ called after the user is done resizing the item, with updated DOM attributes.
 
 ```js
 grid.on('resizestop', function(event: Event, el: GridItemHTMLElement) {
-  let width = parseInt(el.getAttribute('data-gs-width')) || 0;
+  let width = parseInt(el.getAttribute('gs-w')) || 0;
   // or all values...
   let node: GridStackNode = el.gridstackNode; // {x, y, width, height, id, ....}
 });
@@ -402,7 +402,7 @@ Parameters:
 
 ```js
 let grid = GridStack.init();
-grid.el.appendChild('<div id="gsi-1" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="2" data-gs-auto-position="true"></div>')
+grid.el.appendChild('<div id="gsi-1" gs-x="0" gs-y="0" gs-w="3" gs-h="2" gs-auto-position="true"></div>')
 grid.makeWidget('#gsi-1');
 ```
 

--- a/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
+++ b/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
@@ -23,19 +23,19 @@
 <body>
   <br>
   <div class="grid-stack">
-    <div class="grid-stack-item upper" data-gs-width="2" data-gs-height="2" data-gs-id="1">
+    <div class="grid-stack-item upper" gs-w="2" gs-h="2" gs-id="1">
       <div class="grid-stack-item-content">item 1</div>
     </div>
-    <div class="grid-stack-item" data-gs-width="3" data-gs-height="2" data-gs-id="2">
+    <div class="grid-stack-item" gs-w="3" gs-h="2" gs-id="2">
       <div class="grid-stack-item-content">item 2</div>
     </div>
-    <div class="grid-stack-item" data-gs-width="9" data-gs-height="1" data-gs-id="3">
+    <div class="grid-stack-item" gs-w="9" gs-h="1" gs-id="3">
       <div class="grid-stack-item-content">item 3 too big to fit, so next row</div>
     </div>
-    <div class="grid-stack-item" data-gs-width="3" data-gs-height="1" data-gs-id="4">
+    <div class="grid-stack-item" gs-w="3" gs-h="1" gs-id="4">
       <div class="grid-stack-item-content">item 4</div>
     </div>
-    <div class="grid-stack-item" data-gs-x="1" data-gs-y="1" data-gs-width="1" data-gs-height="1" data-gs-id="5" data-gs-auto-position="false">
+    <div class="grid-stack-item" gs-x="1" gs-y="1" gs-w="1" gs-h="1" gs-id="5" gs-auto-position="false">
       <div class="grid-stack-item-content">item 5 first</div>
     </div>
   </div>

--- a/spec/e2e/html/1142_change_event_missing.html
+++ b/spec/e2e/html/1142_change_event_missing.html
@@ -10,10 +10,10 @@
 </head>
 <body>
   <div class="grid-stack">
-    <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">1 click to delete</div></div>
-    <div class="grid-stack-item" data-gs-x="0" data-gs-y="1" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">2 missing change event</div></div>
-    <div class="grid-stack-item" data-gs-x="0" data-gs-y="2" data-gs-width="1" data-gs-height="1"><div class="grid-stack-item-content">3</div></div>
-    <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="1" data-gs-height="1"><div class="grid-stack-item-content">4</div></div>
+    <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="3" gs-h="1"><div class="grid-stack-item-content">1 click to delete</div></div>
+    <div class="grid-stack-item" gs-x="0" gs-y="1" gs-w="3" gs-h="1"><div class="grid-stack-item-content">2 missing change event</div></div>
+    <div class="grid-stack-item" gs-x="0" gs-y="2" gs-w="1" gs-h="1"><div class="grid-stack-item-content">3</div></div>
+    <div class="grid-stack-item" gs-x="4" gs-y="0" gs-w="1" gs-h="1"><div class="grid-stack-item-content">4</div></div>
   </div>
   
 <script type="text/javascript">

--- a/spec/e2e/html/1143_nested_acceptWidget_types.html
+++ b/spec/e2e/html/1143_nested_acceptWidget_types.html
@@ -32,18 +32,18 @@
       </div>
     </div>
     <div class="col-sm-12 col-md-10">
-      <div class="grid-stack outer" data-gs-animate="yes">
-        <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="12" data-gs-height="3">
+      <div class="grid-stack outer" gs-animate="yes">
+        <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="12" gs-h="3">
           <div class="grid-stack-item-content">
             This nested grid accepts new widget with class "newWidget"<br/>
             The parent grid also accepts new widget but with a different class 'otherWidgetType'<br/>&nbsp;
           <div class="grid-stack nested">
-            <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">1</div></div>
-            <div class="grid-stack-item sub" data-gs-x="3" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">2</div></div>
-            <div class="grid-stack-item sub" data-gs-x="6" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">3</div></div>
-            <div class="grid-stack-item sub" data-gs-x="9" data-gs-y="0" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">4</div></div>
-            <div class="grid-stack-item sub" data-gs-x="0" data-gs-y="1" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">5</div></div>
-            <div class="grid-stack-item sub" data-gs-x="3" data-gs-y="1" data-gs-width="3" data-gs-height="1"><div class="grid-stack-item-content">6</div></div>
+            <div class="grid-stack-item sub" gs-x="0" gs-y="0" gs-w="3" gs-h="1"><div class="grid-stack-item-content">1</div></div>
+            <div class="grid-stack-item sub" gs-x="3" gs-y="0" gs-w="3" gs-h="1"><div class="grid-stack-item-content">2</div></div>
+            <div class="grid-stack-item sub" gs-x="6" gs-y="0" gs-w="3" gs-h="1"><div class="grid-stack-item-content">3</div></div>
+            <div class="grid-stack-item sub" gs-x="9" gs-y="0" gs-w="3" gs-h="1"><div class="grid-stack-item-content">4</div></div>
+            <div class="grid-stack-item sub" gs-x="0" gs-y="1" gs-w="3" gs-h="1"><div class="grid-stack-item-content">5</div></div>
+            <div class="grid-stack-item sub" gs-x="3" gs-y="1" gs-w="3" gs-h="1"><div class="grid-stack-item-content">6</div></div>
           </div>
             
           </div>

--- a/spec/e2e/html/1286-load.html
+++ b/spec/e2e/html/1286-load.html
@@ -14,10 +14,10 @@
     <h1>load() Test</h1>
     <br/>
     <div class="grid-stack">
-      <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2" data-gs-id="item1" id="item1">
+      <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="4" gs-h="2" gs-id="item1" id="item1">
         <div class="grid-stack-item-content">item 1</div>
       </div>
-      <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4" data-gs-id="item2" id="item2">
+      <div class="grid-stack-item" gs-x="4" gs-y="0" gs-w="4" gs-h="4" gs-id="item2" id="item2">
         <div class="grid-stack-item-content">item 2</div>
       </div>
     </div>

--- a/spec/e2e/html/810-many-columns.css
+++ b/spec/e2e/html/810-many-columns.css
@@ -6,10 +6,10 @@
     min-width: (100% / $gridstack-columns);
     
     @for $i from 1 through $gridstack-columns {
-      &[data-gs-width='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
-      &[data-gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
-      &[data-gs-min-width='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
-      &[data-gs-max-width='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
+      &[gs-w='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
+      &[gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
+      &[gs-min-w='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
+      &[gs-max-w='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
     }
   }
   */
@@ -18,723 +18,723 @@
   .grid-stack > .grid-stack-item {
     min-width: 1.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="1"] {
+  .grid-stack > .grid-stack-item[gs-w="1"] {
     width: 1.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="1"] {
+  .grid-stack > .grid-stack-item[gs-x="1"] {
     left: 1.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="1"] {
+  .grid-stack > .grid-stack-item[gs-min-w="1"] {
     min-width: 1.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="1"] {
+  .grid-stack > .grid-stack-item[gs-max-w="1"] {
     max-width: 1.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="2"] {
+  .grid-stack > .grid-stack-item[gs-w="2"] {
     width: 3.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="2"] {
+  .grid-stack > .grid-stack-item[gs-x="2"] {
     left: 3.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="2"] {
+  .grid-stack > .grid-stack-item[gs-min-w="2"] {
     min-width: 3.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="2"] {
+  .grid-stack > .grid-stack-item[gs-max-w="2"] {
     max-width: 3.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="3"] {
+  .grid-stack > .grid-stack-item[gs-w="3"] {
     width: 5%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="3"] {
+  .grid-stack > .grid-stack-item[gs-x="3"] {
     left: 5%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="3"] {
+  .grid-stack > .grid-stack-item[gs-min-w="3"] {
     min-width: 5%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="3"] {
+  .grid-stack > .grid-stack-item[gs-max-w="3"] {
     max-width: 5%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="4"] {
+  .grid-stack > .grid-stack-item[gs-w="4"] {
     width: 6.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="4"] {
+  .grid-stack > .grid-stack-item[gs-x="4"] {
     left: 6.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="4"] {
+  .grid-stack > .grid-stack-item[gs-min-w="4"] {
     min-width: 6.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="4"] {
+  .grid-stack > .grid-stack-item[gs-max-w="4"] {
     max-width: 6.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="5"] {
+  .grid-stack > .grid-stack-item[gs-w="5"] {
     width: 8.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="5"] {
+  .grid-stack > .grid-stack-item[gs-x="5"] {
     left: 8.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="5"] {
+  .grid-stack > .grid-stack-item[gs-min-w="5"] {
     min-width: 8.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="5"] {
+  .grid-stack > .grid-stack-item[gs-max-w="5"] {
     max-width: 8.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="6"] {
+  .grid-stack > .grid-stack-item[gs-w="6"] {
     width: 10%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="6"] {
+  .grid-stack > .grid-stack-item[gs-x="6"] {
     left: 10%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="6"] {
+  .grid-stack > .grid-stack-item[gs-min-w="6"] {
     min-width: 10%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="6"] {
+  .grid-stack > .grid-stack-item[gs-max-w="6"] {
     max-width: 10%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="7"] {
+  .grid-stack > .grid-stack-item[gs-w="7"] {
     width: 11.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="7"] {
+  .grid-stack > .grid-stack-item[gs-x="7"] {
     left: 11.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="7"] {
+  .grid-stack > .grid-stack-item[gs-min-w="7"] {
     min-width: 11.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="7"] {
+  .grid-stack > .grid-stack-item[gs-max-w="7"] {
     max-width: 11.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="8"] {
+  .grid-stack > .grid-stack-item[gs-w="8"] {
     width: 13.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="8"] {
+  .grid-stack > .grid-stack-item[gs-x="8"] {
     left: 13.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="8"] {
+  .grid-stack > .grid-stack-item[gs-min-w="8"] {
     min-width: 13.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="8"] {
+  .grid-stack > .grid-stack-item[gs-max-w="8"] {
     max-width: 13.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="9"] {
+  .grid-stack > .grid-stack-item[gs-w="9"] {
     width: 15%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="9"] {
+  .grid-stack > .grid-stack-item[gs-x="9"] {
     left: 15%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="9"] {
+  .grid-stack > .grid-stack-item[gs-min-w="9"] {
     min-width: 15%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="9"] {
+  .grid-stack > .grid-stack-item[gs-max-w="9"] {
     max-width: 15%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="10"] {
+  .grid-stack > .grid-stack-item[gs-w="10"] {
     width: 16.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="10"] {
+  .grid-stack > .grid-stack-item[gs-x="10"] {
     left: 16.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="10"] {
+  .grid-stack > .grid-stack-item[gs-min-w="10"] {
     min-width: 16.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="10"] {
+  .grid-stack > .grid-stack-item[gs-max-w="10"] {
     max-width: 16.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="11"] {
+  .grid-stack > .grid-stack-item[gs-w="11"] {
     width: 18.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="11"] {
+  .grid-stack > .grid-stack-item[gs-x="11"] {
     left: 18.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="11"] {
+  .grid-stack > .grid-stack-item[gs-min-w="11"] {
     min-width: 18.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="11"] {
+  .grid-stack > .grid-stack-item[gs-max-w="11"] {
     max-width: 18.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="12"] {
+  .grid-stack > .grid-stack-item[gs-w="12"] {
     width: 20%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="12"] {
+  .grid-stack > .grid-stack-item[gs-x="12"] {
     left: 20%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="12"] {
+  .grid-stack > .grid-stack-item[gs-min-w="12"] {
     min-width: 20%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="12"] {
+  .grid-stack > .grid-stack-item[gs-max-w="12"] {
     max-width: 20%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="13"] {
+  .grid-stack > .grid-stack-item[gs-w="13"] {
     width: 21.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="13"] {
+  .grid-stack > .grid-stack-item[gs-x="13"] {
     left: 21.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="13"] {
+  .grid-stack > .grid-stack-item[gs-min-w="13"] {
     min-width: 21.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="13"] {
+  .grid-stack > .grid-stack-item[gs-max-w="13"] {
     max-width: 21.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="14"] {
+  .grid-stack > .grid-stack-item[gs-w="14"] {
     width: 23.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="14"] {
+  .grid-stack > .grid-stack-item[gs-x="14"] {
     left: 23.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="14"] {
+  .grid-stack > .grid-stack-item[gs-min-w="14"] {
     min-width: 23.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="14"] {
+  .grid-stack > .grid-stack-item[gs-max-w="14"] {
     max-width: 23.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="15"] {
+  .grid-stack > .grid-stack-item[gs-w="15"] {
     width: 25%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="15"] {
+  .grid-stack > .grid-stack-item[gs-x="15"] {
     left: 25%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="15"] {
+  .grid-stack > .grid-stack-item[gs-min-w="15"] {
     min-width: 25%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="15"] {
+  .grid-stack > .grid-stack-item[gs-max-w="15"] {
     max-width: 25%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="16"] {
+  .grid-stack > .grid-stack-item[gs-w="16"] {
     width: 26.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="16"] {
+  .grid-stack > .grid-stack-item[gs-x="16"] {
     left: 26.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="16"] {
+  .grid-stack > .grid-stack-item[gs-min-w="16"] {
     min-width: 26.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="16"] {
+  .grid-stack > .grid-stack-item[gs-max-w="16"] {
     max-width: 26.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="17"] {
+  .grid-stack > .grid-stack-item[gs-w="17"] {
     width: 28.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="17"] {
+  .grid-stack > .grid-stack-item[gs-x="17"] {
     left: 28.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="17"] {
+  .grid-stack > .grid-stack-item[gs-min-w="17"] {
     min-width: 28.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="17"] {
+  .grid-stack > .grid-stack-item[gs-max-w="17"] {
     max-width: 28.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="18"] {
+  .grid-stack > .grid-stack-item[gs-w="18"] {
     width: 30%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="18"] {
+  .grid-stack > .grid-stack-item[gs-x="18"] {
     left: 30%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="18"] {
+  .grid-stack > .grid-stack-item[gs-min-w="18"] {
     min-width: 30%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="18"] {
+  .grid-stack > .grid-stack-item[gs-max-w="18"] {
     max-width: 30%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="19"] {
+  .grid-stack > .grid-stack-item[gs-w="19"] {
     width: 31.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="19"] {
+  .grid-stack > .grid-stack-item[gs-x="19"] {
     left: 31.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="19"] {
+  .grid-stack > .grid-stack-item[gs-min-w="19"] {
     min-width: 31.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="19"] {
+  .grid-stack > .grid-stack-item[gs-max-w="19"] {
     max-width: 31.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="20"] {
+  .grid-stack > .grid-stack-item[gs-w="20"] {
     width: 33.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="20"] {
+  .grid-stack > .grid-stack-item[gs-x="20"] {
     left: 33.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="20"] {
+  .grid-stack > .grid-stack-item[gs-min-w="20"] {
     min-width: 33.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="20"] {
+  .grid-stack > .grid-stack-item[gs-max-w="20"] {
     max-width: 33.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="21"] {
+  .grid-stack > .grid-stack-item[gs-w="21"] {
     width: 35%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="21"] {
+  .grid-stack > .grid-stack-item[gs-x="21"] {
     left: 35%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="21"] {
+  .grid-stack > .grid-stack-item[gs-min-w="21"] {
     min-width: 35%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="21"] {
+  .grid-stack > .grid-stack-item[gs-max-w="21"] {
     max-width: 35%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="22"] {
+  .grid-stack > .grid-stack-item[gs-w="22"] {
     width: 36.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="22"] {
+  .grid-stack > .grid-stack-item[gs-x="22"] {
     left: 36.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="22"] {
+  .grid-stack > .grid-stack-item[gs-min-w="22"] {
     min-width: 36.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="22"] {
+  .grid-stack > .grid-stack-item[gs-max-w="22"] {
     max-width: 36.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="23"] {
+  .grid-stack > .grid-stack-item[gs-w="23"] {
     width: 38.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="23"] {
+  .grid-stack > .grid-stack-item[gs-x="23"] {
     left: 38.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="23"] {
+  .grid-stack > .grid-stack-item[gs-min-w="23"] {
     min-width: 38.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="23"] {
+  .grid-stack > .grid-stack-item[gs-max-w="23"] {
     max-width: 38.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="24"] {
+  .grid-stack > .grid-stack-item[gs-w="24"] {
     width: 40%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="24"] {
+  .grid-stack > .grid-stack-item[gs-x="24"] {
     left: 40%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="24"] {
+  .grid-stack > .grid-stack-item[gs-min-w="24"] {
     min-width: 40%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="24"] {
+  .grid-stack > .grid-stack-item[gs-max-w="24"] {
     max-width: 40%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="25"] {
+  .grid-stack > .grid-stack-item[gs-w="25"] {
     width: 41.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="25"] {
+  .grid-stack > .grid-stack-item[gs-x="25"] {
     left: 41.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="25"] {
+  .grid-stack > .grid-stack-item[gs-min-w="25"] {
     min-width: 41.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="25"] {
+  .grid-stack > .grid-stack-item[gs-max-w="25"] {
     max-width: 41.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="26"] {
+  .grid-stack > .grid-stack-item[gs-w="26"] {
     width: 43.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="26"] {
+  .grid-stack > .grid-stack-item[gs-x="26"] {
     left: 43.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="26"] {
+  .grid-stack > .grid-stack-item[gs-min-w="26"] {
     min-width: 43.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="26"] {
+  .grid-stack > .grid-stack-item[gs-max-w="26"] {
     max-width: 43.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="27"] {
+  .grid-stack > .grid-stack-item[gs-w="27"] {
     width: 45%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="27"] {
+  .grid-stack > .grid-stack-item[gs-x="27"] {
     left: 45%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="27"] {
+  .grid-stack > .grid-stack-item[gs-min-w="27"] {
     min-width: 45%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="27"] {
+  .grid-stack > .grid-stack-item[gs-max-w="27"] {
     max-width: 45%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="28"] {
+  .grid-stack > .grid-stack-item[gs-w="28"] {
     width: 46.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="28"] {
+  .grid-stack > .grid-stack-item[gs-x="28"] {
     left: 46.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="28"] {
+  .grid-stack > .grid-stack-item[gs-min-w="28"] {
     min-width: 46.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="28"] {
+  .grid-stack > .grid-stack-item[gs-max-w="28"] {
     max-width: 46.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="29"] {
+  .grid-stack > .grid-stack-item[gs-w="29"] {
     width: 48.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="29"] {
+  .grid-stack > .grid-stack-item[gs-x="29"] {
     left: 48.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="29"] {
+  .grid-stack > .grid-stack-item[gs-min-w="29"] {
     min-width: 48.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="29"] {
+  .grid-stack > .grid-stack-item[gs-max-w="29"] {
     max-width: 48.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="30"] {
+  .grid-stack > .grid-stack-item[gs-w="30"] {
     width: 50%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="30"] {
+  .grid-stack > .grid-stack-item[gs-x="30"] {
     left: 50%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="30"] {
+  .grid-stack > .grid-stack-item[gs-min-w="30"] {
     min-width: 50%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="30"] {
+  .grid-stack > .grid-stack-item[gs-max-w="30"] {
     max-width: 50%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="31"] {
+  .grid-stack > .grid-stack-item[gs-w="31"] {
     width: 51.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="31"] {
+  .grid-stack > .grid-stack-item[gs-x="31"] {
     left: 51.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="31"] {
+  .grid-stack > .grid-stack-item[gs-min-w="31"] {
     min-width: 51.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="31"] {
+  .grid-stack > .grid-stack-item[gs-max-w="31"] {
     max-width: 51.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="32"] {
+  .grid-stack > .grid-stack-item[gs-w="32"] {
     width: 53.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="32"] {
+  .grid-stack > .grid-stack-item[gs-x="32"] {
     left: 53.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="32"] {
+  .grid-stack > .grid-stack-item[gs-min-w="32"] {
     min-width: 53.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="32"] {
+  .grid-stack > .grid-stack-item[gs-max-w="32"] {
     max-width: 53.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="33"] {
+  .grid-stack > .grid-stack-item[gs-w="33"] {
     width: 55%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="33"] {
+  .grid-stack > .grid-stack-item[gs-x="33"] {
     left: 55%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="33"] {
+  .grid-stack > .grid-stack-item[gs-min-w="33"] {
     min-width: 55%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="33"] {
+  .grid-stack > .grid-stack-item[gs-max-w="33"] {
     max-width: 55%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="34"] {
+  .grid-stack > .grid-stack-item[gs-w="34"] {
     width: 56.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="34"] {
+  .grid-stack > .grid-stack-item[gs-x="34"] {
     left: 56.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="34"] {
+  .grid-stack > .grid-stack-item[gs-min-w="34"] {
     min-width: 56.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="34"] {
+  .grid-stack > .grid-stack-item[gs-max-w="34"] {
     max-width: 56.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="35"] {
+  .grid-stack > .grid-stack-item[gs-w="35"] {
     width: 58.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="35"] {
+  .grid-stack > .grid-stack-item[gs-x="35"] {
     left: 58.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="35"] {
+  .grid-stack > .grid-stack-item[gs-min-w="35"] {
     min-width: 58.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="35"] {
+  .grid-stack > .grid-stack-item[gs-max-w="35"] {
     max-width: 58.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="36"] {
+  .grid-stack > .grid-stack-item[gs-w="36"] {
     width: 60%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="36"] {
+  .grid-stack > .grid-stack-item[gs-x="36"] {
     left: 60%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="36"] {
+  .grid-stack > .grid-stack-item[gs-min-w="36"] {
     min-width: 60%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="36"] {
+  .grid-stack > .grid-stack-item[gs-max-w="36"] {
     max-width: 60%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="37"] {
+  .grid-stack > .grid-stack-item[gs-w="37"] {
     width: 61.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="37"] {
+  .grid-stack > .grid-stack-item[gs-x="37"] {
     left: 61.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="37"] {
+  .grid-stack > .grid-stack-item[gs-min-w="37"] {
     min-width: 61.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="37"] {
+  .grid-stack > .grid-stack-item[gs-max-w="37"] {
     max-width: 61.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="38"] {
+  .grid-stack > .grid-stack-item[gs-w="38"] {
     width: 63.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="38"] {
+  .grid-stack > .grid-stack-item[gs-x="38"] {
     left: 63.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="38"] {
+  .grid-stack > .grid-stack-item[gs-min-w="38"] {
     min-width: 63.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="38"] {
+  .grid-stack > .grid-stack-item[gs-max-w="38"] {
     max-width: 63.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="39"] {
+  .grid-stack > .grid-stack-item[gs-w="39"] {
     width: 65%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="39"] {
+  .grid-stack > .grid-stack-item[gs-x="39"] {
     left: 65%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="39"] {
+  .grid-stack > .grid-stack-item[gs-min-w="39"] {
     min-width: 65%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="39"] {
+  .grid-stack > .grid-stack-item[gs-max-w="39"] {
     max-width: 65%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="40"] {
+  .grid-stack > .grid-stack-item[gs-w="40"] {
     width: 66.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="40"] {
+  .grid-stack > .grid-stack-item[gs-x="40"] {
     left: 66.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="40"] {
+  .grid-stack > .grid-stack-item[gs-min-w="40"] {
     min-width: 66.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="40"] {
+  .grid-stack > .grid-stack-item[gs-max-w="40"] {
     max-width: 66.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="41"] {
+  .grid-stack > .grid-stack-item[gs-w="41"] {
     width: 68.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="41"] {
+  .grid-stack > .grid-stack-item[gs-x="41"] {
     left: 68.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="41"] {
+  .grid-stack > .grid-stack-item[gs-min-w="41"] {
     min-width: 68.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="41"] {
+  .grid-stack > .grid-stack-item[gs-max-w="41"] {
     max-width: 68.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="42"] {
+  .grid-stack > .grid-stack-item[gs-w="42"] {
     width: 70%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="42"] {
+  .grid-stack > .grid-stack-item[gs-x="42"] {
     left: 70%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="42"] {
+  .grid-stack > .grid-stack-item[gs-min-w="42"] {
     min-width: 70%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="42"] {
+  .grid-stack > .grid-stack-item[gs-max-w="42"] {
     max-width: 70%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="43"] {
+  .grid-stack > .grid-stack-item[gs-w="43"] {
     width: 71.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="43"] {
+  .grid-stack > .grid-stack-item[gs-x="43"] {
     left: 71.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="43"] {
+  .grid-stack > .grid-stack-item[gs-min-w="43"] {
     min-width: 71.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="43"] {
+  .grid-stack > .grid-stack-item[gs-max-w="43"] {
     max-width: 71.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="44"] {
+  .grid-stack > .grid-stack-item[gs-w="44"] {
     width: 73.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="44"] {
+  .grid-stack > .grid-stack-item[gs-x="44"] {
     left: 73.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="44"] {
+  .grid-stack > .grid-stack-item[gs-min-w="44"] {
     min-width: 73.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="44"] {
+  .grid-stack > .grid-stack-item[gs-max-w="44"] {
     max-width: 73.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="45"] {
+  .grid-stack > .grid-stack-item[gs-w="45"] {
     width: 75%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="45"] {
+  .grid-stack > .grid-stack-item[gs-x="45"] {
     left: 75%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="45"] {
+  .grid-stack > .grid-stack-item[gs-min-w="45"] {
     min-width: 75%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="45"] {
+  .grid-stack > .grid-stack-item[gs-max-w="45"] {
     max-width: 75%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="46"] {
+  .grid-stack > .grid-stack-item[gs-w="46"] {
     width: 76.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="46"] {
+  .grid-stack > .grid-stack-item[gs-x="46"] {
     left: 76.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="46"] {
+  .grid-stack > .grid-stack-item[gs-min-w="46"] {
     min-width: 76.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="46"] {
+  .grid-stack > .grid-stack-item[gs-max-w="46"] {
     max-width: 76.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="47"] {
+  .grid-stack > .grid-stack-item[gs-w="47"] {
     width: 78.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="47"] {
+  .grid-stack > .grid-stack-item[gs-x="47"] {
     left: 78.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="47"] {
+  .grid-stack > .grid-stack-item[gs-min-w="47"] {
     min-width: 78.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="47"] {
+  .grid-stack > .grid-stack-item[gs-max-w="47"] {
     max-width: 78.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="48"] {
+  .grid-stack > .grid-stack-item[gs-w="48"] {
     width: 80%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="48"] {
+  .grid-stack > .grid-stack-item[gs-x="48"] {
     left: 80%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="48"] {
+  .grid-stack > .grid-stack-item[gs-min-w="48"] {
     min-width: 80%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="48"] {
+  .grid-stack > .grid-stack-item[gs-max-w="48"] {
     max-width: 80%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="49"] {
+  .grid-stack > .grid-stack-item[gs-w="49"] {
     width: 81.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="49"] {
+  .grid-stack > .grid-stack-item[gs-x="49"] {
     left: 81.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="49"] {
+  .grid-stack > .grid-stack-item[gs-min-w="49"] {
     min-width: 81.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="49"] {
+  .grid-stack > .grid-stack-item[gs-max-w="49"] {
     max-width: 81.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="50"] {
+  .grid-stack > .grid-stack-item[gs-w="50"] {
     width: 83.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="50"] {
+  .grid-stack > .grid-stack-item[gs-x="50"] {
     left: 83.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="50"] {
+  .grid-stack > .grid-stack-item[gs-min-w="50"] {
     min-width: 83.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="50"] {
+  .grid-stack > .grid-stack-item[gs-max-w="50"] {
     max-width: 83.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="51"] {
+  .grid-stack > .grid-stack-item[gs-w="51"] {
     width: 85%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="51"] {
+  .grid-stack > .grid-stack-item[gs-x="51"] {
     left: 85%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="51"] {
+  .grid-stack > .grid-stack-item[gs-min-w="51"] {
     min-width: 85%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="51"] {
+  .grid-stack > .grid-stack-item[gs-max-w="51"] {
     max-width: 85%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="52"] {
+  .grid-stack > .grid-stack-item[gs-w="52"] {
     width: 86.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="52"] {
+  .grid-stack > .grid-stack-item[gs-x="52"] {
     left: 86.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="52"] {
+  .grid-stack > .grid-stack-item[gs-min-w="52"] {
     min-width: 86.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="52"] {
+  .grid-stack > .grid-stack-item[gs-max-w="52"] {
     max-width: 86.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="53"] {
+  .grid-stack > .grid-stack-item[gs-w="53"] {
     width: 88.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="53"] {
+  .grid-stack > .grid-stack-item[gs-x="53"] {
     left: 88.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="53"] {
+  .grid-stack > .grid-stack-item[gs-min-w="53"] {
     min-width: 88.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="53"] {
+  .grid-stack > .grid-stack-item[gs-max-w="53"] {
     max-width: 88.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="54"] {
+  .grid-stack > .grid-stack-item[gs-w="54"] {
     width: 90%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="54"] {
+  .grid-stack > .grid-stack-item[gs-x="54"] {
     left: 90%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="54"] {
+  .grid-stack > .grid-stack-item[gs-min-w="54"] {
     min-width: 90%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="54"] {
+  .grid-stack > .grid-stack-item[gs-max-w="54"] {
     max-width: 90%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="55"] {
+  .grid-stack > .grid-stack-item[gs-w="55"] {
     width: 91.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="55"] {
+  .grid-stack > .grid-stack-item[gs-x="55"] {
     left: 91.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="55"] {
+  .grid-stack > .grid-stack-item[gs-min-w="55"] {
     min-width: 91.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="55"] {
+  .grid-stack > .grid-stack-item[gs-max-w="55"] {
     max-width: 91.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="56"] {
+  .grid-stack > .grid-stack-item[gs-w="56"] {
     width: 93.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="56"] {
+  .grid-stack > .grid-stack-item[gs-x="56"] {
     left: 93.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="56"] {
+  .grid-stack > .grid-stack-item[gs-min-w="56"] {
     min-width: 93.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="56"] {
+  .grid-stack > .grid-stack-item[gs-max-w="56"] {
     max-width: 93.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="57"] {
+  .grid-stack > .grid-stack-item[gs-w="57"] {
     width: 95%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="57"] {
+  .grid-stack > .grid-stack-item[gs-x="57"] {
     left: 95%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="57"] {
+  .grid-stack > .grid-stack-item[gs-min-w="57"] {
     min-width: 95%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="57"] {
+  .grid-stack > .grid-stack-item[gs-max-w="57"] {
     max-width: 95%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="58"] {
+  .grid-stack > .grid-stack-item[gs-w="58"] {
     width: 96.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="58"] {
+  .grid-stack > .grid-stack-item[gs-x="58"] {
     left: 96.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="58"] {
+  .grid-stack > .grid-stack-item[gs-min-w="58"] {
     min-width: 96.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="58"] {
+  .grid-stack > .grid-stack-item[gs-max-w="58"] {
     max-width: 96.6666666667%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="59"] {
+  .grid-stack > .grid-stack-item[gs-w="59"] {
     width: 98.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="59"] {
+  .grid-stack > .grid-stack-item[gs-x="59"] {
     left: 98.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="59"] {
+  .grid-stack > .grid-stack-item[gs-min-w="59"] {
     min-width: 98.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="59"] {
+  .grid-stack > .grid-stack-item[gs-max-w="59"] {
     max-width: 98.3333333333%;
   }
-  .grid-stack > .grid-stack-item[data-gs-width="60"] {
+  .grid-stack > .grid-stack-item[gs-w="60"] {
     width: 100%;
   }
-  .grid-stack > .grid-stack-item[data-gs-x="60"] {
+  .grid-stack > .grid-stack-item[gs-x="60"] {
     left: 100%;
   }
-  .grid-stack > .grid-stack-item[data-gs-min-width="60"] {
+  .grid-stack > .grid-stack-item[gs-min-w="60"] {
     min-width: 100%;
   }
-  .grid-stack > .grid-stack-item[data-gs-max-width="60"] {
+  .grid-stack > .grid-stack-item[gs-max-w="60"] {
     max-width: 100%;
   }

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -8,10 +8,10 @@ describe('gridstack', function() {
   // grid has 4x2 and 4x4 top-left aligned - used on most test cases
   let gridHTML =
   '<div class="grid-stack">' +
-  '  <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="4" data-gs-height="2" data-gs-id="gsItem1" id="item1">' +
+  '  <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="4" gs-h="2" gs-id="gsItem1" id="item1">' +
   '    <div class="grid-stack-item-content">item 1 text</div>' +
   '  </div>' +
-  '  <div class="grid-stack-item" data-gs-x="4" data-gs-y="0" data-gs-width="4" data-gs-height="4" data-gs-id="gsItem2" id="item2">' +
+  '  <div class="grid-stack-item" gs-x="4" gs-y="0" gs-w="4" gs-h="4" gs-id="gsItem2" id="item2">' +
   '    <div class="grid-stack-item-content">item 2 text</div>' +
   '  </div>' +
   '</div>';
@@ -205,7 +205,7 @@ describe('gridstack', function() {
         column: 12
       };
       let grid = GridStack.init(options);
-      let rows = parseInt(grid.el.getAttribute('data-gs-current-row'));
+      let rows = parseInt(grid.el.getAttribute('gs-current-row'));
       
       expect(grid.getRow()).toBe(rows);
 
@@ -256,12 +256,12 @@ describe('gridstack', function() {
       grid.column(9);
       expect(grid.getColumn()).toBe(9);
       for (let j = 0; j < items.length; j++) {
-        expect(parseInt(items[j].getAttribute('data-gs-y'), 10)).toBe(0);
+        expect(parseInt(items[j].getAttribute('gs-y'), 10)).toBe(0);
       }
       grid.column(12);
       expect(grid.getColumn()).toBe(12);
       for (let j = 0; j < items.length; j++) {
-        expect(parseInt(items[j].getAttribute('data-gs-y'), 10)).toBe(0);
+        expect(parseInt(items[j].getAttribute('gs-y'), 10)).toBe(0);
       }
     });
     it('no sizing, no moving', function() {
@@ -270,8 +270,8 @@ describe('gridstack', function() {
       grid.column(8, 'none');
       expect(grid.getColumn()).toBe(8);
       for (let j = 0; j < items.length; j++) {
-        expect(parseInt(items[j].getAttribute('data-gs-width'), 10)).toBe(4);
-        expect(parseInt(items[j].getAttribute('data-gs-y'), 10)).toBe(0);
+        expect(parseInt(items[j].getAttribute('gs-w'), 10)).toBe(4);
+        expect(parseInt(items[j].getAttribute('gs-y'), 10)).toBe(0);
       }
     });
     it('no sizing, but moving down', function() {
@@ -280,10 +280,10 @@ describe('gridstack', function() {
       grid.column(7, 'none');
       expect(grid.getColumn()).toBe(7);
       for (let j = 0; j < items.length; j++) {
-        expect(parseInt(items[j].getAttribute('data-gs-width'), 10)).toBe(4);
+        expect(parseInt(items[j].getAttribute('gs-w'), 10)).toBe(4);
       }
-      expect(parseInt(items[0].getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(items[1].getAttribute('data-gs-y'), 10)).toBe(2);
+      expect(parseInt(items[0].getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(items[1].getAttribute('gs-y'), 10)).toBe(2);
     });
     it('should change column number and re-layout items', function() {
       let options = {
@@ -295,110 +295,110 @@ describe('gridstack', function() {
       let el2 = document.getElementById('item2')
 
       // items start at 4x2 and 4x4
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
       // 1 column will have item1, item2
       grid.column(1);
       expect(grid.getColumn()).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       // add default 1x1 item to the end (1 column)
       let el3 = grid.addWidget();
       expect(el3).not.toBe(null);
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(6);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(6);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
 
       // back to 12 column and initial layout (other than new item3)
       grid.column(12);
       expect(grid.getColumn()).toBe(12);
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(6); // ??? keep same row, but might more intuitive higher
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1); // ??? could take entire width if it did above
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(6); // ??? keep same row, but might more intuitive higher
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1); // ??? could take entire width if it did above
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
 
       // back to 1 column, move item2 to beginning to [3][1][2] vertically
       grid.column(1);
       expect(grid.getColumn()).toBe(1);
       grid.move(el3, 0, 0);
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(3);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       // back to 12 column, el3 to be beginning still, but [1][2] to be in 1 columns still but wide 4x2 and 4x still
       grid.column(12);
       expect(grid.getColumn()).toBe(12);
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(4);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       // 2 column will have item1, item2, item3 in 1 column still but half the width
       grid.column(1); // test convert from small, should use 12 layout still
       grid.column(2);
       expect(grid.getColumn()).toBe(2);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1); // 1 as we scaled from 12 columns
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1); // 1 as we scaled from 12 columns
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(4);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
     });
   });
 
@@ -424,37 +424,37 @@ describe('gridstack', function() {
       grid.commit();
       
       // items are item1[1x1], item3[1x1], item2[2x1]
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
 
       // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
       grid.column(1);
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(3);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
     });
     it('should support oneColumnModeDomSort ON going to 1 column', function() {
       let options = {
@@ -468,37 +468,37 @@ describe('gridstack', function() {
       let el3 = grid.addWidget({x:1, y:0, width:1, height:2});
 
       // items are item1[1x1], item3[1x1], item2[2x1]
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
 
       // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
       grid.column(1);
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el1.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
 
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(2);
-      expect(parseInt(el3.getAttribute('data-gs-width'))).toBe(1);
-      expect(parseInt(el3.getAttribute('data-gs-height'))).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
     });
   });
 
@@ -582,7 +582,7 @@ describe('gridstack', function() {
     it('should have row attr', function() {
       let HTML = 
         '<div style="width: 800px; height: 600px" id="gs-cont">' +
-        '  <div class="grid-stack" data-gs-row="4" data-gs-current-height="1"></div>' + // old attr current-height
+        '  <div class="grid-stack" gs-row="4" gs-current-height="1"></div>' + // old attr current-height
         '</div>';
       document.body.insertAdjacentHTML('afterbegin', HTML);
       let grid = GridStack.init();
@@ -602,7 +602,7 @@ describe('gridstack', function() {
     afterEach(function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
-    it('should set data-gs-min-width to 2.', function() {
+    it('should set gs-min-w to 2.', function() {
       let grid = GridStack.init();
       let items = Utils.getElements('.grid-stack-item');
       for (let i = 0; i < items.length; i++) {
@@ -613,10 +613,10 @@ describe('gridstack', function() {
           .maxHeight(items[i], 5);
       }
       for (let j = 0; j < items.length; j++) {
-        expect(parseInt(items[j].getAttribute('data-gs-min-width'), 10)).toBe(2);
-        expect(parseInt(items[j].getAttribute('data-gs-max-width'), 10)).toBe(3);
-        expect(parseInt(items[j].getAttribute('data-gs-min-height'), 10)).toBe(4);
-        expect(parseInt(items[j].getAttribute('data-gs-max-height'), 10)).toBe(5);
+        expect(parseInt(items[j].getAttribute('gs-min-w'), 10)).toBe(2);
+        expect(parseInt(items[j].getAttribute('gs-max-w'), 10)).toBe(3);
+        expect(parseInt(items[j].getAttribute('gs-min-h'), 10)).toBe(4);
+        expect(parseInt(items[j].getAttribute('gs-max-h'), 10)).toBe(5);
       }
       // remove all constrain
       grid
@@ -625,10 +625,10 @@ describe('gridstack', function() {
         .minHeight('grid-stack-item', undefined)
         .maxHeight(undefined, 0);
       for (let j = 0; j < items.length; j++) {
-        expect(items[j].getAttribute('data-gs-min-width')).toBe(null);
-        expect(items[j].getAttribute('data-gs-max-width')).toBe(null);
-        expect(items[j].getAttribute('data-gs-min-height')).toBe(null);
-        expect(items[j].getAttribute('data-gs-max-height')).toBe(null);
+        expect(items[j].getAttribute('gs-min-w')).toBe(null);
+        expect(items[j].getAttribute('gs-max-w')).toBe(null);
+        expect(items[j].getAttribute('gs-min-h')).toBe(null);
+        expect(items[j].getAttribute('gs-max-h')).toBe(null);
       }
     });
   });
@@ -737,8 +737,8 @@ describe('gridstack', function() {
       for (let i = 0; i < items.length; i++) {
         let el = grid.addWidget(items[i]);
         let oldEl = items[i];
-        expect(parseInt(oldEl.getAttribute('data-gs-x'), 10)).toBe(parseInt(el.getAttribute('data-gs-x'), 10));
-        expect(parseInt(oldEl.getAttribute('data-gs-y'), 10)).toBe(parseInt(el.getAttribute('data-gs-y'), 10));
+        expect(parseInt(oldEl.getAttribute('gs-x'), 10)).toBe(parseInt(el.getAttribute('gs-x'), 10));
+        expect(parseInt(oldEl.getAttribute('gs-y'), 10)).toBe(parseInt(el.getAttribute('gs-y'), 10));
       }
     });
     it('should not allow same x, y coordinates for widgets.', function() {
@@ -751,7 +751,7 @@ describe('gridstack', function() {
       for (let i = 0; i < items.length; i++) {
         let el = items[i].cloneNode(true) as HTMLElement;
         el = grid.addWidget(el);
-        expect(parseInt(el.getAttribute('data-gs-y'), 10)).not.toBe(parseInt(items[i].getAttribute('data-gs-y'), 10));
+        expect(parseInt(el.getAttribute('gs-y'), 10)).not.toBe(parseInt(items[i].getAttribute('gs-y'), 10));
       }
     });
   });
@@ -768,45 +768,45 @@ describe('gridstack', function() {
       let widget = grid.addWidget({x: 6, y:7, width:2, height:3, autoPosition:false,
         minWidth:1, maxWidth:4, minHeight:2, maxHeight:5, id:'coolWidget'});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(6);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(7);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(3);
-      expect(widget.getAttribute('data-gs-auto-position')).toBe(null);
-      expect(parseInt(widget.getAttribute('data-gs-min-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-max-width'), 10)).toBe(4);
-      expect(parseInt(widget.getAttribute('data-gs-min-height'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-max-height'), 10)).toBe(5);
-      expect(widget.getAttribute('data-gs-id')).toBe('coolWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(6);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(7);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(3);
+      expect(widget.getAttribute('gs-auto-position')).toBe(null);
+      expect(parseInt(widget.getAttribute('gs-min-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-max-w'), 10)).toBe(4);
+      expect(parseInt(widget.getAttribute('gs-min-h'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-max-h'), 10)).toBe(5);
+      expect(widget.getAttribute('gs-id')).toBe('coolWidget');
 
       // should move widget to top with float=false
       expect(grid.getFloat()).toBe(true);
       grid.float(false);
       expect(grid.getFloat()).toBe(false);
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(6);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(4); // <--- from 7 to 4 below second original widget
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(3);
-      expect(widget.getAttribute('data-gs-auto-position')).toBe(null);
-      expect(parseInt(widget.getAttribute('data-gs-min-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-max-width'), 10)).toBe(4);
-      expect(parseInt(widget.getAttribute('data-gs-min-height'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-max-height'), 10)).toBe(5);
-      expect(widget.getAttribute('data-gs-id')).toBe('coolWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(6);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(4); // <--- from 7 to 4 below second original widget
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(3);
+      expect(widget.getAttribute('gs-auto-position')).toBe(null);
+      expect(parseInt(widget.getAttribute('gs-min-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-max-w'), 10)).toBe(4);
+      expect(parseInt(widget.getAttribute('gs-min-h'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-max-h'), 10)).toBe(5);
+      expect(widget.getAttribute('gs-id')).toBe('coolWidget');
 
       // should not move again (no-op)
       grid.float(true);
       expect(grid.getFloat()).toBe(true);
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(6);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(4);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(3);
-      expect(widget.getAttribute('data-gs-auto-position')).toBe(null);
-      expect(parseInt(widget.getAttribute('data-gs-min-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-max-width'), 10)).toBe(4);
-      expect(parseInt(widget.getAttribute('data-gs-min-height'), 10)).toBe(2);
-      expect(parseInt(widget.getAttribute('data-gs-max-height'), 10)).toBe(5);
-      expect(widget.getAttribute('data-gs-id')).toBe('coolWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(6);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(4);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(3);
+      expect(widget.getAttribute('gs-auto-position')).toBe(null);
+      expect(parseInt(widget.getAttribute('gs-min-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-max-w'), 10)).toBe(4);
+      expect(parseInt(widget.getAttribute('gs-min-h'), 10)).toBe(2);
+      expect(parseInt(widget.getAttribute('gs-max-h'), 10)).toBe(5);
+      expect(widget.getAttribute('gs-id')).toBe('coolWidget');
     });
   });
 
@@ -821,8 +821,8 @@ describe('gridstack', function() {
       let grid = GridStack.init({float: true});
       let widget = grid.addWidget({x:9, y:7, width:2, height:3, autoPosition:true});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).not.toBe(9);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).not.toBe(7);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).not.toBe(9);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).not.toBe(7);
     });
   });
 
@@ -837,75 +837,75 @@ describe('gridstack', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget({height: 2, id: 'optionWidget'});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(2);
-      // expect(widget.getAttribute('data-gs-auto-position')).toBe('true');
-      expect(widget.getAttribute('data-gs-min-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-min-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-id')).toBe('optionWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
+      // expect(widget.getAttribute('gs-auto-position')).toBe('true');
+      expect(widget.getAttribute('gs-min-w')).toBe(null);
+      expect(widget.getAttribute('gs-max-w')).toBe(null);
+      expect(widget.getAttribute('gs-min-h')).toBe(null);
+      expect(widget.getAttribute('gs-max-h')).toBe(null);
+      expect(widget.getAttribute('gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing X)', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget({y: 9, height: 2, id: 'optionWidget'});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(2);
-      // expect(widget.getAttribute('data-gs-auto-position')).toBe('true');
-      expect(widget.getAttribute('data-gs-min-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-min-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-id')).toBe('optionWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
+      // expect(widget.getAttribute('gs-auto-position')).toBe('true');
+      expect(widget.getAttribute('gs-min-w')).toBe(null);
+      expect(widget.getAttribute('gs-max-w')).toBe(null);
+      expect(widget.getAttribute('gs-min-h')).toBe(null);
+      expect(widget.getAttribute('gs-max-h')).toBe(null);
+      expect(widget.getAttribute('gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (missing Y)', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget({x: 9, height: 2, id: 'optionWidget'});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(2);
-      // expect(widget.getAttribute('data-gs-auto-position')).toBe('true');
-      expect(widget.getAttribute('data-gs-min-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-min-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-id')).toBe('optionWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
+      // expect(widget.getAttribute('gs-auto-position')).toBe('true');
+      expect(widget.getAttribute('gs-min-w')).toBe(null);
+      expect(widget.getAttribute('gs-max-w')).toBe(null);
+      expect(widget.getAttribute('gs-min-h')).toBe(null);
+      expect(widget.getAttribute('gs-max-h')).toBe(null);
+      expect(widget.getAttribute('gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (correct X, missing Y)', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget({x: 8, height: 2, id: 'optionWidget'});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(2);
-      // expect(widget.getAttribute('data-gs-auto-position')).toBe('true');
-      expect(widget.getAttribute('data-gs-min-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-min-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-id')).toBe('optionWidget');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
+      // expect(widget.getAttribute('gs-auto-position')).toBe('true');
+      expect(widget.getAttribute('gs-min-w')).toBe(null);
+      expect(widget.getAttribute('gs-max-w')).toBe(null);
+      expect(widget.getAttribute('gs-min-h')).toBe(null);
+      expect(widget.getAttribute('gs-max-h')).toBe(null);
+      expect(widget.getAttribute('gs-id')).toBe('optionWidget');
     });
     it('should autoPosition (empty options)', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget();
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(1);
-      // expect(widget.getAttribute('data-gs-auto-position')).toBe('true');
-      expect(widget.getAttribute('data-gs-min-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-width')).toBe(null);
-      expect(widget.getAttribute('data-gs-min-height')).toBe(null);
-      expect(widget.getAttribute('data-gs-max-height')).toBe(null);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
+      // expect(widget.getAttribute('gs-auto-position')).toBe('true');
+      expect(widget.getAttribute('gs-min-w')).toBe(null);
+      expect(widget.getAttribute('gs-max-w')).toBe(null);
+      expect(widget.getAttribute('gs-min-h')).toBe(null);
+      expect(widget.getAttribute('gs-max-h')).toBe(null);
     });
 
   });
@@ -921,29 +921,29 @@ describe('gridstack', function() {
       let grid = GridStack.init();
       let widget = grid.addWidget({x: 'foo', y: null, width: 'bar', height: ''} as any);
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
     });
     it('null options should clear x position', function() {
       let grid = GridStack.init({float: true});
-      let HTML = '<div class="grid-stack-item" data-gs-x="9"><div class="grid-stack-item-content"></div></div>';
+      let HTML = '<div class="grid-stack-item" gs-x="9"><div class="grid-stack-item-content"></div></div>';
       let widget = grid.addWidget(HTML, {x:null, y:null, width:undefined});
       
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(8);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
     });
     it('width attr should be retained', function() { // #1276
       let grid = GridStack.init({float: true});
-      let HTML = '<div class="grid-stack-item" data-gs-width="3" data-gs-max-width="4" data-gs-id="foo"><div class="grid-stack-item-content"></div></div>';
+      let HTML = '<div class="grid-stack-item" gs-w="3" gs-max-w="4" gs-id="foo"><div class="grid-stack-item-content"></div></div>';
       let widget = grid.addWidget(HTML, {x: 1, y: 5});
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('data-gs-y'), 10)).toBe(5);
-      expect(parseInt(widget.getAttribute('data-gs-width'), 10)).toBe(3);
-      expect(parseInt(widget.getAttribute('data-gs-max-width'), 10)).toBe(4);
-      expect(parseInt(widget.getAttribute('data-gs-height'), 10)).toBe(1);
-      expect(widget.getAttribute('data-gs-id')).toBe('foo');
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(1);
+      expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(5);
+      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(3);
+      expect(parseInt(widget.getAttribute('gs-max-w'), 10)).toBe(4);
+      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-id')).toBe('foo');
     });
   });
 
@@ -961,7 +961,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget(el);
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
     it('passing class', function() {
       let grid = GridStack.init();
@@ -970,7 +970,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget('.item');
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
     it('passing class no dot', function() {
       let grid = GridStack.init();
@@ -979,7 +979,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget('item');
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
     it('passing id', function() {
       let grid = GridStack.init();
@@ -988,7 +988,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget('#item');
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
     it('passing id no #', function() {
       let grid = GridStack.init();
@@ -997,7 +997,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget('item');
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
     it('passing id as number', function() {
       let grid = GridStack.init();
@@ -1006,7 +1006,7 @@ describe('gridstack', function() {
       let el = doc.body.children[0] as HTMLElement;
       grid.el.appendChild(el);
       let widget = grid.makeWidget('1');
-      expect(parseInt(widget.getAttribute('data-gs-x'), 10)).toBe(0);
+      expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(0);
     });
   });
 
@@ -1077,8 +1077,8 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       let items = Utils.getElements('.grid-stack-item');
       grid.resize(items[0], 5, 5);
-      expect(parseInt(items[0].getAttribute('data-gs-width'), 10)).toBe(5);
-      expect(parseInt(items[0].getAttribute('data-gs-height'), 10)).toBe(5);
+      expect(parseInt(items[0].getAttribute('gs-w'), 10)).toBe(5);
+      expect(parseInt(items[0].getAttribute('gs-h'), 10)).toBe(5);
     });
   });
 
@@ -1098,8 +1098,8 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       let items = Utils.getElements('.grid-stack-item');
       grid.move(items[0], 5, 5);
-      expect(parseInt(items[0].getAttribute('data-gs-x'), 10)).toBe(5);
-      expect(parseInt(items[0].getAttribute('data-gs-y'), 10)).toBe(5);
+      expect(parseInt(items[0].getAttribute('gs-x'), 10)).toBe(5);
+      expect(parseInt(items[0].getAttribute('gs-y'), 10)).toBe(5);
     });
   });
 
@@ -1113,13 +1113,13 @@ describe('gridstack', function() {
     it('should move and resize widget', function() {
       let grid = GridStack.init({float: true});
       let el = Utils.getElements('.grid-stack-item')[1];
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
       
       grid.update(el, {x: 5, y: 4, height: 2});
-      expect(parseInt(el.getAttribute('data-gs-x'), 10)).toBe(5);
-      expect(parseInt(el.getAttribute('data-gs-y'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-height'), 10)).toBe(2);
+      expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(5);
+      expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(2);
     });
     it('should change noMove', function() {
       let grid = GridStack.init({float: true});
@@ -1128,17 +1128,17 @@ describe('gridstack', function() {
       let dd = GridStackDD.get();
       
       grid.update(el, {noMove: true, noResize: false});
-      expect(el.getAttribute('data-gs-no-move')).toBe('true');
-      expect(el.getAttribute('data-gs-no-resize')).toBe(null); // false is no-op
+      expect(el.getAttribute('gs-no-move')).toBe('true');
+      expect(el.getAttribute('gs-no-resize')).toBe(null); // false is no-op
       expect(dd.isResizable(el)).toBe(true);
       expect(dd.isDraggable(el)).toBe(false);
       expect(dd.isResizable(items[0])).toBe(true);
       expect(dd.isDraggable(items[0])).toBe(true);
 
-      expect(parseInt(el.getAttribute('data-gs-x'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-height'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(4);
     });
     it('should change content and id, and move', function() {
       let grid = GridStack.init({float: true});
@@ -1147,57 +1147,57 @@ describe('gridstack', function() {
       let sub = el.querySelector('.grid-stack-item-content');
 
       grid.update(el, {id: 'newID', y: 1, content: 'new content'});
-      expect(el.getAttribute('data-gs-id')).toBe('newID');
+      expect(el.getAttribute('gs-id')).toBe('newID');
       expect(sub.innerHTML).toBe('new content');
-      expect(parseInt(el.getAttribute('data-gs-x'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-y'), 10)).toBe(1);
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-height'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(1);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(4);
     });
     it('should change max and constrain a wanted resize', function() {
       let grid = GridStack.init({float: true});
       let items = Utils.getElements('.grid-stack-item');
       let el = items[1];
-      expect(el.getAttribute('data-gs-max-width')).toBe(null);
+      expect(el.getAttribute('gs-max-w')).toBe(null);
 
       grid.update(el, {maxWidth: 2, width: 5});
-      expect(parseInt(el.getAttribute('data-gs-x'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(2);
-      expect(parseInt(el.getAttribute('data-gs-height'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-max-width'), 10)).toBe(2);
+      expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(2);
+      expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-max-w'), 10)).toBe(2);
     });
     it('should change max and constrain existing', function() {
       let grid = GridStack.init({float: true});
       let items = Utils.getElements('.grid-stack-item');
       let el = items[1];
-      expect(el.getAttribute('data-gs-max-width')).toBe(null);
+      expect(el.getAttribute('gs-max-w')).toBe(null);
 
       grid.update(el, {maxWidth: 2});
-      expect(parseInt(el.getAttribute('data-gs-x'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-y'), 10)).toBe(0);
-      expect(parseInt(el.getAttribute('data-gs-height'), 10)).toBe(4);
-      expect(parseInt(el.getAttribute('data-gs-max-width'), 10)).toBe(2);
-      expect(parseInt(el.getAttribute('data-gs-width'), 10)).toBe(2);
+      expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(4);
+      expect(parseInt(el.getAttribute('gs-max-w'), 10)).toBe(2);
+      expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(2);
     });
     it('should change all max and move', function() {
       let grid = GridStack.init({float: true});
       let items = Utils.getElements('.grid-stack-item');
 
       items.forEach(item => {
-        expect(item.getAttribute('data-gs-max-width')).toBe(null);
-        expect(item.getAttribute('data-gs-max-height')).toBe(null);
+        expect(item.getAttribute('gs-max-w')).toBe(null);
+        expect(item.getAttribute('gs-max-h')).toBe(null);
       });
 
       grid.update('.grid-stack-item', {maxWidth: 2, maxHeight: 2});
-      expect(parseInt(items[0].getAttribute('data-gs-x'), 10)).toBe(0);
-      expect(parseInt(items[1].getAttribute('data-gs-x'), 10)).toBe(4);
+      expect(parseInt(items[0].getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(items[1].getAttribute('gs-x'), 10)).toBe(4);
       items.forEach(item => {
-        expect(parseInt(item.getAttribute('data-gs-y'), 10)).toBe(0);
-        expect(parseInt(item.getAttribute('data-gs-height'), 10)).toBe(2);
-        expect(parseInt(item.getAttribute('data-gs-width'), 10)).toBe(2);
-        expect(parseInt(item.getAttribute('data-gs-max-width'), 10)).toBe(2);
-        expect(parseInt(item.getAttribute('data-gs-max-height'), 10)).toBe(2);
+        expect(parseInt(item.getAttribute('gs-y'), 10)).toBe(0);
+        expect(parseInt(item.getAttribute('gs-h'), 10)).toBe(2);
+        expect(parseInt(item.getAttribute('gs-w'), 10)).toBe(2);
+        expect(parseInt(item.getAttribute('gs-max-w'), 10)).toBe(2);
+        expect(parseInt(item.getAttribute('gs-max-h'), 10)).toBe(2);
       });
     });
 
@@ -1534,7 +1534,7 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       grid.locked('.grid-stack-item', true);
       Utils.getElements('.grid-stack-item').forEach(item => {
-        expect(item.getAttribute('data-gs-locked')).toBe('true');
+        expect(item.getAttribute('gs-locked')).toBe('true');
       })
     });
     it('should unlock widgets', function() {
@@ -1545,7 +1545,7 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       grid.locked('.grid-stack-item', false);
       Utils.getElements('.grid-stack-item').forEach(item => {
-        expect(item.getAttribute('data-gs-locked')).toBe(null);
+        expect(item.getAttribute('gs-locked')).toBe(null);
       })
     });
   });
@@ -1554,16 +1554,16 @@ describe('gridstack', function() {
     let HTML = 
     '<div style="width: 800px; height: 600px" id="gs-cont">' +
     '  <div class="grid-stack">' +
-    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="12" data-gs-height="9">' +
+    '    <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="12" gs-h="9">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
-    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="9" data-gs-width="12" data-gs-height="5">' +
+    '    <div class="grid-stack-item" gs-x="0" gs-y="9" gs-w="12" gs-h="5">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
-    '    <div class="grid-stack-item" data-gs-x="0" data-gs-y="14" data-gs-width="7" data-gs-height="6">' +
+    '    <div class="grid-stack-item" gs-x="0" gs-y="14" gs-w="7" gs-h="6">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
-    '    <div class="grid-stack-item" data-gs-x="7" data-gs-y="14" data-gs-width="5" data-gs-height="6">' +
+    '    <div class="grid-stack-item" gs-x="7" gs-y="14" gs-w="5" gs-h="6">' +
     '      <div class="grid-stack-item-content"></div>' +
     '    </div>' +
     '  </div>' +
@@ -1578,10 +1578,10 @@ describe('gridstack', function() {
     it('should have correct position', function() {
       let items = Utils.getElements('.grid-stack-item');
       for (let i = 0; i < items.length; i++) {
-        expect(parseInt(items[i].getAttribute('data-gs-x'))).toBe(pos[i].x);
-        expect(parseInt(items[i].getAttribute('data-gs-y'))).toBe(pos[i].y);
-        expect(parseInt(items[i].getAttribute('data-gs-width'))).toBe(pos[i].w);
-        expect(parseInt(items[i].getAttribute('data-gs-height'))).toBe(pos[i].h);
+        expect(parseInt(items[i].getAttribute('gs-x'))).toBe(pos[i].x);
+        expect(parseInt(items[i].getAttribute('gs-y'))).toBe(pos[i].y);
+        expect(parseInt(items[i].getAttribute('gs-w'))).toBe(pos[i].w);
+        expect(parseInt(items[i].getAttribute('gs-h'))).toBe(pos[i].h);
       }
     });
   });
@@ -1597,23 +1597,23 @@ describe('gridstack', function() {
       let grid = GridStack.init({float: true});
 
       let el3 = grid.addWidget({x: 3, y: 5});
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(3);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(5);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(3);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(5);
 
       grid.compact();
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(8);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(8);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
     });
     it('not move locked item', function() {
       let grid = GridStack.init({float: true});
 
       let el3 = grid.addWidget({x: 3, y: 5, locked: true, noMove: true});
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(3);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(5);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(3);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(5);
 
       grid.compact();
-      expect(parseInt(el3.getAttribute('data-gs-x'))).toBe(3);
-      expect(parseInt(el3.getAttribute('data-gs-y'))).toBe(5);
+      expect(parseInt(el3.getAttribute('gs-x'))).toBe(3);
+      expect(parseInt(el3.getAttribute('gs-y'))).toBe(5);
     });
   });
 
@@ -1627,15 +1627,15 @@ describe('gridstack', function() {
     it('not move locked item, size down added one', function() {
       let grid = GridStack.init();
       let el1 = grid.addWidget({x: 0, y: 1, width: 12, height: 1, locked: true});
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(1);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
 
       let el2 = grid.addWidget({x: 2, y: 0, height: 3});
-      expect(parseInt(el1.getAttribute('data-gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('data-gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('data-gs-x'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-y'))).toBe(2);
-      expect(parseInt(el2.getAttribute('data-gs-height'))).toBe(3);
+      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-y'))).toBe(2);
+      expect(parseInt(el2.getAttribute('gs-h'))).toBe(3);
     });
 
   });

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -54,12 +54,12 @@ describe('gridstack utils', function() {
       let _id = 'test-123';
       Utils.createStylesheet(_id);
 
-      let style = document.querySelector('STYLE[data-gs-style-id=' + _id + ']');
+      let style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
       expect(style).not.toBe(null);
       // expect(style.prop('tagName')).toEqual('STYLE');
 
       Utils.removeStylesheet(_id)
-      style = document.querySelector('STYLE[data-gs-style-id=' + _id + ']');
+      style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
       expect(style).toBe(null);
     });
 

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -129,9 +129,9 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
 
       // see if we already have a node with widget/height and check for attributes
       if (el.getAttribute && (!node.width || !node.height)) {
-        let w = parseInt(el.getAttribute('data-gs-width'));
+        let w = parseInt(el.getAttribute('gs-w'));
         if (w > 0) { node.width = w; }
-        let h = parseInt(el.getAttribute('data-gs-height'));
+        let h = parseInt(el.getAttribute('gs-h'));
         if (h > 0) { node.height = h; }
       }
 
@@ -344,10 +344,10 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
     cellWidth = this.cellWidth();
     cellHeight = this.getCellHeight(true); // force pixels for calculations
 
-    this.placeholder.setAttribute('data-gs-x', target.getAttribute('data-gs-x'));
-    this.placeholder.setAttribute('data-gs-y', target.getAttribute('data-gs-y'));
-    this.placeholder.setAttribute('data-gs-width', target.getAttribute('data-gs-width'));
-    this.placeholder.setAttribute('data-gs-height', target.getAttribute('data-gs-height'));
+    this.placeholder.setAttribute('gs-x', target.getAttribute('gs-x'));
+    this.placeholder.setAttribute('gs-y', target.getAttribute('gs-y'));
+    this.placeholder.setAttribute('gs-w', target.getAttribute('gs-w'));
+    this.placeholder.setAttribute('gs-h', target.getAttribute('gs-h'));
     this.el.append(this.placeholder);
 
     node.el = this.placeholder;

--- a/src/gridstack-extra.scss
+++ b/src/gridstack-extra.scss
@@ -16,10 +16,10 @@ $gridstack-columns: 11 !default;
       min-width: 100% / $columns;
 
       @for $i from 1 through $columns {
-        &[data-gs-width='#{$i}'] { width: (100% / $columns) * $i; }
-        &[data-gs-x='#{$i}'] { left: (100% / $columns) * $i; }
-        &[data-gs-min-width='#{$i}'] { min-width: (100% / $columns) * $i; }
-        &[data-gs-max-width='#{$i}'] { max-width: (100% / $columns) * $i; }
+        &[gs-w='#{$i}'] { width: (100% / $columns) * $i; }
+        &[gs-x='#{$i}'] { left: (100% / $columns) * $i; }
+        &[gs-min-w='#{$i}'] { min-width: (100% / $columns) * $i; }
+        &[gs-max-w='#{$i}'] { max-width: (100% / $columns) * $i; }
       }
     }
   }

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -99,19 +99,19 @@ $animation_speed: .3s !default;
     }
 
     @for $i from 1 through $gridstack-columns {
-      &[data-gs-width='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
-      &[data-gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
-      &[data-gs-min-width='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
-      &[data-gs-max-width='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
+      &[gs-w='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
+      &[gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
+      &[gs-min-w='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }
+      &[gs-max-w='#{$i}'] { max-width: (100% / $gridstack-columns) * $i; }
     }
   }
 
   &.grid-stack-1>.grid-stack-item {
     min-width: 100%;
-    &[data-gs-width='1'] { width: 100%; }
-    &[data-gs-x='1'] { left: 100%; }
-    &[data-gs-min-width='1'] { min-width: 100%; }
-    &[data-gs-max-width='1'] { max-width: 100%; }
+    &[gs-w='1'] { width: 100%; }
+    &[gs-x='1'] { left: 100%; }
+    &[gs-min-w='1'] { min-width: 100%; }
+    &[gs-max-w='1'] { max-width: 100%; }
   }
 
   &.grid-stack-animate,

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -7,7 +7,7 @@
 */
 
 import { GridStackEngine } from './gridstack-engine';
-import { obsoleteOpts, obsoleteOptsDel, obsoleteAttr, Utils, HeightData } from './utils';
+import { obsoleteOpts, obsoleteAttr, Utils, HeightData } from './utils';
 import { GridStackElement, GridItemHTMLElement, GridStackWidget, GridStackNode, GridStackOptions, numberOrString, ColumnOptions } from './types';
 import { GridStackDDI } from './gridstack-ddi';
 
@@ -149,20 +149,20 @@ export class GridStack {
 
     obsoleteOpts(opts, 'verticalMargin', 'margin', 'v2.0');
 
-    obsoleteAttr(this.el, 'data-gs-current-height', 'data-gs-current-row', 'v1.0.0');
+    obsoleteAttr(this.el, 'data-gs-current-height', 'gs-current-row', 'v1.0.0');
 
     // if row property exists, replace minRow and maxRow instead
     if (opts.row) {
       opts.minRow = opts.maxRow = opts.row;
       delete opts.row;
     }
-    let rowAttr = Utils.toNumber(el.getAttribute('data-gs-row'));
+    let rowAttr = Utils.toNumber(el.getAttribute('gs-row'));
 
     // elements attributes override any passed options (like CSS style) - merge the two together
     let defaults: GridStackOptions = {
-      column: Utils.toNumber(el.getAttribute('data-gs-column')) || 12,
-      minRow: rowAttr ? rowAttr : Utils.toNumber(el.getAttribute('data-gs-min-row')) || 0,
-      maxRow: rowAttr ? rowAttr : Utils.toNumber(el.getAttribute('data-gs-max-row')) || 0,
+      column: Utils.toNumber(el.getAttribute('gs-column')) || 12,
+      minRow: rowAttr ? rowAttr : Utils.toNumber(el.getAttribute('gs-min-row')) || 0,
+      maxRow: rowAttr ? rowAttr : Utils.toNumber(el.getAttribute('gs-max-row')) || 0,
       itemClass: 'grid-stack-item',
       placeholderClass: 'grid-stack-placeholder',
       placeholderText: '',
@@ -174,7 +174,7 @@ export class GridStack {
       auto: true,
       minWidth: 768,
       float: false,
-      staticGrid: Utils.toBool(el.getAttribute('data-gs-static-grid')) || false,
+      staticGrid: Utils.toBool(el.getAttribute('gs-static')) || false,
       _class: 'grid-stack-instance-' + (Math.random() * 10000).toFixed(0),
       animate: true,
       alwaysShowResizeHandle: opts.alwaysShowResizeHandle || false,
@@ -207,8 +207,8 @@ export class GridStack {
       disableOneColumnMode: false,
       oneColumnModeDomSort: false
     };
-    if (el.getAttribute('data-gs-animate')) {
-      defaults.animate = Utils.toBool(el.getAttribute('data-gs-animate'))
+    if (el.getAttribute('gs-animate')) {
+      defaults.animate = Utils.toBool(el.getAttribute('gs-animate'))
     }
 
     this.opts = Utils.defaults(opts, defaults);
@@ -260,8 +260,8 @@ export class GridStack {
     if (this.opts.auto) {
       let elements: {el: HTMLElement; i: number}[] = [];
       this.getGridItems().forEach(el => {
-        let x = parseInt(el.getAttribute('data-gs-x'));
-        let y = parseInt(el.getAttribute('data-gs-y'));
+        let x = parseInt(el.getAttribute('gs-x'));
+        let y = parseInt(el.getAttribute('gs-y'));
         elements.push({
           el,
           // if x,y are missing (autoPosition) add them to end of list - but keep their respective DOM order
@@ -336,7 +336,7 @@ export class GridStack {
     }
 
     // Tempting to initialize the passed in opt with default and valid values, but this break knockout demos
-    // as the actual value are filled in when _prepareElement() calls el.getAttribute('data-gs-xyz) before adding the node.
+    // as the actual value are filled in when _prepareElement() calls el.getAttribute('gs-xyz) before adding the node.
     // So make sure we load any DOM attributes that are not specified in passed in options (which override)
     let domAttr = this._readAttr(el);
     options = {...(options || {})};  // make a copy before we modify in case caller re-uses it
@@ -448,9 +448,9 @@ export class GridStack {
       return this.opts.cellHeight as number;
     }
     // else get first cell height
-    // or do entire grid and # of rows ? (this.el.getBoundingClientRect().height) / parseInt(this.el.getAttribute('data-gs-current-row'))
+    // or do entire grid and # of rows ? (this.el.getBoundingClientRect().height) / parseInt(this.el.getAttribute('gs-current-row'))
     let el = this.el.querySelector('.' + this.opts.itemClass) as HTMLElement;
-    let height = Utils.toNumber(el.getAttribute('data-gs-height'));
+    let height = Utils.toNumber(el.getAttribute('gs-h'));
     return Math.round(el.offsetHeight / height);
   }
 
@@ -686,7 +686,7 @@ export class GridStack {
     let relativeTop = position.top - containerPos.top;
 
     let columnWidth = (box.width / this.opts.column);
-    let rowHeight = (box.height / parseInt(this.el.getAttribute('data-gs-current-row')));
+    let rowHeight = (box.height / parseInt(this.el.getAttribute('gs-current-row')));
 
     return {x: Math.floor(relativeLeft / columnWidth), y: Math.floor(relativeTop / rowHeight)};
   }
@@ -715,7 +715,7 @@ export class GridStack {
    *
    * @example
    * let grid = GridStack.init();
-   * grid.el.appendChild('<div id="gsi-1" data-gs-width="3"></div>');
+   * grid.el.appendChild('<div id="gsi-1" gs-w="3"></div>');
    * grid.makeWidget('#gsi-1');
    */
   public makeWidget(els: GridStackElement): GridItemHTMLElement {
@@ -1097,10 +1097,10 @@ export class GridStack {
       let getHeight = (rows: number): string => (cellHeight * rows) + cellHeightUnit;
       for (let i = this._styles._max + 1; i <= maxHeight; i++) { // start at 1
         let height: string = getHeight(i);
-        Utils.addCSSRule(this._styles, `${prefix}[data-gs-y="${i-1}"]`,        `top: ${getHeight(i-1)}`); // start at 0
-        Utils.addCSSRule(this._styles, `${prefix}[data-gs-height="${i}"]`,     `height: ${height}`);
-        Utils.addCSSRule(this._styles, `${prefix}[data-gs-min-height="${i}"]`, `min-height: ${height}`);
-        Utils.addCSSRule(this._styles, `${prefix}[data-gs-max-height="${i}"]`, `max-height: ${height}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-y="${i-1}"]`,        `top: ${getHeight(i-1)}`); // start at 0
+        Utils.addCSSRule(this._styles, `${prefix}[gs-h="${i}"]`,     `height: ${height}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-min-h="${i}"]`, `min-height: ${height}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-max-h="${i}"]`, `max-height: ${height}`);
       }
       this._styles._max = maxHeight;
     }
@@ -1119,7 +1119,7 @@ export class GridStack {
         row = minRow;
       }
     }
-    this.el.setAttribute('data-gs-current-row', String(row));
+    this.el.setAttribute('gs-current-row', String(row));
     if (row === 0) {
       this.el.style.removeProperty('height');
       return this;
@@ -1162,10 +1162,10 @@ export class GridStack {
 
   /** @internal call to write x,y,w,h attributes back to element */
   private _writeAttrs(el: HTMLElement, x?: number, y?: number, width?: number, height?: number): GridStack {
-    if (x !== undefined && x !== null) { el.setAttribute('data-gs-x', String(x)); }
-    if (y !== undefined && y !== null) { el.setAttribute('data-gs-y', String(y)); }
-    if (width) { el.setAttribute('data-gs-width', String(width)); }
-    if (height) { el.setAttribute('data-gs-height', String(height)); }
+    if (x !== undefined && x !== null) { el.setAttribute('gs-x', String(x)); }
+    if (y !== undefined && y !== null) { el.setAttribute('gs-y', String(y)); }
+    if (width) { el.setAttribute('gs-w', String(width)); }
+    if (height) { el.setAttribute('gs-h', String(height)); }
     return this;
   }
 
@@ -1175,16 +1175,16 @@ export class GridStack {
     this._writeAttrs(el, node.x, node.y, node.width, node.height);
 
     let attrs /*: GridStackWidget*/ = { // remaining attributes
-      autoPosition: 'data-gs-auto-position',
-      minWidth: 'data-gs-min-width',
-      minHeight: 'data-gs-min-height',
-      maxWidth: 'data-gs-max-width',
-      maxHeight: 'data-gs-max-height',
-      noResize: 'data-gs-no-resize',
-      noMove: 'data-gs-no-move',
-      locked: 'data-gs-locked',
-      id: 'data-gs-id',
-      resizeHandles: 'data-gs-resize-handles'
+      autoPosition: 'gs-auto-position',
+      minWidth: 'gs-min-w',
+      minHeight: 'gs-min-h',
+      maxWidth: 'gs-max-w',
+      maxHeight: 'gs-max-h',
+      noResize: 'gs-no-resize',
+      noMove: 'gs-no-move',
+      locked: 'gs-locked',
+      id: 'gs-id',
+      resizeHandles: 'gs-resize-handles'
     };
     for (const key in attrs) {
       if (node[key]) { // 0 is valid for x,y only but done above already and not in list
@@ -1198,20 +1198,20 @@ export class GridStack {
 
   /** @internal call to read any default attributes from element */
   private _readAttr(el: HTMLElement, node: GridStackNode = {}): GridStackWidget {
-    node.x = Utils.toNumber(el.getAttribute('data-gs-x'));
-    node.y = Utils.toNumber(el.getAttribute('data-gs-y'));
-    node.width = Utils.toNumber(el.getAttribute('data-gs-width'));
-    node.height = Utils.toNumber(el.getAttribute('data-gs-height'));
-    node.maxWidth = Utils.toNumber(el.getAttribute('data-gs-max-width'));
-    node.minWidth = Utils.toNumber(el.getAttribute('data-gs-min-width'));
-    node.maxHeight = Utils.toNumber(el.getAttribute('data-gs-max-height'));
-    node.minHeight = Utils.toNumber(el.getAttribute('data-gs-min-height'));
-    node.autoPosition = Utils.toBool(el.getAttribute('data-gs-auto-position'));
-    node.noResize = Utils.toBool(el.getAttribute('data-gs-no-resize'));
-    node.noMove = Utils.toBool(el.getAttribute('data-gs-no-move'));
-    node.locked = Utils.toBool(el.getAttribute('data-gs-locked'));
-    node.resizeHandles = el.getAttribute('data-gs-resize-handles');
-    node.id = el.getAttribute('data-gs-id');
+    node.x = Utils.toNumber(el.getAttribute('gs-x'));
+    node.y = Utils.toNumber(el.getAttribute('gs-y'));
+    node.width = Utils.toNumber(el.getAttribute('gs-w'));
+    node.height = Utils.toNumber(el.getAttribute('gs-h'));
+    node.maxWidth = Utils.toNumber(el.getAttribute('gs-max-w'));
+    node.minWidth = Utils.toNumber(el.getAttribute('gs-min-w'));
+    node.maxHeight = Utils.toNumber(el.getAttribute('gs-max-h'));
+    node.minHeight = Utils.toNumber(el.getAttribute('gs-min-h'));
+    node.autoPosition = Utils.toBool(el.getAttribute('gs-auto-position'));
+    node.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
+    node.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
+    node.locked = Utils.toBool(el.getAttribute('gs-locked'));
+    node.resizeHandles = el.getAttribute('gs-resize-handles');
+    node.id = el.getAttribute('gs-id');
 
     // remove any key not found (null or false which is default)
     for (const key in node) {
@@ -1230,10 +1230,10 @@ export class GridStack {
 
     if (this.opts.staticGrid) {
       this.el.classList.add(...classes);
-      this.el.setAttribute('data-gs-static-grid', 'true');
+      this.el.setAttribute('gs-static', 'true');
     } else {
       this.el.classList.remove(...classes);
-      this.el.removeAttribute('data-gs-static-grid');
+      this.el.removeAttribute('gs-static');
 
     }
     return this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export interface GridStackWidget {
   locked?: boolean;
   /** widgets can have their own resize handles. For example 'e,w' will make the particular widget only resize east and west. */
   resizeHandles?: string;
-  /** value for `data-gs-id` stored on the widget (default?: undefined) */
+  /** value for `gs-id` stored on the widget (default?: undefined) */
   id?: numberOrString;
   /** html to append inside as content */
   content?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,14 +119,14 @@ export class Utils {
 
   /**
    * creates a style sheet with style id under given parent
-   * @param id will set the 'data-gs-style-id' attribute to that id
+   * @param id will set the 'gs-style-id' attribute to that id
    * @param parent to insert the stylesheet as first child,
    * if none supplied it will be appended to the document head instead.
    */
   static createStylesheet(id: string, parent?: HTMLElement): CSSStyleSheet {
     let style: HTMLStyleElement = document.createElement('style');
     style.setAttribute('type', 'text/css');
-    style.setAttribute('data-gs-style-id', id);
+    style.setAttribute('gs-style-id', id);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((style as any).styleSheet) { // TODO: only CSSImportRule have that and different beast ??
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -146,7 +146,7 @@ export class Utils {
 
   /** removed the given stylesheet id */
   static removeStylesheet(id: string): void {
-    let el = document.querySelector('STYLE[data-gs-style-id=' + id + ']');
+    let el = document.querySelector('STYLE[gs-style-id=' + id + ']');
     if (!el || !el.parentNode) return;
     el.parentNode.removeChild(el);
   }


### PR DESCRIPTION
### Description
* removed 'data-' from all attributes (legacy JS style) and shorten width/height to w/h
* make for smaller and more efficient code and CSS.
Easy enough to global replace in your code.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
