### PR TITLE
destroy(false) doesn't force static grid

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -62,6 +62,7 @@ Change log
 * fix [#1760](https://github.com/gridstack/gridstack.js/issues/1760) `removable:true` working again (broke in 4.x)
 * fix [#1761](https://github.com/gridstack/gridstack.js/issues/1761) `staticGrid(false)` will now enable drag in behavior (if set)
 * fix [#1767](https://github.com/gridstack/gridstack.js/issues/1767) `locked` item can be user moved/resized again, just not pushed by other nodes (broke in 1.1.1)
+* fix [#1764](https://github.com/gridstack/gridstack.js/issues/1764) `destroy(false)` can now re-init properly (doesn't force static grid)
 
 ## 4.2.3 (2021-5-8)
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -718,7 +718,8 @@ export class GridStack {
   public destroy(removeDOM = true): GridStack {
     if (!this.el) return; // prevent multiple calls
     this._updateWindowResizeEvent(true);
-    this.setStatic(true); // permanently removes DD
+    this.setStatic(true, false); // permanently removes DD but don't set CSS class (we're going away)
+    this.setAnimation(false);
     if (!removeDOM) {
       this.removeAll(removeDOM);
       this.el.classList.remove(this.opts._styleSheetClass);
@@ -726,6 +727,7 @@ export class GridStack {
       this.el.parentNode.removeChild(this.el);
     }
     this._removeStylesheet();
+    this.el.removeAttribute('gs-current-row');
     delete this.opts._isNested;
     delete this.opts;
     delete this._placeholder;
@@ -948,13 +950,13 @@ export class GridStack {
    * Also toggle the grid-stack-static class.
    * @param val if true the grid become static.
    */
-  public setStatic(val: boolean): GridStack {
+  public setStatic(val: boolean, updateClass = true): GridStack {
     if (this.opts.staticGrid === val) return this;
     this.opts.staticGrid = val;
     this._setupRemoveDrop();
     this._setupAcceptWidget();
     this.engine.nodes.forEach(n => this._prepareDragDropByNode(n)); // either delete or init Drag&drop
-    this._setStaticClass();
+    if (updateClass) { this._setStaticClass(); }
     return this;
   }
 


### PR DESCRIPTION
### Description
* fix #1764
* don't force static grid when deleting content (was incorrectly setting attribute as part of cleanup)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
