### PR TITLE
item gs-x:0 not animating fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -57,6 +57,7 @@ Change log
 ## 4.2.0-dev
 
 - fix [#1700](https://github.com/gridstack/gridstack.js/issues/1700) JQ nested grid drag fix broken in 4.0.3 (but much older underlying issue)
+- fix [#1678](https://github.com/gridstack/gridstack.js/issues/1678) item gs-x:0 not animating fix
 
 ## 4.2.0 (2021-4-11)
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -96,7 +96,7 @@ $animation_speed: .3s !default;
       }
     }
 
-    @for $i from 1 through $gridstack-columns {
+    @for $i from 0 through $gridstack-columns {
       &[gs-w='#{$i}'] { width: (100% / $gridstack-columns) * $i; }
       &[gs-x='#{$i}'] { left: (100% / $gridstack-columns) * $i; }
       &[gs-min-w='#{$i}'] { min-width: (100% / $gridstack-columns) * $i; }


### PR DESCRIPTION
### Description
* fix #1678
* make sure we set CSS rules for gs-x:0 and not just 1+
* turns out this never worked as file always did 1-12 styles.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
