### PR TITLE
collision: more edge case fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
-The MIT License (MIT)
+v4 Copyright (c) 2021 Alain Dumesny
+under MIT license
 
+previous v3.x and older is:
 Copyright (c) 2014-2020  Alain Dumesny, Dylan Weiss, Pavel Reznikov
+
+The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/demo/two.html
+++ b/demo/two.html
@@ -95,9 +95,9 @@
     let grids = GridStack.initAll(options);
     grids[1].float(true);
 
-    // new 4.x static method instead of setting up options on every grid (never been per grid really but old options still work)
+    // new 4.x static method instead of setting up options on every grid (never been per grid really) but old options still works
     GridStack.setupDragIn('.sidebar .grid-stack-item', { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' });
-    // GridStack.setupDragIn(); // will now work as well (cache last values)
+    // GridStack.setupDragIn(); // second call will now work (cache last values)
 
     let items = [
       {x: 0, y: 0, w: 2, h: 2},

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [3.3.0-dev](#330-dev)
+- [4.0.0](#400)
 - [3.3.0 (2021-2-2)](#330-2021-2-2)
 - [3.2.0 (2021-1-25)](#320-2021-1-25)
 - [3.1.5 (2021-1-23)](#315-2021-1-23)
@@ -48,9 +48,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-## 3.3.0-dev
+## 4.0.0
 
-- fix [#149](https://github.com/gridstack/gridstack.js/issues/149) [#1094](https://github.com/gridstack/gridstack.js/issues/1094) [#1605](https://github.com/gridstack/gridstack.js/issues/1605) re-write of the **collision code - fixing 6 years old most requested request**
+- fix [#149](https://github.com/gridstack/gridstack.js/issues/149) [#1094](https://github.com/gridstack/gridstack.js/issues/1094) [#1605](https://github.com/gridstack/gridstack.js/issues/1605) [#1534](https://github.com/gridstack/gridstack.js/issues/1534) re-write of the **collision code - fixing 6 years old most requested request**
 1. you can now swap items of the same size (vertical/horizontal) when grid is full, and is the default in `float:false` (top gravity) as it feels more natural. Could add Alt key for swap vs push behavior later.
 2. Dragging up and down now behave the same (used to require push WAY down past to swap/append). Also much more efficient collision code.
 3. handle mid point of dragged over items (>50%) rather than just a new row/column and check for the most covered item when multiple collide.
@@ -59,6 +59,7 @@ Change log
 1. we now remove item when cursor leaves (`acceptWidgets` case using `dropout` event) or shape is outside (re-using same method) and re-insert on cursor enter (since we only get `dropover` event). Should **not be possible to have 2 placeholders** which confuses the grids.
 2. major re-write and cleanup of the drag in/out. Vars have been renamed and fully documented as I couldn't understand the legacy buggy code.
 3. removed any over trash delay feedback as I don't see the point and could introduce race conditions.
+
 - fix [1617](https://github.com/gridstack/gridstack.js/issues/1617) FireFox DOM order issue. Thanks [@marcel-necker](https://github.com/marcel-necker)
 - fix changing column # `column(n)` now resizes `cellHeight:'auto'` to keep square
 - add [1616](https://github.com/gridstack/gridstack.js/pull/1616) `drag | resize` events while dragging. Thanks [@MrCorba](https://github.com/MrCorba)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "3.3.0-dev",
+  "version": "4.0.0",
   "description": "TypeScript/JS lib for dashboard layout and creation, no external dependencies, with many wrappers (React, Angular, Vue, Ember, knockout...)",
   "main": "./dist/gridstack.js",
   "types": "./dist/gridstack.d.ts",

--- a/spec/e2e/html/141_1534_swap.html
+++ b/spec/e2e/html/141_1534_swap.html
@@ -13,6 +13,7 @@
 <body>
   <div class="container-fluid">
     <h1>Swap collision demo</h1>
+    <p>for bugs 141 <b>1094</b> 1534 1605</p>
     <div>
       <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
       <a class="btn btn-primary" onclick="toggleFloat()" id="float" href="#"></a>
@@ -21,8 +22,9 @@
       with layouts:
       <a class="btn btn-primary" onclick="load(0)" href="#">load 0</a>
       <a class="btn btn-primary" onclick="load(1)" href="#">load 1</a>
-      <a class="btn btn-primary" onclick="load(2)" href="#">load web1</a>
-      <a class="btn btn-primary" onclick="loadAdvanced()" href="#">load web2</a>
+      <a class="btn btn-primary" onclick="load(2)" href="#">load 2</a>
+      <a class="btn btn-primary" onclick="load(3)" href="#">load web1</a>
+      <a class="btn btn-primary" onclick="load(3); loadAdvanced()" href="#">load web2</a>
     </div>
     <br><br>
     <div class="grid-stack"></div>
@@ -38,17 +40,19 @@
     let grid = GridStack.init({float: false, cellHeight: 70, maxRow: 0});
     addEvents(grid);
 
-    let items = [[
+    let items = [[ // load 0
       {x:0, y:0}, {x:0, y:1}, {x:0, y:2},{x:1, y:0}, {x:1, y:1}, {x:1, y:2, /*h:2, w:2*/},
       {x:5, y:0}, {x:4, y:1, w:3, locked: false, _content: 'locked'}, {x:5, y:2},
       {x:7, y:0}, {x:8, y:0}, {x:9, y:0}, {x:7, y:1, w:3}, {x:8, y:2},
       {x:11, y:0}, {x:11, y:1, h:2},
-    ], [
-      {x:1, y:0}, {x:1, y:1}, {x:1, y:2, w:2},  {x:0, y:3, w:3}, {x:1, y:4, h:2},
+    ], [ // load 1
+      {x:1, y:0}, {x:1, y:1, w:2}, {x:1, y:2, h:2}, {x:0, y:4, w:3}, 
       {x:3, y:0, w:3, h:3}, {x:6, y:0},
       {x:7, y:0, w:3}, {x:8, y:1, w:3},
-    ],[
-      // web1.html demo
+    ], [ // load 2
+      {x:1, y:0, w:2}, {x:1, y:1, h:2}, {x:2, y:1}, {x:0, y:3, w:3} , {x:0, y:4},
+      // {x:5, y:0, w:2}, {x:6, y:1}, {x:4, y:2, w:3} , {x:5, y:4, h:2}, {x:4, y:4},
+    ],[ // web1.html demo
       {x:0, y:0, w:4, h:2},
       {x:4, y:0, w:4, h:4, id: 'big'},
       {x:8, y:0, w:2, h:2},
@@ -84,7 +88,6 @@
       grid.load(items[i]);
     }
     loadAdvanced = function() {
-      load(2);
       grid.update(grid.engine.nodes[1].el, {locked: true, content:'locked'});
     }
     toggleFloat = function() {

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -1,10 +1,5 @@
-// gridstack-GridStackDD.get().ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// gridstack-GridStackDD.get().ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { GridStackDDI } from './gridstack-ddi';
 import { GridItemHTMLElement, GridStackNode, GridStackElement, DDUIData, DDDragInOpt, GridStackPosition } from './types';
@@ -432,8 +427,7 @@ GridStack.prototype._prepareDragDropByNode = function(node: GridStackNode): Grid
       } else {
         // got removed - restore item back to before dragging position
         Utils.removePositioningStyles(target);
-        Utils.copyPos(node, node._beforeDrag);
-        delete node._beforeDrag;
+        Utils.copyPos(node, node._orig);
         this._writePosAttr(target, node);
         this.engine.addNode(node);
       }
@@ -483,14 +477,14 @@ GridStack.prototype._onStartMoving = function(event: Event, ui: DDUIData, node: 
   node.el = this.placeholder;
   node._lastUiPosition = ui.position;
   node._prevYPix = ui.position.top;
-  node._moving = (event.type === 'dragstart');
+  node._moving = (event.type === 'dragstart'); // 'dropover' are not initially moving so they can go exactly where they enter (will push stuff out of the way)
   delete node._lastTried;
   delete node._isCursorOutside;
 
   if (event.type === 'dropover' && node._temporaryRemoved) {
     // TEST console.log('engine.addNode x=' + node.x);
-    this.engine.addNode(node); // will add, constrain, update attr and clear _temporaryRemoved
-    node._moving = true; // lastly mark as moving object
+    this.engine.addNode(node); // will add, fix collisions, update attr and clear _temporaryRemoved
+    node._moving = true; // AFTER, mark as moving object (wanted fix location before)
   }
 
   // set the min/max resize info
@@ -533,6 +527,8 @@ GridStack.prototype._leave = function(node: GridStackNode, el: GridItemHTMLEleme
     // item came from outside (like a toolbar) so nuke any node info
     delete node.el;
     delete el.gridstackNode;
+    // and restore all nodes back to original
+    this.engine.restoreInitial();
   }
 }
 

--- a/src/gridstack-ddi.ts
+++ b/src/gridstack-ddi.ts
@@ -1,12 +1,5 @@
-// gridstack-ddi.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
+// gridstack-ddi.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { GridItemHTMLElement } from './types';
 
 /**

--- a/src/gridstack-extra.scss
+++ b/src/gridstack-extra.scss
@@ -1,10 +1,4 @@
-/*!
- * gridstack 3.3.0-dev extra CSS for [2-11] columns (non default)
- * https://gridstackjs.com/
- * (c) 2014-2020  Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// (c) 2021 Alain Dumesny - see root license
 // default to generate [2-11] columns as 1 (oneColumnMode) and 12 (default) are in the main css
 $gridstack-columns-start: 2 !default;
 $gridstack-columns: 11 !default;

--- a/src/gridstack-poly.js
+++ b/src/gridstack-poly.js
@@ -1,11 +1,5 @@
-// gridstack-poly.js 2.0.0 @preserve
-
-/** IE and older browsers Polyfills for this library
- * https://gridstackjs.com/
- * (c) 2019-2020 Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// gridstack-poly.js 2.0.0
+// (c) 2021 Alain Dumesny - see root license
 /* eslint-disable prefer-rest-params */
 /* eslint-disable no-var */
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -1,10 +1,4 @@
-/*!
- * gridstack 3.3.0-dev required CSS for default 12 and 1 column Mode size. Use gridstack-extra.css for column [2-11], else see https://github.com/gridstack/gridstack.js#custom-columns-css
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// (c) 2021 Alain Dumesny - see root license
 $gridstack-columns: 12 !default;
 $animation_speed: .3s !default;
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1,11 +1,7 @@
-// gridstack.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// gridstack.ts 4.0.0
+/*!
+ * (c) 2021 Alain Dumesny - see root license
+ */
 import { GridStackEngine } from './gridstack-engine';
 import { Utils, HeightData } from './utils';
 import { ColumnOptions, GridItemHTMLElement, GridStackElement, GridStackEventHandlerCallback,
@@ -338,7 +334,6 @@ export class GridStack {
       elements.sort((a, b) => a.i - b.i).forEach(e => this._prepareElement(e.el));
       this.commit();
     }
-    this.engine.saveInitial(); // initial start of items (reset after we call _triggerChangeEvent)
 
     this.setAnimation(this.opts.animate);
 

--- a/src/h5/dd-base-impl.ts
+++ b/src/h5/dd-base-impl.ts
@@ -1,10 +1,5 @@
-// dd-base-impl.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-base-impl.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 export type EventCallback = (event: Event) => boolean|void;
 export abstract class DDBaseImplement {
   /** returns the enable state, but you have to call enable()/disable() to change (as other things need to happen) */

--- a/src/h5/dd-draggable.ts
+++ b/src/h5/dd-draggable.ts
@@ -1,10 +1,5 @@
-// dd-draggable.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-draggable.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDManager } from './dd-manager';
 import { DDUtils } from './dd-utils';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -1,10 +1,5 @@
-// dd-droppable.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-droppable.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDDraggable } from './dd-draggable';
 import { DDManager } from './dd-manager';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';

--- a/src/h5/dd-element.ts
+++ b/src/h5/dd-element.ts
@@ -1,10 +1,5 @@
-// dd-elements.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-elements.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDResizable, DDResizableOpt } from './dd-resizable';
 import { GridItemHTMLElement } from './../types';
 import { DDDraggable, DDDraggableOpt } from './dd-draggable';

--- a/src/h5/dd-manager.ts
+++ b/src/h5/dd-manager.ts
@@ -1,10 +1,5 @@
-// dd-manager.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-manager.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDDraggable } from './dd-draggable';
 
 export class DDManager {

--- a/src/h5/dd-resizable-handle.ts
+++ b/src/h5/dd-resizable-handle.ts
@@ -1,10 +1,5 @@
-// dd-resizable-handle.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-resizable-handle.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 export interface DDResizableHandleOpt {
   start?: (event) => void;
   move?: (event) => void;

--- a/src/h5/dd-resizable.ts
+++ b/src/h5/dd-resizable.ts
@@ -1,10 +1,5 @@
-// dd-resizable.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// dd-resizable.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDResizableHandle } from './dd-resizable-handle';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { DDUtils } from './dd-utils';

--- a/src/h5/dd-utils.ts
+++ b/src/h5/dd-utils.ts
@@ -1,11 +1,5 @@
-// dd-utils.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// dd-utils.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 export class DDUtils {
 
   public static isEventSupportPassiveOption = ((() => {

--- a/src/h5/gridstack-dd-native.ts
+++ b/src/h5/gridstack-dd-native.ts
@@ -1,10 +1,5 @@
-// gridstack-dd-native.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2020 rhlin, Alain Dumesny
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// gridstack-dd-native.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { DDManager } from './dd-manager';
 import { DDElement, DDElementHost } from './dd-element';
 

--- a/src/index-h5.ts
+++ b/src/index-h5.ts
@@ -1,7 +1,5 @@
-// index.html5.ts 3.3.0-dev - everything you need for a Grid that uses HTML5 native drag&drop (work in progress) @preserve
-
-// import './gridstack-poly.js';
-
+// index.html5.ts 4.0.0 - everything you need for a Grid that uses HTML5 native drag&drop (work in progress)
+// (c) 2021 Alain Dumesny - see root license
 export * from './types';
 export * from './utils';
 export * from './gridstack-engine';

--- a/src/index-jq.ts
+++ b/src/index-jq.ts
@@ -1,6 +1,5 @@
-// index.jq.ts 3.3.0-dev - everything you need for a Grid that uses Jquery-ui drag&drop (original, full feature) @preserve
-
-// import './gridstack-poly.js';
+// index.jq.ts 4.0.0 - everything you need for a Grid that uses Jquery-ui drag&drop (original, full feature)
+// (c) 2021 Alain Dumesny - see root license
 
 export * from './types';
 export * from './utils';

--- a/src/index-static.ts
+++ b/src/index-static.ts
@@ -1,6 +1,5 @@
-// index.static.ts 3.3.0-dev - everything you need for a static Grid (non draggable) @preserve
-
-// import './gridstack-poly.js';
+// index.static.ts 4.0.0 - everything you need for a static Grid (non draggable)
+// (c) 2021 Alain Dumesny - see root license
 
 export * from './types';
 export * from './utils';

--- a/src/jq/gridstack-dd-jqueryui.ts
+++ b/src/jq/gridstack-dd-jqueryui.ts
@@ -1,11 +1,5 @@
-// gridstack-dd-jqueryui.ts 3.1.3-dev @preserve
-
-/** JQuery UI Drag&Drop plugin
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
-
+// gridstack-dd-jqueryui.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 import { GridStackElement } from '../gridstack';
 import { GridStackDD, DDOpts, DDKey, DDDropOpt, DDCallback, DDValue } from '../gridstack-dd';
 import { GridItemHTMLElement, DDDragInOpt } from '../types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,5 @@
-// types.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// types.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 
 import { GridStack } from './gridstack';
 
@@ -195,6 +190,8 @@ export interface GridStackOptions {
 
 /** options used during GridStackEngine.moveNode() */
 export interface GridStackMoveOpts extends GridStackPosition {
+  /** node to skip collision */
+  skip?: GridStackNode;
   /** do we pack (default true) */
   pack?: boolean;
   /** true if we are calling this recursively to prevent simple swap or coverage collision - default false*/
@@ -332,20 +329,16 @@ export interface GridStackNode extends GridStackWidget {
   _isExternal?: boolean;
   /** @internal moving vs resizing */
   _moving?: boolean;
-  /** @internal true if we jump down past item below (one time jump so we don't have to totally pass it) */
+  /** @internal true if we jumped down past item below (one time jump so we don't have to totally pass it) */
   _skipDown?: boolean;
   /** @internal original values before a drag/size */
   _orig?: GridStackPosition;
-  /** @internal set on the item being dragged/resized to save initial values TODO: vs _orig ? */
-  _beforeDrag?: GridStackPosition;
   /** @internal position in pixels used during collision check  */
   _rect?: GridStackPosition;
   /** @internal top/left pixel location before a drag so we can detect direction of move from last position*/
   _lastUiPosition?: Position;
   /** @internal set on the item being dragged/resized remember the last positions we've tried (but failed) so we don't try again during drag/resize */
   _lastTried?: GridStackPosition;
-  /** @internal original Y when another item is dragged around a float=true so we can restore back as item is dragged around  */
-  _packY?: number;
   /** @internal last drag Y pixel position used to incrementally update V scroll bar */
   _prevYPix?: number;
   /** @internal true if we've remove the item from ourself (dragging out) but might revert it back (release on nothing -> goes back) */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,5 @@
-// utils.ts 3.3.0-dev @preserve
-
-/**
- * https://gridstackjs.com/
- * (c) 2014-2020 Alain Dumesny, Dylan Weiss, Pavel Reznikov
- * gridstack.js may be freely distributed under the MIT license.
-*/
+// utils.ts 4.0.0
+// (c) 2021 Alain Dumesny - see root license
 
 import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition } from './types';
 


### PR DESCRIPTION
### Description
fix #1094

* found I needed to take entire row (not just new location) when doing collision to correctly push down bottom items first so they keep their order and prevent large objects from leapfrogging smaller ones.
(like old code used to do)
* removed _beforeDrag and _packY fields and re-use existing _orig position data which simplifies things
* removed yOffset during _fixCollisions() as it was incorrect (reverse sorting should take care of that)
* on _leave() of external item, we now restore all items to original position using restoreInitial() (prevents any error from sticking)

NEEDLESS to say, this is MUCH more complicated than the old _fixCollision() that moved to new loc then pushed anything down in that row and below (bottom first) which is dead simple... but required you to move 90% past the item when moving down.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
