### PR TITLE
fix removeable:true by itself now works

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [4.2.5-dev (TBD)](#425-dev-tbd)
 - [4.2.5 (2021-5-31)](#425-2021-5-31)
 - [4.2.4 (2021-5-29)](#424-2021-5-29)
 - [4.2.3 (2021-5-8)](#423-2021-5-8)
@@ -58,6 +59,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+## 4.2.5-dev (TBD)
+
+* fix [#1784](https://github.com/gridstack/gridstack.js/issues/1784) `removable:true` working by itself (without needing `acceptWidgets:true`)
+
 ## 4.2.5 (2021-5-31)
 
 * fix for website with JQ `droppable('destroy')` giving error

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -76,7 +76,7 @@ export abstract class GridStackDD extends GridStackDDI {
 GridStack.prototype._setupAcceptWidget = function(this: GridStack): GridStack {
 
   // check if we need to disable things
-  if (this.opts.staticGrid || !this.opts.acceptWidgets) {
+  if (this.opts.staticGrid || (!this.opts.acceptWidgets && !this.opts.removable)) {
     GridStackDD.get().droppable(this.el, 'destroy');
     return this;
   }


### PR DESCRIPTION
### Description
fix #1784
* `removable:true` by itself (without `acceptWidgets:true`) will now you remove items by dragging them out.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
