### PR TITLE
better drag-out/in from below, cellHeight() CSS fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -49,6 +49,7 @@ Change log
 
 - fix [1572](https://github.com/gridstack/gridstack.js/issues/1572) `column: N` option now sets CSS class
 - fix [1571](https://github.com/gridstack/gridstack.js/issues/1571) don't allow drop when grid is full
+- fix [1570](https://github.com/gridstack/gridstack.js/issues/1570) easier to drag out/in from below
 
 ## 3.1.4 (2021-1-11)
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -50,6 +50,7 @@ Change log
 - fix [1572](https://github.com/gridstack/gridstack.js/issues/1572) `column: N` option now sets CSS class
 - fix [1571](https://github.com/gridstack/gridstack.js/issues/1571) don't allow drop when grid is full
 - fix [1570](https://github.com/gridstack/gridstack.js/issues/1570) easier to drag out/in from below
+- fix [1579](https://github.com/gridstack/gridstack.js/issues/1579) `cellHeight()` not updating CSS correctly
 
 ## 3.1.4 (2021-1-11)
 

--- a/spec/e2e/html/1570_drag_bottom_max_row.html
+++ b/spec/e2e/html/1570_drag_bottom_max_row.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>drop onto full</title>
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
   <link rel="stylesheet" href="../../../dist/gridstack.min.css"/>
   <script src="../../../dist/gridstack-h5.js"></script>
 
@@ -89,7 +88,7 @@
   let options2 = {
     disableOneColumnMode: true,
     minRow: 3,
-    // maxRow: 3, // change this to show issue
+    maxRow: 3, // change this to show issue
     acceptWidgets: true,
     removable: true,
     removeTimeout: 0,

--- a/spec/e2e/html/1572_one_column.html
+++ b/spec/e2e/html/1572_one_column.html
@@ -30,7 +30,7 @@
     let count = 0;
     let items = [{x: 0, y: 0, w: 1, h:1, content: String(count++)}];
 
-    let grid = GridStack.init({column: 1});
+    let grid = GridStack.init({column: 1, minRow: 1});
     grid.load(items);
     addEvents(grid);
 

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -392,7 +392,7 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
   /** called when item is being dragged/resized */
   let dragOrResize = (event: Event, ui: DDUIData): void => {
     let x = Math.round(ui.position.left / cellWidth);
-    let y = Math.floor((ui.position.top + cellHeight / 2) / cellHeight);
+    let y = Math.round(ui.position.top / cellHeight);
     let w: number;
     let h: number;
 
@@ -401,7 +401,7 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
       node._prevYPix = ui.position.top;
       Utils.updateScrollPosition(el, ui.position, distance);
       // if inTrash, outside of the bounds or added to another grid (#393) temporarily remove it from us
-      if (el.dataset.inTrashZone || x < 0 || x >= this.engine.column || y < 0 || (!this.engine.float && y > this.engine.getRow()) || node._added) {
+      if (el.dataset.inTrashZone || node._added || this.engine.isOutside(x, y, node)) {
         if (node._temporaryRemoved) return;
         if (this.opts.removable === true) {
           this._setupRemovingTimeout(el);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -582,7 +582,7 @@ export class GridStack {
     this.opts.cellHeight = data.h;
 
     if (update) {
-      this._updateStyles(true); // true = force re-create
+      this._updateStyles(true, this.getRow()); // true = force re-create, for that # of rows
     }
     this._resizeNestedGrids(this.el);
     return this;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,8 +147,7 @@ export class Utils {
   /** removed the given stylesheet id */
   static removeStylesheet(id: string): void {
     let el = document.querySelector('STYLE[gs-style-id=' + id + ']');
-    if (!el || !el.parentNode) return;
-    el.parentNode.removeChild(el);
+    if (el && el.parentNode) el.remove();
   }
 
   /** inserts a CSS rule */


### PR DESCRIPTION
### Description
better drag-out/in from below heuristics

* fix #1570
* we now have code to check if dragging outside of the grid (`engine.isOutside()`) which
checks for items past maxRow or added as last row in a real position vs being dragged out.

fix cellHeight() updating CSS for # of rows

* fix #1579
* make sure to re-create the CSS with actual number of rows needed when changing cell heights
* 
### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
