### PR TITLE
fixed no-drop cursor on windows

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -46,12 +46,12 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## 3.1.3-dev
 
-- TBD
+- fix [1557](https://github.com/gridstack/gridstack.js/pull/1557) fixed no-drop cursor on windows when dragging within a default grid (no external drag in)
 
 ## 3.1.3 (2021-1-2)
 
-- fix [1535](https://github.com/gridstack/gridstack.js/issues/1535) use batchUpdate() around grid init to make sure gs-y attributes are respected.
 - fix [1540](https://github.com/gridstack/gridstack.js/issues/1540) Safari H5 drag&drop fixed
+- fix [1535](https://github.com/gridstack/gridstack.js/issues/1535) use batchUpdate() around grid init to make sure gs-y attributes are respected.
 - fix [1545](https://github.com/gridstack/gridstack.js/issues/1545) `disableMove()` correctly prevents drag later (remove events and draggable attribute)
 - fix [1546](https://github.com/gridstack/gridstack.js/issues/1546) resize no longer delayed, which caused race conditions errors
 - fix [1001](https://github.com/gridstack/gridstack.js/issues/1001) resizing near bottom/top needs to auto-scroll/. thanks [@hbcarlos](https://github.com/hbcarlos)!

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -77,7 +77,16 @@ export abstract class GridStackDD extends GridStackDDI {
 
 /** @internal called to add drag over support to support widgets */
 GridStack.prototype._setupAcceptWidget = function(): GridStack {
-  if (this.opts.staticGrid || !this.opts.acceptWidgets) return this;
+  if (this.opts.staticGrid) return this;
+
+  // if we don't accept external widgets (default) we still need to accept dragging within our
+  // list of items (else we get a no-drop icon on windows)
+  if (!this.opts.acceptWidgets) {
+    GridStackDD.get().droppable(this.el, {
+      accept: (el: GridItemHTMLElement) => el.gridstackNode && el.gridstackNode.grid === this
+    })
+    return this;
+  }
 
   let onDrag = (event, el: GridItemHTMLElement) => {
     let node = el.gridstackNode;


### PR DESCRIPTION
### Description
* fixed no-drop cursor on windows when dragging within a default grid (no external drag in)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
