### PR TITLE
Don't override node width when switching column mode

### DIFF
--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -345,7 +345,7 @@ export class GridStackEngine {
 
     if (node.maxW) { node.w = Math.min(node.w, node.maxW); }
     if (node.maxH) { node.h = Math.min(node.h, node.maxH); }
-    if (node.minW) { node.w = Math.max(node.w, node.minW); }
+    if (node.minW && node.minW < this.column) { node.w = Math.max(node.w, node.minW); }
     if (node.minH) { node.h = Math.max(node.h, node.minH); }
 
     if (node.w > this.column) {


### PR DESCRIPTION
Provides a fix for https://github.com/gridstack/gridstack.js/issues/1835

Explanation:
When going from 12 -> 1 column, this function is run after the node has already had its width set to 1 (I will admit I don't understand the order of events perfectly, this is just what I observed). So when `node.minW` has a value, this condition overrides the node width to be larger than the column count. 

The behavior in #1835 is from a few lines down, where now the condition for `node.w > this.colum`  passes and causes the layout to be cached which was only intended to run when starting from 1 and going to 12.

