### PR TITLE
Collision: part3 making drop-in rewrite

### DIFF
--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -390,6 +390,7 @@ export class GridStackEngine {
 
   /** call to add the given node to our list, fixing collision and re-packing */
   public addNode(node: GridStackNode, triggerAddEvent = false): GridStackNode {
+    if (this.nodes.find(n => n._id === node._id)) return; // prevent inserting twice!
     node = this.prepareNode(node);
 
     if (node.autoPosition) {
@@ -511,6 +512,7 @@ export class GridStackEngine {
 
   /** return true if the passed in node (x,y) is being dragged outside of the grid, and not added to bottom */
   public isOutside(x: number, y: number, node: GridStackNode): boolean {
+    if (node._isOutOfGrid) return false; // dragging out is handled by 'dropout' event instead
     // simple outside boundaries
     if (x < 0 || x >= this.column || y < 0) return true;
     if (this.maxRow) return (y >= this.maxRow);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -8,7 +8,8 @@
 
 import { GridStackEngine } from './gridstack-engine';
 import { obsoleteOpts, obsoleteAttr, Utils, HeightData } from './utils';
-import { ColumnOptions, GridItemHTMLElement, GridStackElement, GridStackEventHandlerCallback, GridStackNode, GridStackOptions, GridStackWidget, numberOrString } from './types';
+import { ColumnOptions, GridItemHTMLElement, GridStackElement, GridStackEventHandlerCallback,
+  GridStackNode, GridStackOptions, GridStackWidget, numberOrString, DDUIData } from './types';
 import { GridStackDDI } from './gridstack-ddi';
 
 // export all dependent file as well to make it easier for users to just import the main file
@@ -569,11 +570,12 @@ export class GridStack {
        (!forcePixel || !this.opts.cellHeightUnit || this.opts.cellHeightUnit === 'px')) {
       return this.opts.cellHeight as number;
     }
-    // else get first cell height
-    // or do entire grid and # of rows ? (this.el.getBoundingClientRect().height) / parseInt(this.el.getAttribute('gs-current-row'))
-    let el = this.el.querySelector('.' + this.opts.itemClass) as HTMLElement;
-    let height = Utils.toNumber(el.getAttribute('gs-h'));
-    return Math.round(el.offsetHeight / height);
+    // else do entire grid and # of rows
+    // or get first cell height ?
+    // let el = this.el.querySelector('.' + this.opts.itemClass) as HTMLElement;
+    // let height = Utils.toNumber(el.getAttribute('gs-h'));
+    // return Math.round(el.offsetHeight / height);
+    return Math.round(this.el.getBoundingClientRect().height) / parseInt(this.el.getAttribute('gs-current-row'));
   }
 
   /**
@@ -1513,6 +1515,10 @@ export class GridStack {
   public _setupDragIn():  GridStack { return this }
   /** @internal prepares the element for drag&drop **/
   public _prepareDragDropByNode(node: GridStackNode): GridStack { return this }
+  /** @internal handles actual drag/resize start **/
+  public _onStartMoving(event: Event, ui: DDUIData, node: GridStackNode, cellWidth: number, cellHeight: number): void { return }
+  /** @internal handles actual drag/resize **/
+  public _dragOrResize(event: Event, ui: DDUIData, node: GridStackNode, cellWidth: number, cellHeight: number): void { return }
 
   // 2.x API that just calls the new and better update() - keep those around for backward compat only...
   /** @internal */

--- a/src/h5/dd-base-impl.ts
+++ b/src/h5/dd-base-impl.ts
@@ -38,11 +38,8 @@ export abstract class DDBaseImplement {
   }
 
   public triggerEvent(eventName: string, event: Event): boolean|void {
-    if (this.disabled) return;
-    if (!this._eventRegister) {return; } // used when destroy before triggerEvent fire
-    if (this._eventRegister[eventName]) {
+    if (!this.disabled && this._eventRegister && this._eventRegister[eventName])
       return this._eventRegister[eventName](event);
-    }
   }
 }
 

--- a/src/h5/dd-draggable.ts
+++ b/src/h5/dd-draggable.ts
@@ -73,7 +73,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     this._dragStart = this._dragStart.bind(this);
     this._drag = this._drag.bind(this);
     this._dragEnd = this._dragEnd.bind(this);
-    this._dragFollow = this._dragFollow.bind(this);
     this.enable();
   }
 

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -83,9 +83,11 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal called when the cursor enters our area - prepare for a possible drop and track leaving */
   private _dragEnter(event: DragEvent): void {
     if (!this._canDrop()) return;
+    event.preventDefault();
+
+    if (this.moving) return; // ignore multiple 'dragenter' as we go over existing items
     this.moving = true;
 
-    event.preventDefault();
     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dropover' });
     if (this.option.over) {
       this.option.over(ev, this._ui(DDManager.dragElement))
@@ -115,6 +117,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
       }
       this.triggerEvent('dropout', ev);
     }
+    delete this.moving;
   }
 
   /** @internal item is being dropped on us - call the client drop event */
@@ -127,6 +130,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
     }
     this.triggerEvent('drop', ev);
     this._removeLeaveCallbacks();
+    delete this.moving;
   }
 
   /** @internal called to remove callbacks when leaving or dropping */
@@ -137,6 +141,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
       this.el.removeEventListener('dragover', this._dragOver);
       this.el.removeEventListener('drop', this._drop);
     }
+    // Note: this.moving is reset by callee of this routine to control the flow
   }
 
   /** @internal */


### PR DESCRIPTION
### Description
* re-write on how dragging new objects in from the outside works.
It now re-uses the same drag collision code as in place,
so we check for 50% coverage and all that good stuff, with full helper
size info boundaries instead of the old way of mouse
cursor -> cell mapping.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
