### PR TITLE
#1794 fix rem unit size for save+reload

### DIFF
--- a/demo/serialization.html
+++ b/demo/serialization.html
@@ -24,7 +24,10 @@
   </div>
 
   <script type="text/javascript">
-    let grid = GridStack.init({minRow: 1, cellHeight: 70}); // don't let it collapse when empty
+    let grid = GridStack.init({
+      minRow: 1, // don't let it collapse when empty
+      cellHeight: '7rem'
+    });
     
     grid.on('added removed change', function(e, items) {
       let str = '';

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -65,6 +65,7 @@ Change log
 
 * fix [#1817](https://github.com/gridstack/gridstack.js/issues/1817) Enable passing of DragEvent to gridstack dropped event. Thanks [@onepartsam](https://github.com/onepartsam)
 * fix [#1835](https://github.com/gridstack/gridstack.js/issues/1835) Layout incorrectly restored when node has a minimum width. Thanks [@hssm](https://github.com/hssm)
+* fix [#1794](https://github.com/gridstack/gridstack.js/issues/1794) addGrid() does not recognize rem cellHeightUnit
 
 ## 4.2.6 (2021-7-11)
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -302,6 +302,11 @@ export class GridStack {
       // make the cell content square initially (will use resize/column event to keep it square)
       this.cellHeight(undefined, false);
     } else {
+      // append unit if any are set
+      if (typeof this.opts.cellHeight == 'number' && this.opts.cellHeightUnit && this.opts.cellHeightUnit !== GridDefaults.cellHeightUnit) {
+        this.opts.cellHeight = this.opts.cellHeight + this.opts.cellHeightUnit;
+        delete this.opts.cellHeightUnit;
+      }
       this.cellHeight(this.opts.cellHeight, false);
     }
 


### PR DESCRIPTION
### Description
* loading grid will now handle `cellHeightUnit` being set (what happens on save)
rather than only '10rem' example
* changed save/load demo to use rem sizing

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
