### PR TITLE
H5 draggable by actual div handle

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -51,6 +51,7 @@ Change log
 - fix [1571](https://github.com/gridstack/gridstack.js/issues/1571) don't allow drop when grid is full
 - fix [1570](https://github.com/gridstack/gridstack.js/issues/1570) easier to drag out/in from below
 - fix [1579](https://github.com/gridstack/gridstack.js/issues/1579) `cellHeight()` not updating CSS correctly
+- fix [1581](https://github.com/gridstack/gridstack.js/issues/1581) H5 draggable by actual div handle rather than entire item (let content respond to drag as well)
 
 ## 3.1.4 (2021-1-11)
 

--- a/spec/e2e/html/1581_drag_by_header_h5.html
+++ b/spec/e2e/html/1581_drag_by_header_h5.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>drag by header</title>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-h5.js"></script>
+  <script src="https://raw.githack.com/SortableJS/Sortable/master/Sortable.js"></script>
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>dragging by header not conflicting with content drag (Sortable.js)</h1>
+    <h3>sortable.js only</h3>
+    <div>
+      <div id="widgetcontent2" class="list-group"> 
+        <div class="list-group-item"> MOVE ME !!!! 11111 11111</div> 
+        <div class="list-group-item"> MOVE ME !!!! 22222 22222</div> 
+        <div class="list-group-item"> MOVE ME !!!! 33333 33333</div> 
+      </div>
+    </div>
+  <br>
+  <div class="grid-stack"></div>
+    
+  </div>
+  <script type="text/javascript">
+//Example Widget HTML Data
+var html = '\
+  <div class="grid-stack-item"> \
+    <div class="grid-stack-item-content" > \
+      <div class="widgetheader">drag me here</div> \
+      <div id="gridstackwidgetcontent" class="list-group"> \
+        <div class="list-group-item"> MOVE ME !!!! 11111 11111</div> \
+        <div class="list-group-item"> MOVE ME !!!! 22222 22222</div> \
+        <div class="list-group-item"> MOVE ME !!!! 33333 33333</div> \
+      </div> \
+    </div> \
+  </div>';
+    
+  var options = {
+    float: true, 
+    draggable: { handle: '.widgetheader' }
+  };
+  let grid = GridStack.init(options);
+  grid.addWidget(html, {w:2, h:1, x:0, y:0});
+  Sortable.create(gridstackwidgetcontent);
+  Sortable.create(widgetcontent2);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Description
* fix #1581
* set `draggabble` to actual div handle rather than entire item so content can also respond to dragging.
* no longer need to have` mousedown` to check for click on actual drag area...
* added demo test

### Checklist
- [X Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
