### PR TITLE
drag in/out re-write

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Join us on Slack: https://gridstackjs.troolee.com
   - [Migrating to v1](#migrating-to-v1)
   - [Migrating to v2](#migrating-to-v2)
   - [Migrating to v3](#migrating-to-v3)
+  - [Migrating to v4](#migrating-to-v4)
 - [jQuery Application](#jquery-application)
 - [Changes](#changes)
 - [The Team](#the-team)
@@ -389,6 +390,30 @@ Breaking changes:
 4. item attribute like `data-gs-min-width` is now `gs-min-w`. We removed 'data-' from all attributes, and shorten 'width|height' to just 'w|h' to require less typing and more efficient (2k saved in .js alone!).
 
 5. `GridStackWidget` used in most API `width|height|minWidth|minHeight|maxWidth|maxHeight` are now shorter `w|h|minW|minH|maxW|maxH` as well
+
+## Migrating to v4
+
+make sure to read v3 migration first!
+
+v4 is a complete re-write of the collision and drag in/out heuristics to fix some very long standing request & bugs. It also greatly improved usability. Read the release notes for more detail.
+
+**Unlikely** Breaking Changes (internal usage):
+
+1. `removeTimeout` was removed (feedback over trash will be immediate - actual removal still on mouse up)
+
+2. the following `GridStackEngine` methods changed (used internally, doesn't affect `GridStack` public API)
+
+```js
+// moved to 3 methods with new option params to support new code and pixel coverage check
+`collision()` -> `collide(), collideAll(), collideCoverage()`
+`moveNodeCheck(node, x, y, w, h)` -> `moveNodeCheck(node, opt: GridStackMoveOpts)`
+`isNodeChangedPosition(node, x, y, w, h)` -> `changedPosConstrain(node, opt: GridStackMoveOpts)`
+`moveNode(node, x, y, w, h, noPack)` -> `moveNode(node, opt: GridStackMoveOpts)`
+```
+
+3. removed old obsolete (v0.6-v1 methods/attrs) `getGridHeight()`, `verticalMargin`, `data-gs-current-height`,
+`locked()`, `maxWidth()`, `minWidth()`, `maxHeight()`, `minHeight()`, `move()`, `resize()`
+
 
 # jQuery Application
 

--- a/demo/two-jq.html
+++ b/demo/two-jq.html
@@ -92,7 +92,6 @@
       dragIn: '.sidebar .grid-stack-item', // add draggable to class
       dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }, // clone
       removable: '.trash', // drag-out delete class
-      removeTimeout: 100,
       acceptWidgets: function(el) { return true; } // function example, else can be simple: true | false | '.someClass' value
     };
     grids = GridStack.initAll(options);

--- a/demo/two.html
+++ b/demo/two.html
@@ -90,7 +90,6 @@
       // dragIn: '.sidebar .grid-stack-item', // add draggable to class
       // dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }, // clone
       removable: '.trash', // drag-out delete class
-      removeTimeout: 100,
       acceptWidgets: function(el) { return true; } // function example, else can be simple: true | false | '.someClass' value
     };
     let grids = GridStack.initAll(options);

--- a/demo/web2.html
+++ b/demo/web2.html
@@ -62,7 +62,6 @@
       dragIn: '.newWidget',  // class that can be dragged from outside
       dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' },
       removable: '#trash', // drag-out delete class
-      removeTimeout: 100,
     });
 
     let items = [

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -50,13 +50,19 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## 3.3.0-dev
 
-- fix [#149](https://github.com/gridstack/gridstack.js/issues/149) [#1094](https://github.com/gridstack/gridstack.js/issues/1094) [#1605](https://github.com/gridstack/gridstack.js/issues/1605) re-write of the **collision code**! you can now swap items of the same size (vertical/horizontal) when grid is full, and is the default in `float:false` (top gravity) as it feels more natural. Could add Alt key for swap vs push behavior later.
-- Dragging up and down now behave the same (used to require push WAY down past to swap/append). Also much more efficient collision code.
-- handle mid point of dragged over items (>50%) rather than a new row/column and check for the most covered when multiple items collide.
+- fix [#149](https://github.com/gridstack/gridstack.js/issues/149) [#1094](https://github.com/gridstack/gridstack.js/issues/1094) [#1605](https://github.com/gridstack/gridstack.js/issues/1605) re-write of the **collision code - fixing 6 years old most requested request**
+1. you can now swap items of the same size (vertical/horizontal) when grid is full, and is the default in `float:false` (top gravity) as it feels more natural. Could add Alt key for swap vs push behavior later.
+2. Dragging up and down now behave the same (used to require push WAY down past to swap/append). Also much more efficient collision code.
+3. handle mid point of dragged over items (>50%) rather than just a new row/column and check for the most covered item when multiple collide.
+
+- fix [#393](https://github.com/gridstack/gridstack.js/issues/393) [#1612](https://github.com/gridstack/gridstack.js/issues/1612) [#1578](https://github.com/gridstack/gridstack.js/issues/1578) re-write of the **drag in/out code - fixing 5 years old bug**
+1. we now remove item when cursor leaves (`acceptWidgets` case using `dropout` event) or shape is outside (re-using same method) and re-insert on cursor enter (since we only get `dropover` event). Should **not be possible to have 2 placeholders** which confuses the grids.
+2. major re-write and cleanup of the drag in/out. Vars have been renamed and fully documented as I couldn't understand the legacy buggy code.
+3. removed any over trash delay feedback as I don't see the point and could introduce race conditions.
 - fix [1617](https://github.com/gridstack/gridstack.js/issues/1617) FireFox DOM order issue. Thanks [@marcel-necker](https://github.com/marcel-necker)
 - fix changing column # `column(n)` now resizes `cellHeight:'auto'` to keep square
-- add `drag | resize` events while dragging [1616](https://github.com/gridstack/gridstack.js/pull/1616). Thanks [@MrCorba](https://github.com/MrCorba)
-- add `GridStack.setupDragIn()` so user can update external draggable after the grid has been created [1637](https://github.com/gridstack/gridstack.js/issues/1637)
+- add [1616](https://github.com/gridstack/gridstack.js/pull/1616) `drag | resize` events while dragging. Thanks [@MrCorba](https://github.com/MrCorba)
+- add [1637](https://github.com/gridstack/gridstack.js/issues/1637) `GridStack.setupDragIn()` so user can update external draggable after the grid has been created
 
 ## 3.3.0 (2021-2-2)
 

--- a/spec/e2e/html/1570_drag_bottom_max_row.html
+++ b/spec/e2e/html/1570_drag_bottom_max_row.html
@@ -91,7 +91,6 @@
     maxRow: 3, // change this to show issue
     acceptWidgets: true,
     removable: true,
-    removeTimeout: 0,
     float: true
   }
 

--- a/spec/e2e/html/1571_drop_onto_full.html
+++ b/spec/e2e/html/1571_drop_onto_full.html
@@ -89,7 +89,6 @@
       dragIn: '.sidebar .grid-stack-item', // class that can be dragged from outside
       dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }, // clone
       removable: '.trash', // drag-out delete class
-      removeTimeout: 100,
       acceptWidgets: function(el) { return true; } // function example, else can be simple: true | false | '.someClass' value
     };
     let grids = GridStack.initAll(options);

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -359,7 +359,7 @@ describe('gridstack', function() {
       // back to 1 column, move item2 to beginning to [3][1][2] vertically
       grid.column(1);
       expect(grid.getColumn()).toBe(1);
-      grid.move(el3, 0, 0);
+      grid.update(el3, {x:0, y:0});
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
@@ -619,11 +619,7 @@ describe('gridstack', function() {
       let grid = GridStack.init();
       let items = Utils.getElements('.grid-stack-item');
       for (let i = 0; i < items.length; i++) {
-        grid
-          .minWidth(items[i], 2)
-          .maxWidth(items[i], 3)
-          .minHeight(items[i], 4)
-          .maxHeight(items[i], 5);
+        grid.update(items[i], {minW: 2, maxW: 3, minH: 4, maxH: 5});
       }
       for (let j = 0; j < items.length; j++) {
         expect(parseInt(items[j].getAttribute('gs-min-w'), 10)).toBe(2);
@@ -632,11 +628,7 @@ describe('gridstack', function() {
         expect(parseInt(items[j].getAttribute('gs-max-h'), 10)).toBe(5);
       }
       // remove all constrain
-      grid
-        .minWidth('grid-stack-item', 0)
-        .maxWidth('.grid-stack-item', null)
-        .minHeight('grid-stack-item', undefined)
-        .maxHeight(undefined, 0);
+      grid.update('grid-stack-item', {minW: 0, maxW: null, minH: undefined, maxH: 0});
       for (let j = 0; j < items.length; j++) {
         expect(items[j].getAttribute('gs-min-w')).toBe(null);
         expect(items[j].getAttribute('gs-max-w')).toBe(null);
@@ -1093,7 +1085,7 @@ describe('gridstack', function() {
       };
       let grid = GridStack.init(options);
       let items = Utils.getElements('.grid-stack-item');
-      grid.resize(items[0], 5, 5);
+      grid.update(items[0], {w:5, h:5});
       expect(parseInt(items[0].getAttribute('gs-w'), 10)).toBe(5);
       expect(parseInt(items[0].getAttribute('gs-h'), 10)).toBe(5);
     });
@@ -1114,7 +1106,7 @@ describe('gridstack', function() {
       };
       let grid = GridStack.init(options);
       let items = Utils.getElements('.grid-stack-item');
-      grid.move(items[0], 5, 5);
+      grid.update(items[0], {x:5, y:5});
       expect(parseInt(items[0].getAttribute('gs-x'), 10)).toBe(5);
       expect(parseInt(items[0].getAttribute('gs-y'), 10)).toBe(5);
     });
@@ -1549,7 +1541,7 @@ describe('gridstack', function() {
         margin: 5
       };
       let grid = GridStack.init(options);
-      grid.locked('.grid-stack-item', true);
+      grid.update('.grid-stack-item', {locked: true});
       Utils.getElements('.grid-stack-item').forEach(item => {
         expect(item.getAttribute('gs-locked')).toBe('true');
       })
@@ -1560,7 +1552,7 @@ describe('gridstack', function() {
         margin: 5
       };
       let grid = GridStack.init(options);
-      grid.locked('.grid-stack-item', false);
+      grid.update('.grid-stack-item', {locked: false});
       Utils.getElements('.grid-stack-item').forEach(item => {
         expect(item.getAttribute('gs-locked')).toBe(null);
       })

--- a/src/h5/dd-utils.ts
+++ b/src/h5/dd-utils.ts
@@ -37,7 +37,7 @@ export class DDUtils {
       parentNode = parent as HTMLElement;
     }
     if (parentNode) {
-      parentNode.append(el);
+      parentNode.appendChild(el);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,11 +165,8 @@ export interface GridStackOptions {
    */
   removable?: boolean | string;
 
-  /** allows to override UI removable options. (default?: { accept: '.' + opts.itemClass }) */
+  /** allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) */
   removableOptions?: DDRemoveOpt;
-
-  /** time in milliseconds before widget is being removed while dragging outside of the grid. (default?: 2000) */
-  removeTimeout?: number;
 
   /** fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) */
   row?: number;
@@ -321,18 +318,18 @@ export interface GridStackNode extends GridStackWidget {
   el?: GridItemHTMLElement;
   /** pointer back to Grid instance */
   grid?: GridStack;
-  /** @internal */
+  /** @internal internal id used to match when cloning engines or saving column layouts */
   _id?: number;
   /** @internal */
   _dirty?: boolean;
   /** @internal */
   _updating?: boolean;
-  /** @internal */
-  _added?: boolean;
-  /** @internal */
-  _temporary?: boolean;
-  /** @internal */
-  _isOutOfGrid?: boolean;
+  /** @internal true if the cursor is outside of the grid, as we get dropout/dropover vs shape being outside */
+  _isCursorOutside?: boolean;
+  /** @internal true when over trash/another grid so we don't bother removing drag CSS style that would animate back to old position */
+  _isAboutToRemove?: boolean;
+  /** @internal true if item came from outside of the grid -> actual item need to be moved over */
+  _isExternal?: boolean;
   /** @internal moving vs resizing */
   _moving?: boolean;
   /** @internal true if we jump down past item below (one time jump so we don't have to totally pass it) */
@@ -347,16 +344,14 @@ export interface GridStackNode extends GridStackWidget {
   _lastUiPosition?: Position;
   /** @internal set on the item being dragged/resized remember the last positions we've tried (but failed) so we don't try again during drag/resize */
   _lastTried?: GridStackPosition;
-  /** @internal */
+  /** @internal original Y when another item is dragged around a float=true so we can restore back as item is dragged around  */
   _packY?: number;
-  /** @internal */
-  _isAboutToRemove?: boolean;
-  /** @internal */
-  _removeTimeout?: number;
   /** @internal last drag Y pixel position used to incrementally update V scroll bar */
   _prevYPix?: number;
-  /** @internal */
+  /** @internal true if we've remove the item from ourself (dragging out) but might revert it back (release on nothing -> goes back) */
   _temporaryRemoved?: boolean;
+  /** @internal true if we should remove DOM element on _notify() rather than clearing _id (old way) */
+  _removeDOM?: boolean;
   /** @internal */
   _initDD?: boolean;
 }


### PR DESCRIPTION
### Description
- fix #393 #1612 #1578
- re-write of the **drag in/out code - fixing 5 years old bug**
1. we now remove item when cursor leaves (`acceptWidgets` case using `dropout` event) or shape is outside (re-using same method) and re-insert on cursor enter (since we only get `dropover` event). Should **not be possible to have 2 placeholders** which confuses the grids.
2. major re-write and cleanup of the drag in/out. Vars have been renamed and fully documented as I couldn't understand the legacy buggy code.
3. removed any over trash delay feedback as I don't see the point and could introduce race conditions.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
