### PR TITLE
fix Safari bug with dropping element inside grid

### DIFF
--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -206,6 +206,11 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
      */
     .on(this.el, 'dropout', (event, el: GridItemHTMLElement, helper: GridItemHTMLElement) => {
       let node = el.gridstackNode;
+      // fix #1684 in Safari, dragleave events incorrectly calls dropout event when the node has not dropped from the grid
+      if (!node._temporaryRemoved) {
+        return false;
+      }
+
       // fix #1578 when dragging fast, we might get leave after other grid gets enter (which calls us to clean)
       // so skip this one if we're not the active grid really..
       if (!node.grid || node.grid === this) {

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -206,10 +206,6 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
      */
     .on(this.el, 'dropout', (event, el: GridItemHTMLElement, helper: GridItemHTMLElement) => {
       let node = el.gridstackNode;
-      // fix #1684 in Safari, dragleave events incorrectly calls dropout event when the node has not dropped from the grid
-      if (!node._temporaryRemoved) {
-        return false;
-      }
 
       // fix #1578 when dragging fast, we might get leave after other grid gets enter (which calls us to clean)
       // so skip this one if we're not the active grid really..

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -206,7 +206,6 @@ GridStack.prototype._setupAcceptWidget = function(): GridStack {
      */
     .on(this.el, 'dropout', (event, el: GridItemHTMLElement, helper: GridItemHTMLElement) => {
       let node = el.gridstackNode;
-
       // fix #1578 when dragging fast, we might get leave after other grid gets enter (which calls us to clean)
       // so skip this one if we're not the active grid really..
       if (!node.grid || node.grid === this) {

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -105,6 +105,11 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
 
   /** @internal called when the item is leaving our area, stop tracking if we had moving item */
   private _dragLeave(event: DragEvent): void {
+    // Note: Safari Mac has null relatedTarget which causes #1684 so check if DragEvent is inside the grid instead
+    if (!event.relatedTarget) {
+      const { bottom, left, right, top } = this.el.getBoundingClientRect();
+      if (event.x < right && event.x > left && event.y < bottom && event.y > top) return;
+    }
     if (this.el.contains(event.relatedTarget as HTMLElement)) return;
     this._removeLeaveCallbacks();
     if (this.moving) {


### PR DESCRIPTION
### Description
This should fix #1684 

In Safari, relatedTarget is null, causing the `dragleave` event to fire the `dropout` event early. To detect if we've actually dropped out, I've added a check to make sure the node has the `_temporaryRemoved` prop set. There was similar logic in place in the `dropout` event in v3 so this might have been the fix for that.

I've also tested that this is still working in Chrome and Edge, but was having issues trying to run the local build on Firefox

Current behavior
![Screen Recording 2021-04-21 at 4 44 05 PM](https://user-images.githubusercontent.com/17258798/115624890-dff92600-a2c0-11eb-8eb9-0e5637418fe2.gif)

With fix
![Screen Recording 2021-04-21 at 4 38 54 PM](https://user-images.githubusercontent.com/17258798/115624771-bc35e000-a2c0-11eb-8849-c55d8832965a.gif)


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
