### PR TITLE
Add keepRatio options for GridStackOptions

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -103,6 +103,7 @@ gridstack.js API
 - `handle` - draggable handle selector (default: `'.grid-stack-item-content'`)
 - `handleClass` - draggable handle class (e.g. `'grid-stack-item-content'`). If set `handle` is ignored (default: `null`)
 - `itemClass` - widget class (default: `'grid-stack-item'`)
+- `keepRatio` - if `true` cells will keep the ratio 1:1 between height and width (default: `false`)
 - `margin` - gap size around grid item and content (default: `10`). Can be:
   * an integer (px)
   * a string (ex: '2em', '20px', '2rem')

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -80,7 +80,8 @@ const GridDefaults: GridStackOptions = {
   marginUnit: 'px',
   cellHeightUnit: 'px',
   disableOneColumnMode: false,
-  oneColumnModeDomSort: false
+  oneColumnModeDomSort: false,
+  keepRatio: false
 };
 
 /**
@@ -1208,6 +1209,7 @@ export class GridStack {
   private _updateContainerHeight(): GridStack {
     if (!this.engine || this.engine.batchMode) return this;
     let row = this.getRow() + this._extraDragRow; // checks for minRow already
+    let column = this.getColumn();
     // check for css min height
     let cssMinHeight = parseInt(getComputedStyle(this.el)['min-height']);
     if (cssMinHeight > 0) {
@@ -1225,6 +1227,8 @@ export class GridStack {
     let unit = this.opts.cellHeightUnit;
     if (!cellHeight) return this;
     this.el.style.height = row * cellHeight + unit;
+    if (this.opts.keepRatio)
+      this.el.style.width = column * cellHeight + unit;
     return this;
   }
 


### PR DESCRIPTION
### Description
I added a new option for Gridstack to allow keep ratio between height and width of cell

### Checklist
- [ x] Created tests which fail without the change (if possible)
- [ x] All tests passing (`yarn test`)
- [ x] Extended the README / documentation, if necessary
