### PR TITLE
Add array sort compareFunction to keep items respective DOM order in Firefox

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -344,7 +344,7 @@ export class GridStack {
           i: (Number.isNaN(x) ? 1000 : x) + (Number.isNaN(y) ? 1000 : y) * this.opts.column
         });
       });
-      elements.sort(e => e.i).forEach(e => this._prepareElement(e.el));
+      elements.sort((a, b) => a.i - b.i).forEach(e => this._prepareElement(e.el));
       this.commit();
     }
     this.engine.saveInitial(); // initial start of items


### PR DESCRIPTION
### Description
grid-stack-items does not keep their respective DOM order if x,y declarations are missing (autoPosition) in Firefox.
The array sort order is implementation-defined if their is not a consistent comparison function for the elements of items:
https://tc39.es/ecma262/#sec-array.prototype.sort

Following simple example shows an reversed order of the grid-stack-items in Firefox than they appear in the DOM:
https://jsbin.com/yitiputuqe/1/edit?html,output

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
