### PR TITLE
GridStackWidget use w,h,minW,minH

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ creating items dynamically...
 
 // ...in your script
 var grid = GridStack.init();
-grid.addWidget({width: 2, content: 'item 1'});
+grid.addWidget({w: 2, content: 'item 1'});
 ```
 
 ... or creating from list
@@ -100,8 +100,8 @@ grid.addWidget({width: 2, content: 'item 1'});
 ```js
 // using serialize data instead of .addWidget()
 const serializedData = [
-  {x: 0, y: 0, width: 2, height: 2},
-  {x: 2, y: 3, width: 3, content: 'item 2'},
+  {x: 0, y: 0, w: 2, h: 2},
+  {x: 2, y: 3, w: 3, content: 'item 2'},
   {x: 1, y: 3}
 ];
 
@@ -315,7 +315,7 @@ var grid = $('.grid-stack').data('gridstack');
 var grid = GridStack.init(opts?, element?);
 
 // returns DOM element
-grid.addWidget('<div><div class="grid-stack-item-content"> test </div></div>', {width: 2});
+grid.addWidget('<div><div class="grid-stack-item-content"> test </div></div>', {w: 2});
 
 // event handler
 grid.on('added', function(e, items) {/* items contains info */});
@@ -362,7 +362,7 @@ v2 is a Typescript rewrite of 1.x, removing all jquery events, using classes and
 
 make sure to read v2 migration first!
 
-v3 has a new HTML5 drag&drop plugging (65k total, all native code), while still allowing you to use the legacy jquery-ui version (188k), or a new static grid version (35k, no user drag&drop but full API support). You will need to decide which version to use as `gridstack.all.js` no longer exist (same as `gridstack-jq.js`) - see include info at top.
+v3 has a new HTML5 drag&drop plugging (63k total, all native code), while still allowing you to use the legacy jquery-ui version (186k), or a new static grid version (34k, no user drag&drop but full API support). You will need to decide which version to use as `gridstack.all.js` no longer exist (same as `gridstack-jq.js`) - see include info at top.
 
 Some breaking changes:
 
@@ -371,6 +371,8 @@ Some breaking changes:
 2. `GridStack.update(el, opt)` now takes `GridStackWidget` options instead, BUT legacy call in JS will continue working the same for now
 
 3. item attribute like `data-gs-min-width` is now `gs-min-w`. We removed 'data-' from all attributes, and shorten 'width|height' to just 'w|h' to require typing and more efficient.
+
+4. `GridStackWidget` used in most API `width|height|minWidth|minHeight|maxWidth|maxHeight` are now shorter `w|h|minW|minH|maxW|maxH` as well
 
 # jQuery Application
 

--- a/demo/advance.html
+++ b/demo/advance.html
@@ -71,17 +71,17 @@
     });
 
     let items = [
-      {x: 0, y: 0, width: 4, height: 2, content: '1'},
-      {x: 4, y: 0, width: 4, height: 4, noMove: true, noResize: true, locked: true, content: 'I can\'t be moved or dragged!<br><ion-icon name="ios-lock" style="font-size:300%"></ion-icon>'},
-      {x: 8, y: 0, width: 2, height: 2, minWidth: 2, noResize: true, content: '<p class="card-text text-center" style="margin-bottom: 0">Drag me!<p class="card-text text-center"style="margin-bottom: 0"><ion-icon name="hand" style="font-size: 300%"></ion-icon><p class="card-text text-center" style="margin-bottom: 0">...but don\'t resize me!'},
-      {x: 10, y: 0, width: 2, height: 2, content: '4'},
-      {x: 0, y: 2, width: 2, height: 2, content: '5'},
-      {x: 2, y: 2, width: 2, height: 4, content: '6'},
-      {x: 8, y: 2, width: 4, height: 2, content: '7'},
-      {x: 0, y: 4, width: 2, height: 2, content: '8'},
-      {x: 4, y: 4, width: 4, height: 2, content: '9'},
-      {x: 8, y: 4, width: 2, height: 2, content: '10'},
-      {x: 10, y: 4, width: 2, height: 2, content: '11'},
+      {x: 0, y: 0, w: 4, h: 2, content: '1'},
+      {x: 4, y: 0, w: 4, h: 4, noMove: true, noResize: true, locked: true, content: 'I can\'t be moved or dragged!<br><ion-icon name="ios-lock" style="font-size:300%"></ion-icon>'},
+      {x: 8, y: 0, w: 2, h: 2, minW: 2, noResize: true, content: '<p class="card-text text-center" style="margin-bottom: 0">Drag me!<p class="card-text text-center"style="margin-bottom: 0"><ion-icon name="hand" style="font-size: 300%"></ion-icon><p class="card-text text-center" style="margin-bottom: 0">...but don\'t resize me!'},
+      {x: 10, y: 0, w: 2, h: 2, content: '4'},
+      {x: 0, y: 2, w: 2, h: 2, content: '5'},
+      {x: 2, y: 2, w: 2, h: 4, content: '6'},
+      {x: 8, y: 2, w: 4, h: 2, content: '7'},
+      {x: 0, y: 4, w: 2, h: 2, content: '8'},
+      {x: 4, y: 4, w: 4, h: 2, content: '9'},
+      {x: 8, y: 4, w: 2, h: 2, content: '10'},
+      {x: 10, y: 4, w: 2, h: 2, content: '11'},
     ];
     grid.load(items);
     

--- a/demo/anijs.html
+++ b/demo/anijs.html
@@ -38,7 +38,7 @@
     });
 
     function addWidget() {
-      grid.addWidget({width: Math.floor(1 + 3 * Math.random()), height: Math.floor(1 + 3 * Math.random())});
+      grid.addWidget({w: Math.floor(1 + 3 * Math.random()), h: Math.floor(1 + 3 * Math.random())});
     };
 
     let animationHelper = AniJS.getHelper();

--- a/demo/column.html
+++ b/demo/column.html
@@ -53,19 +53,19 @@
 
     let items = [
       /* match karma testing
-      {x: 0, y: 0, width: 4, height: 2},
-      {x: 4, y: 0, width: 4, height: 4},
+      {x: 0, y: 0, w: 4, h: 2},
+      {x: 4, y: 0, w: 4, h: 4},
       {text: ' auto'},
       */
-      {x: 0, y: 0, width: 2, height: 2},
-      {x: 2, y: 0, width: 2, height: 1},
-      {x: 5, y: 1, width: 1, height: 1},
-      {x: 5, y: 0, width: 2, height: 1},
-      // {x: 0, y: 0, width: 1, height: 1}, // conflict
+      {x: 0, y: 0, w: 2, h: 2},
+      {x: 2, y: 0, w: 2},
+      {x: 5, y: 1},
+      {x: 5, y: 0, w: 2},
+      // {x: 0, y: 0}, // conflict
       {text: ' auto'}, // autoPosition testing
-      // {x: 4, y: 0, width: 1, height: 1}, // same auto-pos
-      {x: 5, y: 3, width: 2, height: 1},
-      {x: 0, y: 4, width: 12, height: 1}
+      // {x: 4, y: 0}, // same auto-pos
+      {x: 5, y: 3, w: 2},
+      {x: 0, y: 4, w: 12}
     ];
     let count = 0;
     grid.batchUpdate();
@@ -76,8 +76,8 @@
       let n = items[count] || {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
-        width: Math.round(1 + 3 * Math.random()),
-        height: Math.round(1 + 3 * Math.random())
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
       };
       n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
       grid.addWidget(n);

--- a/demo/events.js
+++ b/demo/events.js
@@ -3,7 +3,7 @@ function addEvents(grid, id) {
 
   grid.on('added removed change', function(event, items) {
     let str = '';
-    items.forEach(function(item) { str += ' (' + item.x + ',' + item.y + ' ' + item.width + 'x' + item.height + ')'; });
+    items.forEach(function(item) { str += ' (' + item.x + ',' + item.y + ' ' + item.w + 'x' + item.h + ')'; });
     console.log(g + event.type + ' ' + items.length + ' items (x,y w h):' + str );
   });
 

--- a/demo/float.html
+++ b/demo/float.html
@@ -26,11 +26,11 @@
     addEvents(grid);
 
     let items = [
-      {x: 1, y: 1, width: 1, height: 1},
-      {x: 2, y: 2, width: 3, height: 1},
-      {x: 4, y: 2, width: 1, height: 1},
-      {x: 3, y: 1, width: 1, height: 2},
-      {x: 0, y: 6, width: 2, height: 2}
+      {x: 1, y: 1},
+      {x: 2, y: 2, w: 3},
+      {x: 4, y: 2},
+      {x: 3, y: 1, h: 2},
+      {x: 0, y: 6, w: 2, h: 2}
     ];
     let count = 0;
 
@@ -38,8 +38,8 @@
       let n = items[count] || {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
-        width: Math.round(1 + 3 * Math.random()),
-        height: Math.round(1 + 3 * Math.random())
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
       };
       n.content = String(count++);
       grid.addWidget(n);

--- a/demo/knockout.html
+++ b/demo/knockout.html
@@ -49,7 +49,7 @@
       template:
         [
           '<div class="grid-stack" data-bind="foreach: {data: widgets, afterRender: afterAddWidget}">',
-          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.width, \'gs-h\': $data.height, \'gs-auto-position\': $data.auto_position, \'gs-id\': $data.id}">',
+          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.w, \'gs-h\': $data.h, \'gs-auto-position\': $data.auto_position, \'gs-id\': $data.id}">',
           '     <div class="grid-stack-item-content"><button data-bind="click: $root.deleteWidget">Delete me</button></div>',
           '   </div>',
           '</div> '
@@ -65,8 +65,8 @@
         this.widgets.push({
           x: 0,
           y: 0,
-          width: Math.floor(1 + 3 * Math.random()),
-          height: Math.floor(1 + 3 * Math.random()),
+          w: Math.floor(1 + 3 * Math.random()),
+          h: Math.floor(1 + 3 * Math.random()),
           auto_position: true
         });
         return false;
@@ -79,10 +79,10 @@
     };
 
     let widgets = [
-      {x: 0, y: 0, width: 2, height: 2, id: '0'},
-      {x: 2, y: 0, width: 4, height: 2, id: '1'},
-      {x: 6, y: 0, width: 2, height: 4, id: '2'},
-      {x: 1, y: 2, width: 4, height: 2, id: '3'}
+      {x: 0, y: 0, w: 2, h: 2, id: '0'},
+      {x: 2, y: 0, w: 4, h: 2, id: '1'},
+      {x: 6, y: 0, w: 2, h: 4, id: '2'},
+      {x: 1, y: 2, w: 4, h: 2, id: '3'}
     ];
 
     let controller = new Controller(widgets);

--- a/demo/locked.html
+++ b/demo/locked.html
@@ -31,11 +31,11 @@
     });
 
     let items = [
-      {x: 0, y: 1, width: 12, height: 1, locked: 'yes', noMove: true, noResize: true, text: 'locked, noResize, noMove'},
-      {x: 1, y: 0, width: 2, height: 3},
-      {x: 4, y: 2, width: 1, height: 1},
-      {x: 3, y: 1, width: 1, height: 2},
-      {x: 0, y: 6, width: 2, height: 2}
+      {x: 0, y: 1, w: 12, locked: 'yes', noMove: true, noResize: true, text: 'locked, noResize, noMove'},
+      {x: 1, y: 0, w: 2, h: 3},
+      {x: 4, y: 2},
+      {x: 3, y: 1, h: 2},
+      {x: 0, y: 6, w: 2, h: 2}
     ];
     let count = 0;
 
@@ -43,8 +43,8 @@
       let n = items[count] || {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
-        width: Math.round(1 + 3 * Math.random()),
-        height: Math.round(1 + 3 * Math.random())
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
       };
       n.content = n.text ? n.text : String(count);
       grid.addWidget(n);

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -70,8 +70,8 @@
       let node = {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
-        width: Math.round(1 + 3 * Math.random()),
-        height: Math.round(1 + 3 * Math.random())
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
       };
       // Note: we have additional style .sub here so add the HTML passed directly...
       grid.addWidget('<div class="grid-stack-item sub"><div class="grid-stack-item-content">' + count++ + '</div></div>', node);

--- a/demo/react.html
+++ b/demo/react.html
@@ -23,11 +23,11 @@
         count: 0,
         info: "",
         items: [
-          { x: 2, y: 1, height: 2 },
-          { x: 2, y: 4, width: 3 },
-          { x: 4, y: 2, width: 1 },
-          { x: 3, y: 1, height: 2 },
-          { x: 0, y: 6, width: 2, height: 2 },
+          { x: 2, y: 1, h: 2 },
+          { x: 2, y: 4, w: 3 },
+          { x: 4, y: 2 },
+          { x: 3, y: 1, h: 2 },
+          { x: 0, y: 6, w: 2, h: 2 },
         ],
       };
 
@@ -60,8 +60,8 @@
         const node = this.state.items[this.state.count] || {
           x: Math.round(12 * Math.random()),
           y: Math.round(5 * Math.random()),
-          width: Math.round(1 + 3 * Math.random()),
-          height: Math.round(1 + 3 * Math.random()),
+          w: Math.round(1 + 3 * Math.random()),
+          h: Math.round(1 + 3 * Math.random()),
         };
         node.id = node.content = String(this.state.count);
         this.setState((prevState) => ({

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -55,12 +55,12 @@
     };
     
     let items = [
-      {x: 0, y: 0, width: 2, height: 2, content: '0'},
-      {x: 2, y: 0, width: 2, content: '1'},
+      {x: 0, y: 0, w: 2, h: 2, content: '0'},
+      {x: 2, y: 0, w: 2, content: '1'},
       {x: 5, y: 0, content: '2'},
-      {x: 1, y: 3, width: 4, content: '3'},
-      {x: 5, y: 2, width: 2, content: '4'},
-      {x: 0, y: 4, width: 12, content: '5'}
+      {x: 1, y: 3, w: 4, content: '3'},
+      {x: 5, y: 2, w: 2, content: '4'},
+      {x: 0, y: 4, w: 12, content: '5'}
     ];
     grid.load(items);
     resizeGrid();

--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -54,7 +54,7 @@
       template:
         [
           '<div class="grid-stack" data-bind="foreach: {data: widgets, afterRender: afterAddWidget}">',
-          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.width, \'gs-h\': $data.height, \'gs-auto-position\': $data.auto_position}">',
+          '   <div class="grid-stack-item" data-bind="attr: {\'gs-x\': $data.x, \'gs-y\': $data.y, \'gs-w\': $data.w, \'gs-h\': $data.h, \'gs-auto-position\': $data.auto_position}">',
           '     <div class="grid-stack-item-content"><center><button data-bind="click: $root.deleteWidget">Delete me</button><br><h5 data-bind="text: index" /></center><br><p>lorem ipsum</p></div>',
           '   </div>',
           '</div> '
@@ -70,8 +70,8 @@
         this.widgets.push({
           x: 0,
           y: 0,
-          width: Math.floor(1 + 3 * Math.random()),
-          height: Math.floor(1 + 3 * Math.random()),
+          w: Math.floor(1 + 3 * Math.random()),
+          h: Math.floor(1 + 3 * Math.random()),
           auto_position: true,
           index: 'auto'
         });
@@ -85,10 +85,10 @@
     };
 
     let widgets = [
-      {x: 0, y: 0, width: 2, height: 2, index: 1},
-      {x: 2, y: 0, width: 4, height: 2, index: 2},
-      {x: 6, y: 0, width: 2, height: 4, index: 3},
-      {x: 1, y: 2, width: 4, height: 2, index: 4}
+      {x: 0, y: 0, w: 2, h: 2, index: 1},
+      {x: 2, y: 0, w: 4, h: 2, index: 2},
+      {x: 6, y: 0, w: 2, h: 4, index: 3},
+      {x: 1, y: 2, w: 4, h: 2, index: 4}
     ];
 
     let controller = new Controller(widgets);

--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -33,11 +33,11 @@
     });
 
     let serializedData = [
-      {x: 0, y: 0, width: 2, height: 2, id: '0'},
-      {x: 3, y: 1, width: 1, height: 2, id: '1', content: "<button onclick=\"alert('clicked!')\">Press me</button>"},
-      {x: 4, y: 1, width: 1, height: 1, id: '2'},
-      {x: 2, y: 3, width: 3, height: 1, id: '3'},
-      {x: 1, y: 3, width: 1, height: 1, id: '4'}
+      {x: 0, y: 0, w: 2, h: 2, id: '0'},
+      {x: 3, y: 1, h: 2, id: '1', content: "<button onclick=\"alert('clicked!')\">Press me</button>"},
+      {x: 4, y: 1, id: '2'},
+      {x: 2, y: 3, w: 3, id: '3'},
+      {x: 1, y: 3, id: '4'}
     ];
     serializedData.forEach((n, i) =>
       n.content = `<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br> ${i}<br> ${n.content ? n.content : ''}`);
@@ -67,7 +67,7 @@
         // else update existing nodes (instead of calling grid.removeAll())
         grid.engine.nodes.forEach(function (node) {
           let item = items.find(function(e) { return e.id === node.id});
-          grid.move(node.el, item.x, item.y, item.width, item.height);
+          grid.move(node.el, item.x, item.y, item.w, item.h);
         });
       }
 
@@ -81,8 +81,8 @@
         serializedData.push({
           x: node.x,
           y: node.y,
-          width: node.width,
-          height: node.height,
+          w: node.w,
+          h: node.h,
           id: node.id,
           custom: 'save anything here'
         });

--- a/demo/static.html
+++ b/demo/static.html
@@ -31,11 +31,11 @@
     addEvents(grid);
 
     let serializedData = [
-      {x: 0, y: 0, width: 2, height: 2, id: '0'},
-      {x: 3, y: 1, width: 1, height: 2, id: 'no_move', noMove: true, content: 'no move'},
-      {x: 4, y: 1, width: 1, height: 1, id: '2'},
-      {x: 2, y: 3, width: 3, height: 1, id: 'no_resize', noResize: true, content: 'no resize'},
-      {x: 1, y: 3, width: 1, height: 1, id: 'locked', locked: true, content: 'locked'}
+      {x: 0, y: 0, w: 2, h: 2, id: '0'},
+      {x: 3, y: 1, h: 2, id: 'no_move', noMove: true, content: 'no move'},
+      {x: 4, y: 1, id: '2'},
+      {x: 2, y: 3, w: 3, id: 'no_resize', noResize: true, content: 'no resize'},
+      {x: 1, y: 3, id: 'locked', locked: true, content: 'locked'}
     ];
     grid.load(serializedData, true);
 

--- a/demo/two-jq.html
+++ b/demo/two-jq.html
@@ -99,11 +99,11 @@
     grids[1].float(true);
 
     let items = [
-      {x: 0, y: 0, width: 2, height: 2},
-      {x: 3, y: 1, width: 1, height: 2},
-      {x: 4, y: 1, width: 1},
-      {x: 2, y: 3, width: 3, maxWidth: 3, id: 'special', content: 'has maxWidth=3'},
-      {x: 2, y: 5, width: 1}
+      {x: 0, y: 0, w: 2, h: 2},
+      {x: 3, y: 1, h: 2},
+      {x: 4, y: 1},
+      {x: 2, y: 3, w: 3, maxW: 3, id: 'special', content: 'has maxW=3'},
+      {x: 2, y: 5}
     ];
 
     grids.forEach(function (grid, i) {

--- a/demo/two.html
+++ b/demo/two.html
@@ -99,11 +99,11 @@
     grids[1].float(true);
 
     let items = [
-      {x: 0, y: 0, width: 2, height: 2},
-      {x: 3, y: 1, width: 1, height: 2},
-      {x: 4, y: 1, width: 1},
-      {x: 2, y: 3, width: 3, maxWidth: 3, id: 'special', content: 'has maxWidth=3'},
-      {x: 2, y: 5, width: 1}
+    {x: 0, y: 0, w: 2, h: 2},
+      {x: 3, y: 1, h: 2},
+      {x: 4, y: 1},
+      {x: 2, y: 3, w: 3, maxW: 3, id: 'special', content: 'has maxW=3'},
+      {x: 2, y: 5}
     ];
 
     grids.forEach(function (grid, i) {

--- a/demo/vue2js.html
+++ b/demo/vue2js.html
@@ -41,11 +41,11 @@
           timerId: undefined,
         },
         items: [
-          { x: 2, y: 1, height: 2 },
-          { x: 2, y: 4, width: 3},
-          { x: 4, y: 2, width: 1},
-          { x: 3, y: 1, height: 2 },
-          { x: 0, y: 6, width: 2, height: 2 }
+          { x: 2, y: 1, h: 2 },
+          { x: 2, y: 4, w: 3},
+          { x: 4, y: 2},
+          { x: 3, y: 1, h: 2 },
+          { x: 0, y: 6, w: 2, h: 2 }
         ],
         watch: {
           /**
@@ -76,8 +76,8 @@
             const node = this.$options.items[this.count] || {
               x: Math.round(12 * Math.random()),
               y: Math.round(5 * Math.random()),
-              width: Math.round(1 + 3 * Math.random()),
-              height: Math.round(1 + 3 * Math.random()),
+              w: Math.round(1 + 3 * Math.random()),
+              h: Math.round(1 + 3 * Math.random()),
             };
             node.id = node.content = String(this.count++);
             this.grid.addWidget(node);

--- a/demo/vue3js.html
+++ b/demo/vue3js.html
@@ -39,11 +39,11 @@
           };
         },
         items: [
-          { x: 2, y: 1, height: 2 },
-          { x: 2, y: 4, width: 3},
-          { x: 4, y: 2, width: 1},
-          { x: 3, y: 1, height: 2 },
-          { x: 0, y: 6, width: 2, height: 2 }
+          { x: 2, y: 1, h: 2 },
+          { x: 2, y: 4, w: 3},
+          { x: 4, y: 2},
+          { x: 3, y: 1, h: 2 },
+          { x: 0, y: 6, w: 2, h: 2 }
         ],
         watch: {
           /**
@@ -74,8 +74,8 @@
             const node = this.$options.items[this.count] || {
               x: Math.round(12 * Math.random()),
               y: Math.round(5 * Math.random()),
-              width: Math.round(1 + 3 * Math.random()),
-              height: Math.round(1 + 3 * Math.random()),
+              w: Math.round(1 + 3 * Math.random()),
+              h: Math.round(1 + 3 * Math.random()),
             };
             node.id = node.content = String(this.count++);
             this.grid.addWidget(node);

--- a/doc/README.md
+++ b/doc/README.md
@@ -76,7 +76,7 @@ gridstack.js API
   * `'auto'` - height will be square cells initially.
 - `column` - number of columns (default: `12`) which can change on the fly with `column(N)` as well. See [example](http://gridstackjs.com/demo/column.html)
 - `disableDrag` - disallows dragging of widgets (default: `false`).
-- `disableOneColumnMode` - disables the onColumnMode when the grid width is less than minWidth (default: 'false')
+- `disableOneColumnMode` - disables the onColumnMode when the grid width is less than minW (default: 'false')
 - `disableResize` - disallows resizing of widgets (default: `false`).
 - `dragIn` - specify the class of items that can be dragged into the grid (ex: dragIn: '.newWidget'
 - `dragInOptions` - options for items that can be dragged into the grid (ex: dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }
@@ -95,7 +95,7 @@ gridstack.js API
 - `marginLeft`: numberOrString
 - `maxRow` - maximum rows amount. Default is `0` which means no max.
 - `minRow` - minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`. You can also do this with `min-height` CSS attribute on the grid div in pixels, which will round to the closest row.
-- `minWidth` - minimal width. If grid width is less than or equal to, grid will be shown in one-column mode (default: `768`)
+- `minW` - minimal width. If grid width is less than or equal to, grid will be shown in one-column mode (default: `768`)
 - `oneColumnModeDomSort` - set to `true` if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: `false`)
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)
 - `placeholderText` - placeholder default content (default: `''`)
@@ -116,12 +116,12 @@ Extras:
 
 ## Item Options
 
-options you can pass when calling `addWidget()`
+options you can pass when calling `addWidget()`, `update()`, `load()` and many others
 
 - `autoPosition` - tells to ignore `x` and `y` attributes and to place element to the first available position. Having either one missing will also do that.
 - `x`, `y` - (number) element position in column/row. Note: if one is missing this will `autoPosition` the item
-- `width`, `height` - (number) element size in column/row (default 1x1)
-- `maxWidth`, `minWidth`, `maxHeight`, `minHeight` - element constraints in column/row (default none)
+- `w`, `h` - (number) element size in column/row (default 1x1)
+- `maxW`, `minW`, `maxH`, `minH` - element constraints in column/row (default none)
 - `locked` - means another widget wouldn't be able to move it during dragging or resizing.
 The widget can still be dragged or resized by the user.
 You need to add `noResize` and `noMove` attributes to completely lock the widget.
@@ -260,9 +260,9 @@ before calling `addWidget` for additional check.
 
 ```js
 let grid = GridStack.init();
-grid.addWidget({width: 3, content: 'hello'});
+grid.addWidget({w: 3, content: 'hello'});
 // or
-grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">hello</div></div>', {width: 3});
+grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">hello</div></div>', {w: 3});
 ```
 
 ### batchUpdate()
@@ -478,7 +478,7 @@ Returns `true` if the `height` of the grid will be less the vertical constraint.
 have `height` constraint.
 
 ```js
-if (grid.willItFit(newNode.x, newNode.y, newNode.width, newNode.height, newNode.autoPosition)) {
+if (grid.willItFit(newNode.x, newNode.y, newNode.w, newNode.h, newNode.autoPosition)) {
   grid.addWidget(newNode.el, newNode);
 }
 else {

--- a/spec/e2e/html/1155-max-row.html
+++ b/spec/e2e/html/1155-max-row.html
@@ -18,8 +18,8 @@
   <script type="text/javascript">
     let grid = GridStack.init({float: true, maxRow: 3});
     let items = [
-      {x: 0, y: 1, width: 1, height: 2, content: '0'},
-      {x: 1, y: 3, width: 2, height: 1, content: 'Y=3 out of bound should align'}
+      {x: 0, y: 1, h: 2, content: '0'},
+      {x: 1, y: 3, w: 2,  content: 'Y=3 out of bound should align'}
     ];
     grid.load(items);
   </script>

--- a/spec/e2e/html/1471-load-column1.html
+++ b/spec/e2e/html/1471-load-column1.html
@@ -27,11 +27,11 @@
     addEvents(grid);
 
     let items = [
-      {x: 1, y: 0, width: 2, height: 1, content: '0'},
-      {x: 3, y: 1, width: 1, height: 2, content: '1'},
-      {x: 4, y: 1, width: 1, height: 1, content: '2'},
-      {x: 2, y: 3, width: 3, height: 1, content: '3'},
-      {x: 0, y: 6, width: 2, height: 2, content: '4'}
+      {x: 1, y: 0, w: 2, content: '0'},
+      {x: 3, y: 1, h: 2, content: '1'},
+      {x: 4, y: 1, content: '2'},
+      {x: 2, y: 3, w: 3,content: '3'},
+      {x: 0, y: 6, w: 2, h: 2, content: '4'}
     ];
     grid.load(items);
 
@@ -39,8 +39,8 @@
       let n = items[count] || {
         x: Math.round(12 * Math.random()),
         y: Math.round(5 * Math.random()),
-        width: Math.round(1 + 3 * Math.random()),
-        height: Math.round(1 + 3 * Math.random())
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
       };
       n.content = String(count++);
       grid.addWidget(n);

--- a/spec/gridstack-engine-spec.ts
+++ b/spec/gridstack-engine-spec.ts
@@ -57,20 +57,20 @@ describe('gridstack engine', function() {
       engine = new GridStackEngine(12);
     });
     it('should prepare a node', function() {
-      expect(engine.prepareNode({}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({x: 10}, false)).toEqual(jasmine.objectContaining({x: 10, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({x: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({y: 10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 10, width: 1, height: 1}));
-      expect(engine.prepareNode({y: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({width: 3}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 3, height: 1}));
-      expect(engine.prepareNode({width: 100}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 12, height: 1}));
-      expect(engine.prepareNode({width: 0}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({width: -190}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({height: 3}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 3}));
-      expect(engine.prepareNode({height: 0}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({height: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
-      expect(engine.prepareNode({x: 4, width: 10}, false)).toEqual(jasmine.objectContaining({x: 2, y: 0, width: 10, height: 1}));
-      expect(engine.prepareNode({x: 4, width: 10}, true)).toEqual(jasmine.objectContaining({x: 4, y: 0, width: 8, height: 1}));
+      expect(engine.prepareNode({}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({x: 10}, false)).toEqual(jasmine.objectContaining({x: 10, y: 0,  h: 1}));
+      expect(engine.prepareNode({x: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({y: 10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 10,  h: 1}));
+      expect(engine.prepareNode({y: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({w: 3}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, w: 3, h: 1}));
+      expect(engine.prepareNode({w: 100}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0, w: 12, h: 1}));
+      expect(engine.prepareNode({w: 0}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({w: -190}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({h: 3}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 3}));
+      expect(engine.prepareNode({h: 0}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({h: -10}, false)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
+      expect(engine.prepareNode({x: 4, w: 10}, false)).toEqual(jasmine.objectContaining({x: 2, y: 0, w: 10, h: 1}));
+      expect(engine.prepareNode({x: 4, w: 10}, true)).toEqual(jasmine.objectContaining({x: 4, y: 0, w: 8, h: 1}));
     });
   });
 
@@ -106,16 +106,16 @@ describe('gridstack engine', function() {
   
     it('should sort ascending without columns.', function() {
       w.column = undefined;
-      w.nodes = [{x: 7, y: 0, width: 1}, {x: 4, y: 4, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}];
+      w.nodes = [{x: 7, y: 0, w: 1}, {x: 4, y: 4, w: 1}, {x: 9, y: 0, w: 1}, {x: 0, y: 1, w: 1}];
       e.prototype._sortNodes.call(w, 1);
-      expect(w.nodes).toEqual([{x: 7, y: 0, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}, {x: 4, y: 4, width: 1}]);
+      expect(w.nodes).toEqual([{x: 7, y: 0, w: 1}, {x: 9, y: 0, w: 1}, {x: 0, y: 1, w: 1}, {x: 4, y: 4, w: 1}]);
     });
   
     it('should sort descending without columns.', function() {
       w.column = undefined;
-      w.nodes = [{x: 7, y: 0, width: 1}, {x: 4, y: 4, width: 1}, {x: 9, y: 0, width: 1}, {x: 0, y: 1, width: 1}];
+      w.nodes = [{x: 7, y: 0, w: 1}, {x: 4, y: 4, w: 1}, {x: 9, y: 0, w: 1}, {x: 0, y: 1, w: 1}];
       e.prototype._sortNodes.call(w, -1);
-      expect(w.nodes).toEqual([{x: 4, y: 4, width: 1}, {x: 0, y: 1, width: 1}, {x: 9, y: 0, width: 1}, {x: 7, y: 0, width: 1}]);
+      expect(w.nodes).toEqual([{x: 4, y: 4, w: 1}, {x: 0, y: 1, w: 1}, {x: 9, y: 0, w: 1}, {x: 7, y: 0, w: 1}]);
     });
   
   });
@@ -125,7 +125,7 @@ describe('gridstack engine', function() {
     beforeAll(function() {
       engine = new GridStackEngine(12, null, true);
       engine.nodes = [
-        engine.prepareNode({x: 3, y: 2, width: 3, height: 2})
+        engine.prepareNode({x: 3, y: 2, w: 3, h: 2})
       ];
     });
 
@@ -145,9 +145,9 @@ describe('gridstack engine', function() {
     beforeAll(function() {
       engine = new GridStackEngine(12, null, true);
       engine.nodes = [
-        engine.prepareNode({x: 0, y: 0, width: 1, height: 1, idx: 1, _dirty: true}),
-        engine.prepareNode({x: 3, y: 2, width: 3, height: 2, idx: 2, _dirty: true}),
-        engine.prepareNode({x: 3, y: 7, width: 3, height: 2, idx: 3})
+        engine.prepareNode({x: 0, y: 0,   idx: 1, _dirty: true}),
+        engine.prepareNode({x: 3, y: 2, w: 3, h: 2, idx: 2, _dirty: true}),
+        engine.prepareNode({x: 3, y: 7, w: 3, h: 2, idx: 3})
       ];
     });
 
@@ -229,9 +229,9 @@ describe('gridstack engine', function() {
       spyOn(spy, 'callback');
       engine = new GridStackEngine(12, spy.callback, true);
       engine.nodes = [
-        engine.prepareNode({x: 0, y: 0, width: 1, height: 1, idx: 1, _dirty: true}),
-        engine.prepareNode({x: 3, y: 2, width: 3, height: 2, idx: 2, _dirty: true}),
-        engine.prepareNode({x: 3, y: 7, width: 3, height: 2, idx: 3})
+        engine.prepareNode({x: 0, y: 0,   idx: 1, _dirty: true}),
+        engine.prepareNode({x: 3, y: 2, w: 3, h: 2, idx: 2, _dirty: true}),
+        engine.prepareNode({x: 3, y: 7, w: 3, h: 2, idx: 3})
       ];
     });
 
@@ -278,50 +278,50 @@ describe('gridstack engine', function() {
 
       it('shouldn\'t pack one node with y coord eq 0', function() {
         engine.nodes = [
-          {x: 0, y: 0, width: 1, height: 1, _id: 1},
+          {x: 0, y: 0, w:1, h:1,_id: 1},
         ];
         engine._packNodes();
-        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1}));
+        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0,  h: 1}));
         expect(findNode(engine, 1)._dirty).toBeFalsy();
       });
 
       it('should pack one node correctly', function() {
         engine.nodes = [
-          {x: 0, y: 1, width: 1, height: 1, _id: 1},
+          {x: 0, y: 1, w:1, h:1,_id: 1},
         ];
         engine._packNodes();
-        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1, _dirty: true}));
+        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0,   _dirty: true}));
       });
 
       it('should pack nodes correctly', function() {
         engine.nodes = [
-          {x: 0, y: 1, width: 1, height: 1, _id: 1},
-          {x: 0, y: 5, width: 1, height: 1, _id: 2},
+          {x: 0, y: 1, w:1, h:1,_id: 1},
+          {x: 0, y: 5, w:1, h:1,_id: 2},
         ];
         engine._packNodes();
-        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1, _dirty: true}));
-        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 1, width: 1, height: 1, _dirty: true}));
+        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 0,   _dirty: true}));
+        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 1,   _dirty: true}));
       });
   
       it('should pack nodes correctly', function() {
         engine.nodes = [
-          {x: 0, y: 5, width: 1, height: 1, _id: 1},
-          {x: 0, y: 1, width: 1, height: 1, _id: 2},
+          {x: 0, y: 5, w:1, h:1,_id: 1},
+          {x: 0, y: 1, w:1, h:1,_id: 2},
         ];
         engine._packNodes();
-        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 0, width: 1, height: 1, _dirty: true}));
-        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, width: 1, height: 1, _dirty: true}));
+        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 0,   _dirty: true}));
+        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1,   _dirty: true}));
       });
   
       it('should respect locked nodes', function() {
         engine.nodes = [
-          {x: 0, y: 1, width: 1, height: 1, _id: 1, locked: true},
-          {x: 0, y: 5, width: 1, height: 1, _id: 2},
+          {x: 0, y: 1, w:1, h:1,_id: 1, locked: true},
+          {x: 0, y: 5, w:1, h:1,_id: 2},
         ];
         engine._packNodes();
-        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, width: 1, height: 1}));
+        expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1,  h: 1}));
         expect(findNode(engine, 1)._dirty).toBeFalsy();
-        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 2, width: 1, height: 1, _dirty: true}));
+        expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 0, y: 2,   _dirty: true}));
       });
     });
   });
@@ -331,23 +331,23 @@ describe('gridstack engine', function() {
       engine = new GridStackEngine(12);
     });
     it('should return true for changed x', function() {
-      let widget = { x: 1, y: 2, width: 3, height: 4 };
+      let widget = { x: 1, y: 2, w: 3, h: 4 };
       expect(engine.isNodeChangedPosition(widget, 2, 2)).toEqual(true);
     });
     it('should return true for changed y', function() {
-      let widget = { x: 1, y: 2, width: 3, height: 4 };
+      let widget = { x: 1, y: 2, w: 3, h: 4 };
       expect(engine.isNodeChangedPosition(widget, 1, 1)).toEqual(true);
     });
     it('should return true for changed width', function() {
-      let widget = { x: 1, y: 2, width: 3, height: 4 };
+      let widget = { x: 1, y: 2, w: 3, h: 4 };
       expect(engine.isNodeChangedPosition(widget, 2, 2, 4, 4)).toEqual(true);
     });
     it('should return true for changed height', function() {
-      let widget = { x: 1, y: 2, width: 3, height: 4 };
+      let widget = { x: 1, y: 2, w: 3, h: 4 };
       expect(engine.isNodeChangedPosition(widget, 1, 2, 3, 3)).toEqual(true);
     });
     it('should return false for unchanged position', function() {
-      let widget = { x: 1, y: 2, width: 3, height: 4 };
+      let widget = { x: 1, y: 2, w: 3, h: 4 };
       expect(engine.isNodeChangedPosition(widget, 1, 2, 3, 4)).toEqual(false);
     });
   });
@@ -358,25 +358,25 @@ describe('gridstack engine', function() {
     });
     it('should add widgets around locked one', function() {
       let nodes = [
-        {x: 0, y: 1, width: 12, height: 1, locked: 'yes', noMove: true, noResize: true, _id: 1},
-        {x: 1, y: 0, width: 2, height: 3, _id: 2}
+        {x: 0, y: 1, w: 12, h: 1, locked: 'yes', noMove: true, noResize: true, _id: 1},
+        {x: 1, y: 0, w: 2, h: 3, _id: 2}
       ];
       // add locked item
       engine.addNode(nodes[0])
-      expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, width: 12, height: 1, locked: 'yes'}));
+      expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, w: 12, h: 1, locked: 'yes'}));
       engine.addNode(nodes[1])
       // add item that moves past locked one
-      expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, width: 12, height: 1, locked: 'yes'}));
+      expect(findNode(engine, 1)).toEqual(jasmine.objectContaining({x: 0, y: 1, w: 12, h: 1, locked: 'yes'}));
       expect(findNode(engine, 2)).toEqual(jasmine.objectContaining({x: 1, y: 2}));
       // prevents moving locked item
       let node1 = findNode(engine, 1);
       expect(engine.moveNode(node1, 6, 6)).toEqual(null);
       // but moves regular one (gravity ON)
       let node2 = findNode(engine, 2);
-      expect(engine.moveNode(node2, 6, 6)).toEqual(jasmine.objectContaining({x: 6, y: 2, width: 2, height: 3,}));
+      expect(engine.moveNode(node2, 6, 6)).toEqual(jasmine.objectContaining({x: 6, y: 2, w: 2, h: 3,}));
       // but moves regular one (gravity OFF)
       engine.float = true;
-      expect(engine.moveNode(node2, 7, 6)).toEqual(jasmine.objectContaining({x: 7, y: 6, width: 2, height: 3,}));
+      expect(engine.moveNode(node2, 7, 6)).toEqual(jasmine.objectContaining({x: 7, y: 6, w: 2, h: 3,}));
     });
   });
   

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -417,9 +417,9 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       grid.batchUpdate();
       grid.batchUpdate();
-      let el1 = grid.addWidget({width:1, height:1});
-      let el2 = grid.addWidget({x:2, y:0, width:2, height:1});
-      let el3 = grid.addWidget({x:1, y:0, width:1, height:2});
+      let el1 = grid.addWidget({w:1, h:1});
+      let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
+      let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
       grid.commit();
       grid.commit();
       
@@ -463,9 +463,9 @@ describe('gridstack', function() {
         float: true
       };
       let grid = GridStack.init(options);
-      let el1 = grid.addWidget({width:1, height:1});
-      let el2 = grid.addWidget({x:2, y:0, width:2, height:1});
-      let el3 = grid.addWidget({x:1, y:0, width:1, height:2});
+      let el1 = grid.addWidget({w:1, h:1});
+      let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
+      let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
 
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
@@ -513,11 +513,11 @@ describe('gridstack', function() {
       let grid = GridStack.init();
       expect(grid.getColumn()).toBe(1);
     });
-    it('should go to 1 column with large minWidth', function() {
+    it('should go to 1 column with large minW', function() {
       let grid = GridStack.init({minWidth: 1000});
       expect(grid.getColumn()).toBe(1);
     });
-    it('should stay at 12 with minWidth', function() {
+    it('should stay at 12 with minW', function() {
       let grid = GridStack.init({minWidth: 300});
       expect(grid.getColumn()).toBe(12);
     });
@@ -581,7 +581,7 @@ describe('gridstack', function() {
     });
     it('should have row attr', function() {
       let HTML = 
-        '<div style="width: 800px; height: 600px" id="gs-cont">' +
+        '<div style="w: 800px; h: 600px" id="gs-cont">' +
         '  <div class="grid-stack" gs-row="4" gs-current-height="1"></div>' + // old attr current-height
         '</div>';
       document.body.insertAdjacentHTML('afterbegin', HTML);
@@ -589,7 +589,7 @@ describe('gridstack', function() {
       expect(grid.getRow()).toBe(4);
       expect(grid.opts.minRow).toBe(4);
       expect(grid.opts.maxRow).toBe(4);
-      grid.addWidget({height: 6});
+      grid.addWidget({h: 6});
       expect(grid.engine.getRow()).toBe(4);
       expect(grid.getRow()).toBe(4);
     });
@@ -607,10 +607,10 @@ describe('gridstack', function() {
       let items = Utils.getElements('.grid-stack-item');
       for (let i = 0; i < items.length; i++) {
         grid
-          .minWidth(items[i], 2)
-          .maxWidth(items[i], 3)
-          .minHeight(items[i], 4)
-          .maxHeight(items[i], 5);
+          .minW(items[i], 2)
+          .maxW(items[i], 3)
+          .minH(items[i], 4)
+          .maxH(items[i], 5);
       }
       for (let j = 0; j < items.length; j++) {
         expect(parseInt(items[j].getAttribute('gs-min-w'), 10)).toBe(2);
@@ -620,10 +620,10 @@ describe('gridstack', function() {
       }
       // remove all constrain
       grid
-        .minWidth('grid-stack-item', 0)
-        .maxWidth('.grid-stack-item', null)
-        .minHeight('grid-stack-item', undefined)
-        .maxHeight(undefined, 0);
+        .minW('grid-stack-item', 0)
+        .maxW('.grid-stack-item', null)
+        .minH('grid-stack-item', undefined)
+        .maxH(undefined, 0);
       for (let j = 0; j < items.length; j++) {
         expect(items[j].getAttribute('gs-min-w')).toBe(null);
         expect(items[j].getAttribute('gs-max-w')).toBe(null);
@@ -765,8 +765,8 @@ describe('gridstack', function() {
     });
     it('should keep all widget options the same (autoPosition off', function() {
       let grid = GridStack.init({float: true});;
-      let widget = grid.addWidget({x: 6, y:7, width:2, height:3, autoPosition:false,
-        minWidth:1, maxWidth:4, minHeight:2, maxHeight:5, id:'coolWidget'});
+      let widget = grid.addWidget({x: 6, y:7, w:2, h:3, autoPosition:false,
+        minW:1, maxW:4, minH:2, maxH:5, id:'coolWidget'});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(6);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(7);
@@ -819,7 +819,7 @@ describe('gridstack', function() {
     });
     it('should change x, y coordinates for widgets.', function() {
       let grid = GridStack.init({float: true});
-      let widget = grid.addWidget({x:9, y:7, width:2, height:3, autoPosition:true});
+      let widget = grid.addWidget({x:9, y:7, w:2, h:3, autoPosition:true});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).not.toBe(9);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).not.toBe(7);
@@ -835,7 +835,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing X,Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget({height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({h: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -850,7 +850,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing X)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget({y: 9, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({y: 9, h: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -865,7 +865,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (missing Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget({x: 9, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({x: 9, h: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -880,7 +880,7 @@ describe('gridstack', function() {
     });
     it('should autoPosition (correct X, missing Y)', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget({x: 8, height: 2, id: 'optionWidget'});
+      let widget = grid.addWidget({x: 8, h: 2, id: 'optionWidget'});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -919,7 +919,7 @@ describe('gridstack', function() {
     });
     it('bad string options should use default', function() {
       let grid = GridStack.init();
-      let widget = grid.addWidget({x: 'foo', y: null, width: 'bar', height: ''} as any);
+      let widget = grid.addWidget({x: 'foo', y: null, w: 'bar', h: ''} as any);
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -929,7 +929,7 @@ describe('gridstack', function() {
     it('null options should clear x position', function() {
       let grid = GridStack.init({float: true});
       let HTML = '<div class="grid-stack-item" gs-x="9"><div class="grid-stack-item-content"></div></div>';
-      let widget = grid.addWidget(HTML, {x:null, y:null, width:undefined});
+      let widget = grid.addWidget(HTML, {x:null, y:null, w:undefined});
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
@@ -1115,7 +1115,7 @@ describe('gridstack', function() {
       let el = Utils.getElements('.grid-stack-item')[1];
       expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
       
-      grid.update(el, {x: 5, y: 4, height: 2});
+      grid.update(el, {x: 5, y: 4, h: 2});
       expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(5);
       expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(4);
       expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(4);
@@ -1160,7 +1160,7 @@ describe('gridstack', function() {
       let el = items[1];
       expect(el.getAttribute('gs-max-w')).toBe(null);
 
-      grid.update(el, {maxWidth: 2, width: 5});
+      grid.update(el, {maxW: 2, w: 5});
       expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
       expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(0);
       expect(parseInt(el.getAttribute('gs-w'), 10)).toBe(2);
@@ -1173,7 +1173,7 @@ describe('gridstack', function() {
       let el = items[1];
       expect(el.getAttribute('gs-max-w')).toBe(null);
 
-      grid.update(el, {maxWidth: 2});
+      grid.update(el, {maxW: 2});
       expect(parseInt(el.getAttribute('gs-x'), 10)).toBe(4);
       expect(parseInt(el.getAttribute('gs-y'), 10)).toBe(0);
       expect(parseInt(el.getAttribute('gs-h'), 10)).toBe(4);
@@ -1189,7 +1189,7 @@ describe('gridstack', function() {
         expect(item.getAttribute('gs-max-h')).toBe(null);
       });
 
-      grid.update('.grid-stack-item', {maxWidth: 2, maxHeight: 2});
+      grid.update('.grid-stack-item', {maxW: 2, maxH: 2});
       expect(parseInt(items[0].getAttribute('gs-x'), 10)).toBe(0);
       expect(parseInt(items[1].getAttribute('gs-x'), 10)).toBe(4);
       items.forEach(item => {
@@ -1552,7 +1552,7 @@ describe('gridstack', function() {
 
   describe('custom grid placement #1054', function() {
     let HTML = 
-    '<div style="width: 800px; height: 600px" id="gs-cont">' +
+    '<div style="w: 800px; h: 600px" id="gs-cont">' +
     '  <div class="grid-stack">' +
     '    <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="12" gs-h="9">' +
     '      <div class="grid-stack-item-content"></div>' +
@@ -1626,11 +1626,11 @@ describe('gridstack', function() {
     });
     it('not move locked item, size down added one', function() {
       let grid = GridStack.init();
-      let el1 = grid.addWidget({x: 0, y: 1, width: 12, height: 1, locked: true});
+      let el1 = grid.addWidget({x: 0, y: 1, w: 12,  locked: true});
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
 
-      let el2 = grid.addWidget({x: 2, y: 0, height: 3});
+      let el2 = grid.addWidget({x: 2, y: 0, h: 3});
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
@@ -1727,35 +1727,35 @@ describe('gridstack', function() {
     it('save layout', function() {
       let grid = GridStack.init();
       let layout = grid.save(false);
-      expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'gsItem1'}, {x:4, y:0, width:4, height:4, id:'gsItem2'}]);
+      expect(layout).toEqual([{x:0, y:0, w:4, h:2, id:'gsItem1'}, {x:4, y:0, w:4, h:4, id:'gsItem2'}]);
       layout = grid.save();
-      expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'gsItem1', content:'item 1 text'}, {x:4, y:0, width:4, height:4, id:'gsItem2', content:'item 2 text'}]);
+      expect(layout).toEqual([{x:0, y:0, w:4, h:2, id:'gsItem1', content:'item 1 text'}, {x:4, y:0, w:4, h:4, id:'gsItem2', content:'item 2 text'}]);
       layout = grid.save(true);
-      expect(layout).toEqual([{x:0, y:0, width:4, height:2, id:'gsItem1', content:'item 1 text'}, {x:4, y:0, width:4, height:4, id:'gsItem2', content:'item 2 text'}]);
+      expect(layout).toEqual([{x:0, y:0, w:4, h:2, id:'gsItem1', content:'item 1 text'}, {x:4, y:0, w:4, h:4, id:'gsItem2', content:'item 2 text'}]);
     });
     it('load move 1 item, delete others', function() {
       let grid = GridStack.init();
-      grid.load([{x:2, height:1, id:'gsItem2'}]);
+      grid.load([{x:2, h:1, id:'gsItem2'}]);
       let layout = grid.save(false);
-      expect(layout).toEqual([{x:2, y:0, width:4, height:1, id:'gsItem2'}]);
+      expect(layout).toEqual([{x:2, y:0, w:4, h:1, id:'gsItem2'}]);
     });
     it('load add new, delete others', function() {
       let grid = GridStack.init();
-      grid.load([{width:2, height:1, id:'gsItem3'}], true);
+      grid.load([{w:2, h:1, id:'gsItem3'}], true);
       let layout = grid.save(false);
-      expect(layout).toEqual([{x:0, y:0, width:2, height:1, id:'gsItem3'}]);
+      expect(layout).toEqual([{x:0, y:0, w:2, h:1, id:'gsItem3'}]);
     });
     it('load size 1 item only', function() {
       let grid = GridStack.init();
-      grid.load([{height:3, id:'gsItem1'}], false);
+      grid.load([{h:3, id:'gsItem1'}], false);
       let layout = grid.save(false);
-      expect(layout).toEqual([{x:0, y:0, width:4, height:3, id:'gsItem1'}, {x:4, y:0, width:4, height:4, id:'gsItem2'}]);
+      expect(layout).toEqual([{x:0, y:0, w:4, h:3, id:'gsItem1'}, {x:4, y:0, w:4, h:4, id:'gsItem2'}]);
     });
     it('load size 1 item only with callback', function() {
       let grid = GridStack.init();
-      grid.load([{height:3, id:'gsItem1'}], () => {});
+      grid.load([{h:3, id:'gsItem1'}], () => {});
       let layout = grid.save(false);
-      expect(layout).toEqual([{x:0, y:0, width:4, height:3, id:'gsItem1'}, {x:4, y:0, width:4, height:4, id:'gsItem2'}]);
+      expect(layout).toEqual([{x:0, y:0, w:4, h:3, id:'gsItem1'}, {x:4, y:0, w:4, h:4, id:'gsItem2'}]);
     });
   });
 

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -31,20 +31,20 @@ describe('gridstack utils', function() {
   });
 
   describe('test isIntercepted', function() {
-    let src = {x: 3, y: 2, width: 3, height: 2};
+    let src = {x: 3, y: 2, w: 3, h: 2};
 
     it('should intercept.', function() {
-      expect(Utils.isIntercepted(src, {x: 0, y: 0, width: 4, height: 3})).toEqual(true);
-      expect(Utils.isIntercepted(src, {x: 0, y: 0, width: 40, height: 30})).toEqual(true);
-      expect(Utils.isIntercepted(src, {x: 3, y: 2, width: 3, height: 2})).toEqual(true);
-      expect(Utils.isIntercepted(src, {x: 5, y: 3, width: 3, height: 2})).toEqual(true);
+      expect(Utils.isIntercepted(src, {x: 0, y: 0, w: 4, h: 3})).toEqual(true);
+      expect(Utils.isIntercepted(src, {x: 0, y: 0, w: 40, h: 30})).toEqual(true);
+      expect(Utils.isIntercepted(src, {x: 3, y: 2, w: 3, h: 2})).toEqual(true);
+      expect(Utils.isIntercepted(src, {x: 5, y: 3, w: 3, h: 2})).toEqual(true);
     });
     it('shouldn\'t intercept.', function() {
-      expect(Utils.isIntercepted(src, {x: 0, y: 0, width: 3, height: 2})).toEqual(false);
-      expect(Utils.isIntercepted(src, {x: 0, y: 0, width: 13, height: 2})).toEqual(false);
-      expect(Utils.isIntercepted(src, {x: 1, y: 4, width: 13, height: 2})).toEqual(false);
-      expect(Utils.isIntercepted(src, {x: 0, y: 3, width: 3, height: 2})).toEqual(false);
-      expect(Utils.isIntercepted(src, {x: 6, y: 3, width: 3, height: 2})).toEqual(false);
+      expect(Utils.isIntercepted(src, {x: 0, y: 0, w: 3, h: 2})).toEqual(false);
+      expect(Utils.isIntercepted(src, {x: 0, y: 0, w: 13, h: 2})).toEqual(false);
+      expect(Utils.isIntercepted(src, {x: 1, y: 4, w: 13, h: 2})).toEqual(false);
+      expect(Utils.isIntercepted(src, {x: 0, y: 3, w: 3, h: 2})).toEqual(false);
+      expect(Utils.isIntercepted(src, {x: 6, y: 3, w: 3, h: 2})).toEqual(false);
     });
   });
 
@@ -68,28 +68,28 @@ describe('gridstack utils', function() {
   describe('test parseHeight', function() {
 
     it('should parse height value', function() {
-      expect(Utils.parseHeight(12)).toEqual(jasmine.objectContaining({height: 12, unit: 'px'}));
-      expect(Utils.parseHeight('12px')).toEqual(jasmine.objectContaining({height: 12, unit: 'px'}));
-      expect(Utils.parseHeight('12.3px')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'px'}));
-      expect(Utils.parseHeight('12.3em')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'em'}));
-      expect(Utils.parseHeight('12.3rem')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'rem'}));
-      expect(Utils.parseHeight('12.3vh')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vh'}));
-      expect(Utils.parseHeight('12.3vw')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vw'}));
-      expect(Utils.parseHeight('12.3%')).toEqual(jasmine.objectContaining({height: 12.3, unit: '%'}));
-      expect(Utils.parseHeight('12.5')).toEqual(jasmine.objectContaining({height: 12.5, unit: 'px'}));
+      expect(Utils.parseHeight(12)).toEqual(jasmine.objectContaining({h: 12, unit: 'px'}));
+      expect(Utils.parseHeight('12px')).toEqual(jasmine.objectContaining({h: 12, unit: 'px'}));
+      expect(Utils.parseHeight('12.3px')).toEqual(jasmine.objectContaining({h: 12.3, unit: 'px'}));
+      expect(Utils.parseHeight('12.3em')).toEqual(jasmine.objectContaining({h: 12.3, unit: 'em'}));
+      expect(Utils.parseHeight('12.3rem')).toEqual(jasmine.objectContaining({h: 12.3, unit: 'rem'}));
+      expect(Utils.parseHeight('12.3vh')).toEqual(jasmine.objectContaining({h: 12.3, unit: 'vh'}));
+      expect(Utils.parseHeight('12.3vw')).toEqual(jasmine.objectContaining({h: 12.3, unit: 'vw'}));
+      expect(Utils.parseHeight('12.3%')).toEqual(jasmine.objectContaining({h: 12.3, unit: '%'}));
+      expect(Utils.parseHeight('12.5')).toEqual(jasmine.objectContaining({h: 12.5, unit: 'px'}));
       expect(function() { Utils.parseHeight('12.5 df'); }).toThrowError('Invalid height');
     });
 
     it('should parse negative height value', function() {
-      expect(Utils.parseHeight(-12)).toEqual(jasmine.objectContaining({height: -12, unit: 'px'}));
-      expect(Utils.parseHeight('-12px')).toEqual(jasmine.objectContaining({height: -12, unit: 'px'}));
-      expect(Utils.parseHeight('-12.3px')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'px'}));
-      expect(Utils.parseHeight('-12.3em')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'em'}));
-      expect(Utils.parseHeight('-12.3rem')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'rem'}));
-      expect(Utils.parseHeight('-12.3vh')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'vh'}));
-      expect(Utils.parseHeight('-12.3vw')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'vw'}));
-      expect(Utils.parseHeight('-12.3%')).toEqual(jasmine.objectContaining({height: -12.3, unit: '%'}));
-      expect(Utils.parseHeight('-12.5')).toEqual(jasmine.objectContaining({height: -12.5, unit: 'px'}));
+      expect(Utils.parseHeight(-12)).toEqual(jasmine.objectContaining({h: -12, unit: 'px'}));
+      expect(Utils.parseHeight('-12px')).toEqual(jasmine.objectContaining({h: -12, unit: 'px'}));
+      expect(Utils.parseHeight('-12.3px')).toEqual(jasmine.objectContaining({h: -12.3, unit: 'px'}));
+      expect(Utils.parseHeight('-12.3em')).toEqual(jasmine.objectContaining({h: -12.3, unit: 'em'}));
+      expect(Utils.parseHeight('-12.3rem')).toEqual(jasmine.objectContaining({h: -12.3, unit: 'rem'}));
+      expect(Utils.parseHeight('-12.3vh')).toEqual(jasmine.objectContaining({h: -12.3, unit: 'vh'}));
+      expect(Utils.parseHeight('-12.3vw')).toEqual(jasmine.objectContaining({h: -12.3, unit: 'vw'}));
+      expect(Utils.parseHeight('-12.3%')).toEqual(jasmine.objectContaining({h: -12.3, unit: '%'}));
+      expect(Utils.parseHeight('-12.5')).toEqual(jasmine.objectContaining({h: -12.5, unit: 'px'}));
       expect(function() { Utils.parseHeight('-12.5 df'); }).toThrowError('Invalid height');
     });
   });
@@ -100,14 +100,14 @@ describe('gridstack utils', function() {
       expect(src).toEqual({});
       expect(Utils.defaults(src, {x: 1, y: 2})).toEqual({x: 1, y: 2});
       expect(Utils.defaults(src, {x: 10})).toEqual({x: 1, y: 2});
-      src.width = undefined;
-      expect(src).toEqual({x: 1, y: 2, width: undefined});
-      expect(Utils.defaults(src, {x: 10, width: 3})).toEqual({x: 1, y: 2, width: 3});
-      expect(Utils.defaults(src, {height: undefined})).toEqual({x: 1, y: 2, width: 3, height: undefined});
+      src.w = undefined;
+      expect(src).toEqual({x: 1, y: 2, w: undefined});
+      expect(Utils.defaults(src, {x: 10, w: 3})).toEqual({x: 1, y: 2, w: 3});
+      expect(Utils.defaults(src, {h: undefined})).toEqual({x: 1, y: 2, w: 3, h: undefined});
       src = {x: 1, y: 2, sub: {foo: 1, two: 2}};
       expect(src).toEqual({x: 1, y: 2, sub: {foo: 1, two: 2}});
-      expect(Utils.defaults(src, {x: 10, width: 3})).toEqual({x: 1, y: 2, width: 3, sub: {foo: 1, two: 2}});
-      expect(Utils.defaults(src, {sub: {three: 3}})).toEqual({x: 1, y: 2, width: 3, sub: {foo: 1, two: 2, three: 3}});
+      expect(Utils.defaults(src, {x: 10, w: 3})).toEqual({x: 1, y: 2, w: 3, sub: {foo: 1, two: 2}});
+      expect(Utils.defaults(src, {sub: {three: 3}})).toEqual({x: 1, y: 2, w: 3, sub: {foo: 1, two: 2, three: 3}});
     });
   });
 
@@ -126,7 +126,7 @@ describe('gridstack utils', function() {
   describe('removePositioningStyles', function() {
     it('should remove styles', function() {
       let doc = document.implementation.createHTMLDocument();
-      doc.body.innerHTML = '<div style="position: absolute; left: 1; top: 2; width: 3; height: 4"></div>';
+      doc.body.innerHTML = '<div style="position: absolute; left: 1; top: 2; w: 3; h: 4"></div>';
       let el = doc.body.children[0] as HTMLElement;
       expect(el.style.position).toEqual('absolute');
       // expect(el.style.left).toEqual('1'); // not working!

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -244,17 +244,17 @@ export class GridStack {
     this._updateStyles();
 
     this.engine = new GridStackEngine(this.opts.column, (cbNodes, removeDOM = true) => {
-      let maxHeight = 0;
-      this.engine.nodes.forEach(n => { maxHeight = Math.max(maxHeight, n.y + n.height) });
+      let maxH = 0;
+      this.engine.nodes.forEach(n => { maxH = Math.max(maxH, n.y + n.h) });
       cbNodes.forEach(n => {
         let el = n.el;
         if (removeDOM && n._id === null) {
           if (el && el.parentNode) { el.parentNode.removeChild(el) }
         } else {
-          this._writeAttrs(el, n.x, n.y, n.width, n.height);
+          this._writeAttrs(el, n.x, n.y, n.w, n.h);
         }
       });
-      this._updateStyles(false, maxHeight); // false = don't recreate, just append if need be
+      this._updateStyles(false, maxH); // false = don't recreate, just append if need be
     }, this.opts.float, this.opts.maxRow);
 
     if (this.opts.auto) {
@@ -298,8 +298,8 @@ export class GridStack {
    *
    * @example
    * let grid = GridStack.init();
-   * grid.addWidget({width: 3, content: 'hello'});
-   * grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">hello</div></div>', {width: 3});
+   * grid.addWidget({w: 3, content: 'hello'});
+   * grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content">hello</div></div>', {w: 3});
    *
    * @param el  GridStackWidget (which can have content string as well), html element, or string definition to add
    * @param options widget position/size options (optional, and ignore if first param is already option) - see GridStackWidget
@@ -308,16 +308,16 @@ export class GridStack {
 
     // support legacy call for now ?
     if (arguments.length > 2) {
-      console.warn('gridstack.ts: `addWidget(el, x, y, width...)` is deprecated. Use `addWidget({x, y, width, content, ...})`. It will be removed soon');
+      console.warn('gridstack.ts: `addWidget(el, x, y, width...)` is deprecated. Use `addWidget({x, y, w, content, ...})`. It will be removed soon');
       // eslint-disable-next-line prefer-rest-params
       let a = arguments, i = 1,
-        opt: GridStackWidget = { x:a[i++], y:a[i++], width:a[i++], height:a[i++], autoPosition:a[i++],
-          minWidth:a[i++], maxWidth:a[i++], minHeight:a[i++], maxHeight:a[i++], id:a[i++] };
+        opt: GridStackWidget = { x:a[i++], y:a[i++], w:a[i++], h:a[i++], autoPosition:a[i++],
+          minW:a[i++], maxW:a[i++], minH:a[i++], maxH:a[i++], id:a[i++] };
       return this.addWidget(els, opt);
     }
 
     function isGridStackWidget(w: GridStackWidget): w is GridStackWidget { // https://medium.com/ovrsea/checking-the-type-of-an-object-in-typescript-the-type-guards-24d98d9119b0
-      return w.x !== undefined || w.y !== undefined || w.width !== undefined || w.height !== undefined || w.content !== undefined ? true : false;
+      return w.x !== undefined || w.y !== undefined || w.w !== undefined || w.h !== undefined || w.content !== undefined ? true : false;
     }
 
     let el: HTMLElement;
@@ -387,7 +387,7 @@ export class GridStack {
 
     // if we're loading a layout into 1 column (_prevColumn is set only when going to 1) and items don't fit, make sure to save
     // the original wanted layout so we can scale back up correctly #1471
-    if (this._prevColumn && this._prevColumn !== this.opts.column && items.some(n => (n.x + n.width) > this.opts.column)) {
+    if (this._prevColumn && this._prevColumn !== this.opts.column && items.some(n => (n.x + n.w) > this.opts.column)) {
       this._ignoreLayoutsNodeChange = true; // skip layout update
       this.engine.cacheLayout(items, this._prevColumn, true);
     }
@@ -467,11 +467,11 @@ export class GridStack {
    */
   public cellHeight(val: numberOrString, update = true): GridStack {
     let data = Utils.parseHeight(val);
-    if (this.opts.cellHeightUnit === data.unit && this.opts.cellHeight === data.height) {
+    if (this.opts.cellHeightUnit === data.unit && this.opts.cellHeight === data.h) {
       return this;
     }
     this.opts.cellHeightUnit = data.unit;
-    this.opts.cellHeight = data.height;
+    this.opts.cellHeight = data.h;
 
     if (update) {
       this._updateStyles(true); // true = force re-create
@@ -518,7 +518,7 @@ export class GridStack {
     if (this.opts.column === column) { return this; }
     let oldColumn = this.opts.column;
 
-    // if we go into 1 column mode (which happens if we're sized less than minWidth unless disableOneColumnMode is on)
+    // if we go into 1 column mode (which happens if we're sized less than minW unless disableOneColumnMode is on)
     // then remember the original columns so we can restore.
     if (column === 1) {
       this._prevColumn = oldColumn;
@@ -673,7 +673,7 @@ export class GridStack {
    */
   public getCellFromPixel(position: MousePosition, useDocRelative = false): CellPosition {
     let box = this.el.getBoundingClientRect();
-    // console.log(`getBoundingClientRect left: ${box.left} top: ${box.top} w: ${box.width} h: ${box.height}`)
+    // console.log(`getBoundingClientRect left: ${box.left} top: ${box.top} w: ${box.w} h: ${box.h}`)
     let containerPos;
     if (useDocRelative) {
       containerPos = {top: box.top + document.documentElement.scrollTop, left: box.left};
@@ -700,11 +700,11 @@ export class GridStack {
    * Checks if specified area is empty.
    * @param x the position x.
    * @param y the position y.
-   * @param width the width of to check
-   * @param height the height of to check
+   * @param w the width of to check
+   * @param h the height of to check
    */
-  public isAreaEmpty(x: number, y: number, width: number, height: number): boolean {
-    return this.engine.isAreaEmpty(x, y, width, height);
+  public isAreaEmpty(x: number, y: number, w: number, h: number): boolean {
+    return this.engine.isAreaEmpty(x, y, w, h);
   }
 
   /**
@@ -871,16 +871,16 @@ export class GridStack {
   /**
    * Updates widget position/size and other info. Note: if you need to call this on all nodes, use load() instead which will update what changed.
    * @param els  widget or selector of objects to modify (note: setting the same x,y for multiple items will be indeterministic and likely unwanted)
-   * @param opt new widget options (x,y,width,height, etc..). Only those set will be updated.
+   * @param opt new widget options (x,y,w,h, etc..). Only those set will be updated.
    */
   public update(els: GridStackElement, opt: GridStackWidget): GridStack {
 
     // support legacy call for now ?
     if (arguments.length > 2) {
-      console.warn('gridstack.ts: `update(el, x, y, width, height)` is deprecated. Use `update({x, width, content, ...})`. It will be removed soon');
+      console.warn('gridstack.ts: `update(el, x, y, w, h)` is deprecated. Use `update({x, w, content, ...})`. It will be removed soon');
       // eslint-disable-next-line prefer-rest-params
       let a = arguments, i = 1;
-      opt = { x:a[i++], y:a[i++], width:a[i++], height:a[i++] };
+      opt = { x:a[i++], y:a[i++], w:a[i++], h:a[i++] };
       return this.update(els, opt);
     }
 
@@ -891,7 +891,7 @@ export class GridStack {
       delete w.autoPosition;
 
       // move/resize widget if anything changed
-      let keys = ['x', 'y', 'width', 'height'];
+      let keys = ['x', 'y', 'w', 'h'];
       let m: GridStackWidget;
       if (keys.some(k => w[k] !== undefined && w[k] !== n[k])) {
         m = {};
@@ -901,7 +901,7 @@ export class GridStack {
         });
       }
       // for a move as well IFF there is any min/max fields set
-      if (!m && (w.minWidth || w.minHeight || w.maxWidth || w.maxHeight)) {
+      if (!m && (w.minW || w.minH || w.maxW || w.maxH)) {
         m = {}; // will use node position but validate values
       }
 
@@ -929,12 +929,12 @@ export class GridStack {
       if (m) {
         this.engine.cleanNodes();
         this.engine.beginUpdate(n);
-        this.engine.moveNode(n, m.x, m.y, m.width, m.height);
+        this.engine.moveNode(n, m.x, m.y, m.w, m.h);
         this._updateContainerHeight();
         this._triggerChangeEvent();
         this.engine.endUpdate();
       }
-      if (changed) { // move will only update x,y,width,height so update the rest too
+      if (changed) { // move will only update x,y,w,h so update the rest too
         this._writeAttr(el, n);
       }
       if (ddChanged) {
@@ -953,7 +953,7 @@ export class GridStack {
     // check if we can skip re-creating our CSS file... won't check if multi values (too much hassle)
     if (!isMultiValue) {
       let data = Utils.parseHeight(value);
-      if (this.opts.marginUnit === data.unit && this.opts.margin === data.height) return;
+      if (this.opts.marginUnit === data.unit && this.opts.margin === data.h) return;
     }
     // re-use existing margin handling
     this.opts.margin = value;
@@ -973,20 +973,20 @@ export class GridStack {
    * constraint. Always returns true if grid doesn't have height constraint.
    * @param x new position x. If value is null or undefined it will be ignored.
    * @param y new position y. If value is null or undefined it will be ignored.
-   * @param width new dimensions width. If value is null or undefined it will be ignored.
-   * @param height new dimensions height. If value is null or undefined it will be ignored.
+   * @param w new dimensions width. If value is null or undefined it will be ignored.
+   * @param h new dimensions height. If value is null or undefined it will be ignored.
    * @param autoPosition if true then x, y parameters will be ignored and widget
    * will be places on the first available position
    *
    * @example
-   * if (grid.willItFit(newNode.x, newNode.y, newNode.width, newNode.height, newNode.autoPosition)) {
+   * if (grid.willItFit(newNode.x, newNode.y, newNode.w, newNode.h, newNode.autoPosition)) {
    *   grid.addWidget(newNode);
    * } else {
    *   alert('Not enough free space to place the widget');
    * }
    */
-  public willItFit(x: number, y: number, width: number, height: number, autoPosition: boolean): boolean {
-    return this.engine.canBePlacedWithRespectToHeight({x, y, width, height, autoPosition});
+  public willItFit(x: number, y: number, w: number, h: number, autoPosition: boolean): boolean {
+    return this.engine.canBePlacedWithRespectToHeight({x, y, w, h, autoPosition});
   }
 
   /** @internal */
@@ -1046,7 +1046,7 @@ export class GridStack {
   }
 
   /** @internal updated/create the CSS styles for row based layout and initial margin setting */
-  private _updateStyles(forceUpdate = false, maxHeight?: number): GridStack {
+  private _updateStyles(forceUpdate = false, maxH?: number): GridStack {
     // call to delete existing one if we change cellHeight / margin
     if (forceUpdate) {
       this._removeStylesheet();
@@ -1092,17 +1092,17 @@ export class GridStack {
     }
 
     // now update the height specific fields
-    maxHeight = maxHeight || this._styles._max;
-    if (maxHeight > this._styles._max) {
+    maxH = maxH || this._styles._max;
+    if (maxH > this._styles._max) {
       let getHeight = (rows: number): string => (cellHeight * rows) + cellHeightUnit;
-      for (let i = this._styles._max + 1; i <= maxHeight; i++) { // start at 1
-        let height: string = getHeight(i);
+      for (let i = this._styles._max + 1; i <= maxH; i++) { // start at 1
+        let h: string = getHeight(i);
         Utils.addCSSRule(this._styles, `${prefix}[gs-y="${i-1}"]`,        `top: ${getHeight(i-1)}`); // start at 0
-        Utils.addCSSRule(this._styles, `${prefix}[gs-h="${i}"]`,     `height: ${height}`);
-        Utils.addCSSRule(this._styles, `${prefix}[gs-min-h="${i}"]`, `min-height: ${height}`);
-        Utils.addCSSRule(this._styles, `${prefix}[gs-max-h="${i}"]`, `max-height: ${height}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-h="${i}"]`,     `height: ${h}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-min-h="${i}"]`, `min-height: ${h}`);
+        Utils.addCSSRule(this._styles, `${prefix}[gs-max-h="${i}"]`, `max-height: ${h}`);
       }
-      this._styles._max = maxHeight;
+      this._styles._max = maxH;
     }
     return this;
   }
@@ -1161,25 +1161,25 @@ export class GridStack {
   }
 
   /** @internal call to write x,y,w,h attributes back to element */
-  private _writeAttrs(el: HTMLElement, x?: number, y?: number, width?: number, height?: number): GridStack {
+  private _writeAttrs(el: HTMLElement, x?: number, y?: number, w?: number, h?: number): GridStack {
     if (x !== undefined && x !== null) { el.setAttribute('gs-x', String(x)); }
     if (y !== undefined && y !== null) { el.setAttribute('gs-y', String(y)); }
-    if (width) { el.setAttribute('gs-w', String(width)); }
-    if (height) { el.setAttribute('gs-h', String(height)); }
+    if (w) { el.setAttribute('gs-w', String(w)); }
+    if (h) { el.setAttribute('gs-h', String(h)); }
     return this;
   }
 
   /** @internal call to write any default attributes back to element */
   private _writeAttr(el: HTMLElement, node: GridStackWidget): GridStack {
     if (!node) return this;
-    this._writeAttrs(el, node.x, node.y, node.width, node.height);
+    this._writeAttrs(el, node.x, node.y, node.w, node.h);
 
     let attrs /*: GridStackWidget*/ = { // remaining attributes
       autoPosition: 'gs-auto-position',
-      minWidth: 'gs-min-w',
-      minHeight: 'gs-min-h',
-      maxWidth: 'gs-max-w',
-      maxHeight: 'gs-max-h',
+      minW: 'gs-min-w',
+      minH: 'gs-min-h',
+      maxW: 'gs-max-w',
+      maxH: 'gs-max-h',
       noResize: 'gs-no-resize',
       noMove: 'gs-no-move',
       locked: 'gs-locked',
@@ -1200,12 +1200,12 @@ export class GridStack {
   private _readAttr(el: HTMLElement, node: GridStackNode = {}): GridStackWidget {
     node.x = Utils.toNumber(el.getAttribute('gs-x'));
     node.y = Utils.toNumber(el.getAttribute('gs-y'));
-    node.width = Utils.toNumber(el.getAttribute('gs-w'));
-    node.height = Utils.toNumber(el.getAttribute('gs-h'));
-    node.maxWidth = Utils.toNumber(el.getAttribute('gs-max-w'));
-    node.minWidth = Utils.toNumber(el.getAttribute('gs-min-w'));
-    node.maxHeight = Utils.toNumber(el.getAttribute('gs-max-h'));
-    node.minHeight = Utils.toNumber(el.getAttribute('gs-min-h'));
+    node.w = Utils.toNumber(el.getAttribute('gs-w'));
+    node.h = Utils.toNumber(el.getAttribute('gs-h'));
+    node.maxW = Utils.toNumber(el.getAttribute('gs-max-w'));
+    node.minW = Utils.toNumber(el.getAttribute('gs-min-w'));
+    node.maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
+    node.minH = Utils.toNumber(el.getAttribute('gs-min-h'));
     node.autoPosition = Utils.toBool(el.getAttribute('gs-auto-position'));
     node.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
     node.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
@@ -1316,7 +1316,7 @@ export class GridStack {
     } else {
       data = Utils.parseHeight(this.opts.margin);
       this.opts.marginUnit = data.unit;
-      margin = this.opts.margin = data.height;
+      margin = this.opts.margin = data.h;
     }
 
     // see if top/bottom/left/right need to be set as well
@@ -1324,7 +1324,7 @@ export class GridStack {
       this.opts.marginTop = margin;
     } else {
       data = Utils.parseHeight(this.opts.marginTop);
-      this.opts.marginTop = data.height;
+      this.opts.marginTop = data.h;
       delete this.opts.margin;
     }
 
@@ -1332,7 +1332,7 @@ export class GridStack {
       this.opts.marginBottom = margin;
     } else {
       data = Utils.parseHeight(this.opts.marginBottom);
-      this.opts.marginBottom = data.height;
+      this.opts.marginBottom = data.h;
       delete this.opts.margin;
     }
 
@@ -1340,7 +1340,7 @@ export class GridStack {
       this.opts.marginRight = margin;
     } else {
       data = Utils.parseHeight(this.opts.marginRight);
-      this.opts.marginRight = data.height;
+      this.opts.marginRight = data.h;
       delete this.opts.margin;
     }
 
@@ -1348,7 +1348,7 @@ export class GridStack {
       this.opts.marginLeft = margin;
     } else {
       data = Utils.parseHeight(this.opts.marginLeft);
-      this.opts.marginLeft = data.height;
+      this.opts.marginLeft = data.h;
       delete this.opts.margin;
     }
     this.opts.marginUnit = data.unit; // in case side were spelled out, use those units instead...
@@ -1396,15 +1396,15 @@ export class GridStack {
   /** @internal */
   public locked(els: GridStackElement, locked: boolean): GridStack { return this.update(els, {locked}) }
   /** @internal */
-  public maxWidth(els: GridStackElement, maxWidth: number): GridStack { return this.update(els, {maxWidth}) }
+  public maxW(els: GridStackElement, maxW: number): GridStack { return this.update(els, {maxW}) }
   /** @internal */
-  public minWidth(els: GridStackElement, minWidth: number): GridStack {  return this.update(els, {minWidth}) }
+  public minW(els: GridStackElement, minW: number): GridStack {  return this.update(els, {minW}) }
   /** @internal */
-  public maxHeight(els: GridStackElement, maxHeight: number): GridStack { return this.update(els, {maxHeight}) }
+  public maxH(els: GridStackElement, maxH: number): GridStack { return this.update(els, {maxH}) }
   /** @internal */
-  public minHeight(els: GridStackElement, minHeight: number): GridStack { return this.update(els, {minHeight}) }
+  public minH(els: GridStackElement, minH: number): GridStack { return this.update(els, {minH}) }
   /** @internal */
   public move(els: GridStackElement, x?: number, y?: number): GridStack { return this.update(els, {x, y}) }
   /** @internal */
-  public resize(els: GridStackElement, width?: number, height?: number): GridStack { return this.update(els, {width, height}) }
+  public resize(els: GridStackElement, w?: number, h?: number): GridStack { return this.update(els, {w, h}) }
 }

--- a/src/h5/dd-draggable.ts
+++ b/src/h5/dd-draggable.ts
@@ -24,7 +24,7 @@ export interface DDDraggableOpt {
   drag?: (event: Event, ui: DDUIData) => void;
 }
 
-export interface DragOffset {
+interface DragOffset {
   left: number;
   top: number;
   width: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,19 +187,19 @@ export interface GridStackWidget {
   /** widget position y (default?: 0) */
   y?: number;
   /** widget dimension width (default?: 1) */
-  width?: number;
+  w?: number;
   /** widget dimension height (default?: 1) */
-  height?: number;
+  h?: number;
   /** if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) */
   autoPosition?: boolean;
   /** minimum width allowed during resize/creation (default?: undefined = un-constrained) */
-  minWidth?: number;
+  minW?: number;
   /** maximum width allowed during resize/creation (default?: undefined = un-constrained) */
-  maxWidth?: number;
+  maxW?: number;
   /** minimum height allowed during resize/creation (default?: undefined = un-constrained) */
-  minHeight?: number;
+  minH?: number;
   /** maximum height allowed during resize/creation (default?: undefined = un-constrained) */
-  maxHeight?: number;
+  maxH?: number;
   /** prevent resizing (default?: undefined = un-constrained) */
   noResize?: boolean;
   /** prevents moving (default?: undefined = un-constrained) */
@@ -308,9 +308,9 @@ export interface GridStackNode extends GridStackWidget {
   /** @internal */
   _lastTriedY?: number;
   /** @internal */
-  _lastTriedWidth?: number;
+  _lastTriedW?: number;
   /** @internal */
-  _lastTriedHeight?: number;
+  _lastTriedH?: number;
   /** @internal */
   _isAboutToRemove?: boolean;
   /** @internal */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@
 import { GridStackElement, GridStackWidget, GridStackNode, GridStackOptions, numberOrString } from './types';
 
 export interface HeightData {
-  height: number;
+  h: number;
   unit: string;
 }
 
@@ -96,7 +96,7 @@ export class Utils {
 
   /** returns true if a and b overlap */
   static isIntercepted(a: GridStackWidget, b: GridStackWidget): boolean {
-    return !(a.x + a.width <= b.x || b.x + b.width <= a.x || a.y + a.height <= b.y || b.y + b.height <= a.y);
+    return !(a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y);
   }
 
   /**
@@ -107,7 +107,7 @@ export class Utils {
    **/
   static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
     if (!column) {
-      let widths = nodes.map(n => n.x + n.width);
+      let widths = nodes.map(n => n.x + n.w);
       column = Math.max(...widths);
     }
 
@@ -177,7 +177,7 @@ export class Utils {
   }
 
   static parseHeight(val: numberOrString): HeightData {
-    let height: number;
+    let h: number;
     let unit = 'px';
     if (typeof val === 'string') {
       let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
@@ -185,11 +185,11 @@ export class Utils {
         throw new Error('Invalid height');
       }
       unit = match[2] || 'px';
-      height = parseFloat(match[1]);
+      h = parseFloat(match[1]);
     } else {
-      height = val;
+      h = val;
     }
-    return { height, unit };
+    return { h, unit };
   }
 
   /** copies unset fields in target to use the given default sources values */


### PR DESCRIPTION
### Description
* just like the attributes shortening, Grid Item position are now
x,y,w,h with shorter min/maxW|H
* this and prev change end up saving 2k on gridstack-h5.js output file!
(now only 63.2k)
* hard to change as not simple global replace, as width|height are still
used in CSS and rect, etc....

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
