### PR TITLE
collision: Resizable: {handles:'w/sw'} fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -52,6 +52,7 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## 4.0.1-dev
 
+- fix [#1679](https://github.com/gridstack/gridstack.js/issues/1679) `Resizable: {handles:'w/sw'}` work again in 4.x
 - fix [#1658](https://github.com/gridstack/gridstack.js/issues/1658) `enableMove(T/F)` not working correctly
 - fix `helper: myFunction` now working for H5 case for `dragInOptions` & `setupDragIn()`
 ## 4.0.1 (2021-3-20)

--- a/spec/e2e/html/141_1534_swap.html
+++ b/spec/e2e/html/141_1534_swap.html
@@ -37,7 +37,7 @@
     let size = 1;
     let layout = 0;
 
-    let grid = GridStack.init({float: false, cellHeight: 70, maxRow: 0});
+    let grid = GridStack.init({float: false, cellHeight: 70, maxRow: 0, resizable: {handles: 'sw,w,e,se'}});
     addEvents(grid);
 
     let items = [[ // load 0


### PR DESCRIPTION
### Description
fix #1679
* 4.x broke the left side size handle (as it needs to move item as well as resize)
now works again and should be more solid too.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
