### PR TITLE
enableMove() fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [4.0.1-dev](#401-dev)
 - [4.0.1 (2021-3-20)](#401-2021-3-20)
 - [4.0.0 (2021-3-19)](#400-2021-3-19)
 - [3.3.0 (2021-2-2)](#330-2021-2-2)
@@ -49,6 +50,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+## 4.0.1-dev
+
+- fix [#1658](https://github.com/gridstack/gridstack.js/issues/1658) `enableMove(T/F)` not working correctly
 ## 4.0.1 (2021-3-20)
 
 - fix [#1669](https://github.com/gridstack/gridstack.js/issues/1669) JQ resize broken

--- a/doc/README.md
+++ b/doc/README.md
@@ -38,8 +38,8 @@ gridstack.js API
   - [`destroy([removeDOM])`](#destroyremovedom)
   - [`disable()`](#disable)
   - [`enable()`](#enable)
-  - [`enableMove(doEnable, includeNewWidgets)`](#enablemovedoenable-includenewwidgets)
-  - [`enableResize(doEnable, includeNewWidgets)`](#enableresizedoenable-includenewwidgets)
+  - [`enableMove(doEnable)`](#enablemovedoenable)
+  - [`enableResize(doEnable)`](#enableresizedoenable)
   - [`float(val?)`](#floatval)
   - [`getCellHeight()`](#getcellheight)
   - [`getCellFromPixel(position[, useOffset])`](#getcellfrompixelposition-useoffset)
@@ -403,22 +403,22 @@ grid.enableMove(true);
 grid.enableResize(true);
 ```
 
-### `enableMove(doEnable, includeNewWidgets)`
+### `enableMove(doEnable)`
 
-Enables/disables widget moving. `includeNewWidgets` will force new widgets to be draggable as per `doEnable`'s value by changing the `disableDrag` grid option (default: true). This is a shortcut for:
+Enables/disables widget moving (default: true), and setting the `disableDrag` grid option. This is a shortcut for:
 
 ```js
-grid.movable('.grid-stack-item', doEnable);
 grid.opts.disableDrag = !doEnable;
+grid.movable('.grid-stack-item', doEnable);
 ```
 
-### `enableResize(doEnable, includeNewWidgets)`
+### `enableResize(doEnable)`
 
-Enables/disables widget resizing. `includeNewWidgets` will force new widgets to be resizable as per `doEnable`'s value by changing the `disableResize` grid option  (default: true). This is a shortcut for:
+Enables/disables widget sizing (default: true), and setting the `disableResize` grid option. This is a shortcut for:
 
 ```js
-grid.resizable('.grid-stack-item', doEnable);
 grid.opts.disableResize = !doEnable;
+grid.resizable('.grid-stack-item', doEnable);
 ```
 
 ### `float(val?)`
@@ -445,7 +445,7 @@ Returns an object with properties `x` and `y` i.e. the column and row in the gri
 
 ### `getGridItems(): GridItemHTMLElement[]`
 
-Return list of GridItem HTML dom elements (excluding temporary placeholder)
+Return list of GridItem HTML elements (excluding temporary placeholder) in DOM order, wether they are node items yet or not (looks by class)
 
 ### `getMargin()`
 

--- a/spec/e2e/html/1658_enableMove.html
+++ b/spec/e2e/html/1658_enableMove.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Float grid demo</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-h5.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Float grid demo</h1>
+    <div>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
+      <a class="btn btn-primary" onclick="toggleFloat()" id="float" href="#">float: true</a>
+      <a class="btn btn-primary" onclick="grid.enableMove(true)" href="#">enable</a>
+      <a class="btn btn-primary" onclick="grid.disable()" href="#">disable</a>
+    </div>
+    <br><br>
+    <div class="grid-stack"></div>
+  </div>
+  <script src="../../../demo/events.js"></script>
+  <script type="text/javascript">
+    let grid = GridStack.init({disableResize: true, disableDrag: true});
+    addEvents(grid);
+
+    let items = [
+      {x: 1, y: 1},
+      {x: 2, y: 2, w: 3},
+      {x: 4, y: 2},
+      {x: 3, y: 1, h: 2},
+      {x: 0, y: 6, w: 2, h: 2}
+    ];
+    let count = 0;
+
+    addNewWidget = function() {
+      let n = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
+      };
+      n.content = String(count++);
+      grid.addWidget(n);
+    };
+
+    toggleFloat = function() {
+      grid.float(! grid.getFloat());
+      document.querySelector('#float').innerHTML = 'float: ' + grid.getFloat();
+    };
+    addNewWidget();
+  </script>
+</body>
+</html>

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1420,7 +1420,7 @@ describe('gridstack', function() {
       }
       expect(grid.opts.disableDrag).toBe(true);
 
-      grid.enableMove(true, true);
+      grid.enableMove(true);
       for (let i = 0; i < items.length; i++) {
         expect(items[i].classList.contains('ui-draggable-disabled')).toBe(false);
       }
@@ -1438,11 +1438,11 @@ describe('gridstack', function() {
       }
       expect(grid.opts.disableDrag).toBe(false);
 
-      grid.enableMove(false, false);
+      grid.enableMove(false);
       for (let i = 0; i < items.length; i++) {
         expect(items[i].classList.contains('ui-draggable-disabled')).toBe(true);
       }
-      expect(grid.opts.disableDrag).toBe(false);
+      expect(grid.opts.disableDrag).toBe(true);
     });
   });
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -328,7 +328,7 @@ export class GridStack {
     if (this.opts.auto) {
       this.batchUpdate(); // prevent in between re-layout #1535 TODO: this only set float=true, need to prevent collision check...
       let elements: {el: HTMLElement; i: number}[] = [];
-      this.getGridItems().forEach(el => {
+      this.getGridItems().forEach(el => { // get dom elements (not nodes yet)
         let x = parseInt(el.getAttribute('gs-x'));
         let y = parseInt(el.getAttribute('gs-y'));
         elements.push({
@@ -676,7 +676,7 @@ export class GridStack {
     let domNodes: GridStackNode[];
     if (column === 1 && this.opts.oneColumnModeDomSort) {
       domNodes = [];
-      this.getGridItems().forEach(el => {
+      this.getGridItems().forEach(el => { // get dom elements in order
         if (el.gridstackNode) { domNodes.push(el.gridstackNode); }
       });
       if (!domNodes.length) { domNodes = undefined; }
@@ -699,7 +699,7 @@ export class GridStack {
     return this.opts.column;
   }
 
-  /** returns an array of grid HTML elements (no placeholder) - used to iterate through our children */
+  /** returns an array of grid HTML elements (no placeholder) - used to iterate through our children in DOM order */
   public getGridItems(): GridItemHTMLElement[] {
     return Array.from(this.el.children)
       .filter((el: HTMLElement) => el.matches('.' + this.opts.itemClass) && !el.matches('.' + this.opts.placeholderClass)) as GridItemHTMLElement[];
@@ -1463,13 +1463,13 @@ export class GridStack {
   public static setupDragIn(dragIn?: string, dragInOptions?: DDDragInOpt): void { /* implemented in gridstack-dd.ts */ }
 
   /**
-   * Enables/Disables moving. No-op for static grids.
+   * Enables/Disables moving of specific grid elements. If you want all items, and have it stay, use enableMove() instead. No-op for static grids.
    * @param els widget or selector to modify.
    * @param val if true widget will be draggable.
    */
   public movable(els: GridStackElement, val: boolean): GridStack { return this }
   /**
-   * Enables/Disables resizing. No-op for static grids.
+   * Enables/Disables resizing of specific grid elements. If you want all items, and have it stay, use enableResize() instead. No-op for static grids.
    * @param els  widget or selector to modify
    * @param val  if true widget will be resizable.
    */
@@ -1495,19 +1495,12 @@ export class GridStack {
   public enable(): GridStack { return this }
   /**
    * Enables/disables widget moving. No-op for static grids.
-   *
-   * @param doEnable
-   * @param includeNewWidgets will force new widgets to be draggable as per
-   * doEnable`s value by changing the disableDrag grid option (default: true).
    */
-  public enableMove(doEnable: boolean, includeNewWidgets = true): GridStack { return this }
+  public enableMove(doEnable: boolean): GridStack { return this }
   /**
    * Enables/disables widget resizing. No-op for static grids.
-   * @param doEnable
-   * @param includeNewWidgets will force new widgets to be draggable as per
-   * doEnable`s value by changing the disableResize grid option (default: true).
    */
-  public enableResize(doEnable: boolean, includeNewWidgets = true): GridStack { return this }
+  public enableResize(doEnable: boolean): GridStack { return this }
 
   /** @internal called to add drag over support to support widgets */
   public _setupAcceptWidget(): GridStack { return this }

--- a/src/h5/gridstack-dd-native.ts
+++ b/src/h5/gridstack-dd-native.ts
@@ -98,17 +98,17 @@ export class GridStackDDNative extends GridStackDD {
 
   /** true if element is droppable */
   public isDroppable(el: DDElementHost): boolean {
-    return el && el.ddElement && el.ddElement.ddDroppable && !el.ddElement.ddDroppable.disabled;
+    return !!(el && el.ddElement && el.ddElement.ddDroppable && !el.ddElement.ddDroppable.disabled);
   }
 
   /** true if element is draggable */
   public isDraggable(el: DDElementHost): boolean {
-    return el && el.ddElement && el.ddElement.ddDraggable && !el.ddElement.ddDraggable.disabled;
+    return !!(el && el.ddElement && el.ddElement.ddDraggable && !el.ddElement.ddDraggable.disabled);
   }
 
   /** true if element is draggable */
   public isResizable(el: DDElementHost): boolean {
-    return el && el.ddElement && el.ddElement.ddResizable && !el.ddElement.ddResizable.disabled;
+    return !!(el && el.ddElement && el.ddElement.ddResizable && !el.ddElement.ddResizable.disabled);
   }
 
   public on(el: GridItemHTMLElement, name: string, callback: DDCallback): GridStackDDNative {


### PR DESCRIPTION
### Description
* fix #1658
* we now set the grid options BEFORE we update each item as that override
* `enableMove()` and `enableResize()` no longer take a second optional param as we must set grid options for things to work
(if you want to enable current items but not change the grid itself, there is already the `movable('.grid-stack-item')` method that doesn't change the grid (no need for 2 ways)
* did some more cleanup and added test case.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
