### PR TITLE
insert extra rows, insert below

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -54,6 +54,8 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## 4.0.3-dev
 
+- fix [#219](https://github.com/gridstack/gridstack.js/issues/219) **fixing another 6 years old request** we now automatically insert extra rows
+when dragging an item at the bottom below others to make it easier to insert below.
 - fix [#1687](https://github.com/gridstack/gridstack.js/issues/1687) more fix for drag between 2 grids with `row / maxRow` broken in 4.x
 
 ## 4.0.3 (2021-3-28)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -228,6 +228,8 @@ export class GridStack {
   private _cellHeightThrottle: () => void;
   /** @internal true when loading items to insert first rather than append */
   private _insertNotAppend: boolean;
+  /** @internal extra row added when dragging at the bottom of the grid */
+  private _extraDragRow = 0;
 
   /**
    * Construct a grid item from the given element and options
@@ -1200,7 +1202,7 @@ export class GridStack {
   /** @internal */
   private _updateContainerHeight(): GridStack {
     if (!this.engine || this.engine.batchMode) return this;
-    let row = this.getRow(); // checks for minRow already
+    let row = this.getRow() + this._extraDragRow; // checks for minRow already
     // check for css min height
     let cssMinHeight = parseInt(getComputedStyle(this.el)['min-height']);
     if (cssMinHeight > 0) {


### PR DESCRIPTION
### Description
fix #219
**fixing another 6 years old request**
* we now automatically insert extra rows
when dragging an item at the bottom below others to make it easier to insert below.
* added `_extraDragRow` to grids driven by dragged item

### Checklist
- [] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
