### PR TITLE
collision: fix dragging long items from outside

### DIFF
--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -107,6 +107,7 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
       node.x = Math.max(0, Math.round(left / cellWidth));
       node.y = Math.max(0, Math.round(top / cellHeight));
       delete node.autoPosition;
+      this.engine.nodeBoundFix(node);
 
       // don't accept *initial* location if doesn't fit #1419 (locked drop region, or can't grow), but maybe try if it will go somewhere
       if (!this.engine.willItFit(node)) {
@@ -508,13 +509,13 @@ GridStack.prototype._dragOrResize = function(event: Event, ui: DDUIData, node: G
   let top = ui.position.top + (ui.position.top > node._lastUiPosition.top  ? -this.opts.marginBottom : this.opts.marginTop);
   let x = Math.round(left / cellWidth);
   let y = Math.round(top / cellHeight);
-  if (node._isOutOfGrid) {
-    // items coming from outside are handled by 'dragout' event instead, so make coordinates fit
-    x = Math.max(0, x);
-    y = Math.max(0, y);
-  }
   let w = node.w;
   let h = node.h;
+  if (node._isOutOfGrid) {
+    // items coming from outside are handled by 'dragout' event instead, so make coordinates fit
+    let fix = this.engine.nodeBoundFix({x, y, w, h});
+    x = fix.x; y = fix.y; w = fix.w; h = fix.h;
+  }
   let resizing: boolean;
 
   if (event.type === 'drag') {

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -315,6 +315,11 @@ export class GridStackEngine {
     if (node.minW) { node.w = Math.max(node.w, node.minW); }
     if (node.minH) { node.h = Math.max(node.h, node.minH); }
 
+    return this.nodeBoundFix(node, resizing);
+  }
+
+  /** part2 of preparing a node to fit inside our grid - checks  for x,y from grid dimensions */
+  public nodeBoundFix(node: GridStackNode, resizing?: boolean): GridStackNode {
     if (node.w > this.column) {
       node.w = this.column;
     } else if (node.w < 1) {


### PR DESCRIPTION
### Description
fix dragging long items from outside (ex two.html) - we now constrain to fit in grid as dragout event will tell us when we leave (not shape but cursor event)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
