### PR TITLE
support all options for new dragged in widgets

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -50,16 +50,14 @@
     <div class="row">
       <div class="col-md-3">
         <div class="sidebar">
-          
           <!-- will size to match content -->
           <div class="grid-stack-item">
             <div class="grid-stack-item-content">Drag me</div>
           </div>
           <!-- manually force a drop size of 2x1 -->
-          <div class="grid-stack-item" gs-w="2" gs-h="1">
-            <div class="grid-stack-item-content">Drag me 2x1</div>
+          <div class="grid-stack-item" gs-w="2" gs-h="1" gs-max-w="3">
+            <div class="grid-stack-item-content">2x1, max=3</div>
           </div>
-
         </div>
       </div>
       <div class="col-md-9">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -46,7 +46,12 @@ Change log
 ## 3.1.0-dev
 
 - fix [1419](https://github.com/gridstack/gridstack.js/issues/1419) dragging into a fixed row grid works better (check if it will fit, else try to append, else won't insert)
+-- **possible BREAK** (unlikely you use engine directly)
+* engine constructor takes Options struct rather than spelling arguments (easier to extend/use)
+* `canBePlacedWithRespectToHeight()` -> `willItFit()` like grid method
+
 - fix [1330](https://github.com/gridstack/gridstack.js/issues/1330) `maxW` does not work as intended with resizable handle `"w"`
+- fix [1472](https://github.com/gridstack/gridstack.js/issues/1472) support all options for new dragged in widgets (read all `gs-xyz` attributes)
 
 ## 3.1.0 (2020-12-4)
 

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -130,18 +130,15 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
     })
     .on(this.el, 'dropover', (event, el: GridItemHTMLElement) => {
       // ignore drop enter on ourself, and prevent parent from receiving event
-      let node = el.gridstackNode || {};
-      if (node.grid === this) {
+      let node = el.gridstackNode;
+      if (node && node.grid === this) {
         delete node._added; // reset this to track placeholder again in case we were over other grid #1484 (dropout doesn't always clear)
         return false;
       }
 
-      // see if we already have a node with widget/height and check for attributes
-      if (el.getAttribute && (!node.w || !node.h)) {
-        let w = parseInt(el.getAttribute('gs-w'));
-        if (w > 0) { node.w = w; }
-        let h = parseInt(el.getAttribute('gs-h'));
-        if (h > 0) { node.h = h; }
+      // load any element attributes if we don't have a node
+      if (!node) {
+        node = this._readAttr(el);
       }
 
       // if the item came from another grid, let it know it was added here to removed duplicate shadow #393

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1307,7 +1307,8 @@ export class GridStack {
   }
 
   /** @internal call to read any default attributes from element */
-  private _readAttr(el: HTMLElement, node: GridStackNode = {}): GridStackWidget {
+  private _readAttr(el: HTMLElement): GridStackWidget {
+    let node: GridStackNode = {};
     node.x = Utils.toNumber(el.getAttribute('gs-x'));
     node.y = Utils.toNumber(el.getAttribute('gs-y'));
     node.w = Utils.toNumber(el.getAttribute('gs-w'));


### PR DESCRIPTION
### Description
* fix #1472
* drag over now loads all widget attributes if we don't have a node
(dragged from toolbar)

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
