### PR TITLE
JQ nested grid drag

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [4.2.0-dev](#420-dev)
 - [4.2.0 (2021-4-11)](#420-2021-4-11)
 - [4.1.0 (2021-4-7)](#410-2021-4-7)
 - [4.0.3 (2021-3-28)](#403-2021-3-28)
@@ -53,6 +54,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+## 4.2.0-dev
+
+- fix [#1700](https://github.com/gridstack/gridstack.js/issues/1700) JQ nested grid drag fix broken in 4.0.3 (but much older underlying issue)
+
 ## 4.2.0 (2021-4-11)
 
 - fix [#1704](https://github.com/gridstack/gridstack.js/issues/1704) scrollbar fix broken in 4.x

--- a/src/jq/gridstack-dd-jqueryui.ts
+++ b/src/jq/gridstack-dd-jqueryui.ts
@@ -111,7 +111,7 @@ export class GridStackDDJQueryUI extends GridStackDD {
 
   public on(el: GridItemHTMLElement, name: string, callback: DDCallback): GridStackDD {
     let $el: JQuery = $(el);
-    $el.on(name, (event, ui) => { callback(event as any, ui.draggable ? ui.draggable[0] : event.target, ui.helper ? ui.helper[0] : null) });
+    $el.on(name, (event, ui) => { return callback(event as any, ui.draggable ? ui.draggable[0] : event.target, ui.helper ? ui.helper[0] : null) });
     return this;
   }
 


### PR DESCRIPTION
### Description
* fix #1700
* jquery DD wrapper now correctly returns status to callee,
to prevent parent grid to also handle drag event
* exposed in 4.0.3 but issues was much older.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
