### PR TITLE
collision: re-pack in middle of collision

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -202,10 +202,8 @@ export interface GridStackMoveOpts extends GridStackPosition {
   pack?: boolean;
   /** do we verify for bad or > max/min values (default true) */
   sanitize?: boolean;
-  /** true if we just want to push down (skip swapping) - default false*/
-  disableSwap?: boolean;
-  /** true if we just want simple row/column overlap vs checking >50% coverage - default false*/
-  disableCoverage?: boolean;
+  /** true if we are calling this recursively to prevent simple swap or coverage collision - default false*/
+  nested?: boolean;
   /* vars to calculate other cells coordinates */
   cellWidth?: number;
   cellHeight?: number;


### PR DESCRIPTION
### Description
in order to improve #1094 behavior, we may now do a partial repack after we moved an item below
keeping the original wanted location so we can try again
and push items out of the way.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
