### PR TITLE
quickly set external helper initial position + fix scrollbar issue

### DIFF
--- a/src/h5/dd-draggable.ts
+++ b/src/h5/dd-draggable.ts
@@ -126,6 +126,8 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dragstart' });
     if (this.helper !== this.el) {
       this._setupDragFollowNodeNotifyStart(ev);
+      // immediately set external helper initial position to avoid flickering behavior and unnecessary looping in `_packNodes()`
+      this._dragFollow(event);
     } else {
       this.dragFollowTimer = window.setTimeout(() => {
         delete this.dragFollowTimer;
@@ -286,6 +288,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     let img = document.createElement('div');
     img.style.width = '1px';
     img.style.height = '1px';
+    img.style.position = 'fixed'; // prevent unwanted scrollbar
     document.body.appendChild(img);
     e.dataTransfer.setDragImage(img, 0, 0);
     setTimeout(() => document.body.removeChild(img)); // nuke once drag had a chance to grab this 'image'


### PR DESCRIPTION
### Description
This change will immediately set the initial position of the external helper, it will fix:
* issue shown in [this video](https://www.loom.com/share/904ac32dd4b44c37a60485567e85cf5e)
* by setting the correct initial `y` position of the helper, could skip unnecessary looping in `_packNodes()`

The added "fixed" position will fix the scrollbar issue when the body/container height is set to 100% (relative to window height). 
