### PR TITLE
call batchUpdate() on init load

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [3.1.2-dev](#312-dev)
 - [3.1.2 (2020-12-7)](#312-2020-12-7)
 - [3.1.0 (2020-12-4)](#310-2020-12-4)
 - [3.0.0 (2020-11-29)](#300-2020-11-29)
@@ -42,6 +43,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 3.1.2-dev
+
+- fix [1535](https://github.com/gridstack/gridstack.js/issues/1535) use batchUpdate() around grid init to make sure gs-y attributes are respected.
 
 ## 3.1.2 (2020-12-7)
 

--- a/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
+++ b/spec/e2e/html/1017-items-no-x-y-for-autoPosition.html
@@ -1,6 +1,6 @@
 <!-- 
   grid items have no x,y position, just size. Used to come up with wrong size and overlap. https://github.com/gridstack/gridstack.js/issues/1017
-  Now, will have element 5 (autoPosition but small x,y), 1,2,4, then 3 (too big to fit)
+  Now, will have element 5 (position first with small x,y), 1,2,4, then 3 (too big to fit)
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -35,7 +35,7 @@
     <div class="grid-stack-item" gs-w="3" gs-h="1" gs-id="4">
       <div class="grid-stack-item-content">item 4</div>
     </div>
-    <div class="grid-stack-item" gs-x="1" gs-y="1" gs-w="1" gs-h="1" gs-id="5" gs-auto-position="false">
+    <div class="grid-stack-item" gs-x="1" gs-y="1" gs-w="1" gs-h="1" gs-id="5">
       <div class="grid-stack-item-content">item 5 first</div>
     </div>
   </div>

--- a/spec/e2e/html/1535-out-of-order.html
+++ b/spec/e2e/html/1535-out-of-order.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Out of order</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-h5.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Out of order demo</h1>
+    <div class="grid-stack">
+      <div class="grid-stack-item" gs-x="0" gs-y="2" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">2</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="1" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">1</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">0</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="4" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">4</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="5" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">5</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="6" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">6</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="7" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">7</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="11" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">11</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="8" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">8</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="9" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">9</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="12" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">12</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="10" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">10</span>
+        </div>
+      </div>
+      <div class="grid-stack-item" gs-x="0" gs-y="3" gs-w="12" gs-h="1">
+        <div class="grid-stack-item-content">
+          This should be at position <span class="order-number">3</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="events.js"></script>
+  <script type="text/javascript">
+  GridStack.init({cellHeight: 70});
+  </script>
+</body>
+</html>

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -312,6 +312,7 @@ export class GridStack {
     });
 
     if (this.opts.auto) {
+      this.batchUpdate(); // prevent in between re-layout #1535 TODO: this only set float=true, need to prevent collision check...
       let elements: {el: HTMLElement; i: number}[] = [];
       this.getGridItems().forEach(el => {
         let x = parseInt(el.getAttribute('gs-x'));
@@ -322,7 +323,8 @@ export class GridStack {
           i: (Number.isNaN(x) ? 1000 : x) + (Number.isNaN(y) ? 1000 : y) * this.opts.column
         });
       });
-      elements.sort(e => e.i).forEach(item => { this._prepareElement(item.el) });
+      elements.sort(e => e.i).forEach(e => this._prepareElement(e.el));
+      this.commit();
     }
     this.engine.saveInitial(); // initial start of items
 


### PR DESCRIPTION
### Description
* fix #1535
* make sure to call batchUpdate() on init load to preserve gs-y values

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
