### PR TITLE
W side resize and maxW fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -46,6 +46,7 @@ Change log
 ## 3.1.0-dev
 
 - fix [1419](https://github.com/gridstack/gridstack.js/issues/1419) dragging into a fixed row grid works better (check if it will fit, else try to append, else won't insert)
+- fix [1330](https://github.com/gridstack/gridstack.js/issues/1330) `maxW` does not work as intended with resizable handle `"w"`
 
 ## 3.1.0 (2020-12-4)
 

--- a/spec/e2e/html/1330-maxw-left-resize.html
+++ b/spec/e2e/html/1330-maxw-left-resize.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>resize maxW</title>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-h5.js"></script>
+</head>
+<body>
+  <div class="container-fluid">
+    <p>resize to left with maxW set</p>
+    <div class="grid-stack"></div>
+  </div>
+  <script src="../../../demo/events.js"></script>
+  <script type="text/javascript">
+    let grid = GridStack.init({resizable: { handles: 'sw, se, w, e, s' }});
+    addEvents(grid);
+    grid.load([{x: 2, y: 0, maxW: 1, content: 'max 1'}, {x: 5, y: 0, maxW: 2, content: 'max 2'}]);
+  </script>
+</body>
+</html>

--- a/src/h5/dd-resizable.ts
+++ b/src/h5/dd-resizable.ts
@@ -242,13 +242,13 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     const reshape = this._getReShapeSize(newRect.width, newRect.height);
     if (newRect.width !== reshape.width) {
       if (dir.indexOf('w') > -1) {
-        newRect.left += reshape.width - newRect.width;
+        newRect.left += newRect.width - reshape.width;
       }
       newRect.width = reshape.width;
     }
     if (newRect.height !== reshape.height) {
       if (dir.indexOf('n') > -1) {
-        newRect.top += reshape.height - newRect.height;
+        newRect.top += newRect.height - reshape.height;
       }
       newRect.height = reshape.height;
     }
@@ -274,7 +274,8 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
       const { left, top } = containmentEl.getBoundingClientRect();
       containmentRect = { left, top, width: 0, height: 0 };
     }
-    Object.keys(this.temporalRect || this.originalRect).forEach(key => {
+    if (!this.temporalRect) return this;
+    Object.keys(this.temporalRect).forEach(key => {
       const value = this.temporalRect[key];
       this.el.style[key] = value - containmentRect[key] + 'px';
     });


### PR DESCRIPTION
### Description
fix #1330
* we now set maxWidth/maxHeight to prevent grid item from resizing past their size
* fixed code to prevent item from moving left when they reach max width
* added sample test case

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
