### PR TITLE
drag | resize events tweaks

### DIFF
--- a/demo/events.js
+++ b/demo/events.js
@@ -7,6 +7,11 @@ function addEvents(grid, id) {
     console.log(g + event.type + ' ' + items.length + ' items (x,y w h):' + str );
   });
 
+  grid.on('enable', function(event) {
+    let grid = event.target;
+    console.log(g + 'enable');
+  });
+
   grid.on('disable', function(event) {
     let grid = event.target;
     console.log(g + 'disable');
@@ -14,23 +19,23 @@ function addEvents(grid, id) {
 
   grid.on('dragstart', function(event, el) {
     let node = el.gridstackNode;
-    let x = el.getAttribute('gs-x');
-    let y= el.getAttribute('gs-y');
-    console.log(g + 'dragstart ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') vs (' + x + ',' + y + ')');
+    let x = el.getAttribute('gs-x'); // verify node (easiest) and attr are the same
+    let y = el.getAttribute('gs-y');
+    console.log(g + 'dragstart ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') = (' + x + ',' + y + ')');
   });
 
   grid.on('drag', function(event, el) {
     let node = el.gridstackNode;
-    let x = el.getAttribute('gs-x');
-    let y= el.getAttribute('gs-y');
-    console.log(g + 'drag ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') vs (' + x + ',' + y + ')');
+    let x = el.getAttribute('gs-x'); // verify node (easiest) and attr are the same
+    let y = el.getAttribute('gs-y');
+    console.log(g + 'drag ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') = (' + x + ',' + y + ')');
   });
 
   grid.on('dragstop', function(event, el) {
     let node = el.gridstackNode;
-    let x = el.getAttribute('gs-x');
-    let y= el.getAttribute('gs-y');
-    console.log(g + 'dragstop ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') vs (' + x + ',' + y + ')');
+    let x = el.getAttribute('gs-x'); // verify node (easiest) and attr are the same
+    let y = el.getAttribute('gs-y');
+    console.log(g + 'dragstop ' + el.textContent + ' pos: (' + node.x + ',' + node.y + ') = (' + x + ',' + y + ')');
   });
 
   grid.on('dropped', function(event, previousWidget, newWidget) {
@@ -42,25 +47,24 @@ function addEvents(grid, id) {
     }
   });
 
-  grid.on('enable', function(event) {
-    let grid = event.target;
-    console.log(g + 'enable');
-  });
-
   grid.on('resizestart', function(event, el) {
-    let w = el.getAttribute('gs-w');
+    let node = el.gridstackNode;
+    let w = el.getAttribute('gs-w');  // verify node (easiest) and attr are the same
     let h = el.getAttribute('gs-h');
-    console.log(g + 'resizestart ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
+    console.log(g + 'resizestart ' + el.textContent + ' size: (' + node.w + 'x' + node.h + ') = (' + w + 'x' + h + ')');
   });
 
   grid.on('resize', function(event, el) {
     let node = el.gridstackNode;
-    console.log(g + 'resize ' + el.textContent + ' size: (' + node.w + ' x ' + node.h + ')');
+    let w = el.getAttribute('gs-w');  // verify node (easiest) and attr are the same
+    let h = el.getAttribute('gs-h');
+    console.log(g + 'resize ' + el.textContent + ' size: (' + node.w + 'x' + node.h + ') = (' + w + 'x' + h + ')');
   });
 
   grid.on('resizestop', function(event, el) {
-    let w = el.getAttribute('gs-w');
+    let node = el.gridstackNode;
+    let w = el.getAttribute('gs-w'); // verify node (easiest) and attr are the same
     let h = el.getAttribute('gs-h');
-    console.log(g + 'resizestop ' + el.textContent + ' size: (' + w + ' x ' + h + ')');
+    console.log(g + 'resizestop ' + el.textContent + ' size: (' + node.w + 'x' + node.h + ') = (' + w + 'x' + h + ')');
   });
 }

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -54,6 +54,7 @@ Change log
 - Dragging up and down now behave the same (used to require push WAY down past to swap/append). Also much more efficient collision code.
 - handle mid point of dragged over items (>50%) rather than a new row/column and check for the most covered when multiple items collide.
 - fix [1617](https://github.com/gridstack/gridstack.js/issues/1617) FireFox DOM order issue. Thanks [@marcel-necker](https://github.com/marcel-necker)
+- add `drag | resize` events while dragging [1616](https://github.com/gridstack/gridstack.js/pull/1616). Thanks [@MrCorba](https://github.com/MrCorba)
 
 ## 3.3.0 (2021-2-2)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -193,10 +193,10 @@ grid.on('dragstart', function(event: Event, el: GridItemHTMLElement) {
 
 ### drag(event, el)
 
-called when grid item is dragged
+called while grid item is being dragged, for each new row/column value (not every pixel)
 
 ```js
-grid.on('dragstart', function(event: Event, el: GridItemHTMLElement) {
+grid.on('drag', function(event: Event, el: GridItemHTMLElement) {
 });
 ```
 
@@ -251,7 +251,7 @@ grid.on('resizestart', function(event: Event, el: GridItemHTMLElement) {
 
 ### resize(event, el)
 
-called while the user is resizing an item
+called while grid item is being resized, for each new row/column value (not every pixel)
 
 ```js
 grid.on('resize', function(event: Event, el: GridItemHTMLElement) {

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -399,7 +399,6 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
     let w = node.w;
     let h = node.h;
     let resizing: boolean;
-    let target: GridItemHTMLElement = event.target as GridItemHTMLElement;
 
     if (event.type === 'drag') {
       let distance = ui.position.top - node._prevYPix;
@@ -461,11 +460,12 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
       delete node._skipDown;
       if (resizing && node.subGrid) { (node.subGrid as GridStack).onParentResize(); }
       this._updateContainerHeight();
-    }
-    this._writePosAttr(target, node.x, node.y, node.w, node.h);
 
-    if (this._gsEventHandler[event.type]) {
-      this._gsEventHandler[event.type](event, target);
+      let target = event.target as GridItemHTMLElement;
+      this._writePosAttr(target, node.x, node.y, node.w, node.h);
+      if (this._gsEventHandler[event.type]) {
+        this._gsEventHandler[event.type](event, target);
+      }
     }
   }
 


### PR DESCRIPTION
### Description
fixes to #1616 for new `drag|resize event` - only call when they change.
Updated docs

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
