### PR TITLE
nested grid save inf loop fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [4.2.7-dev (TBD)](#427-dev-tbd)
 - [4.2.7 (2021-9-12)](#427-2021-9-12)
 - [4.2.6 (2021-7-11)](#426-2021-7-11)
 - [4.2.5 (2021-5-31)](#425-2021-5-31)
@@ -60,6 +61,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 4.2.7-dev (TBD)
+* fix [#1860](https://github.com/gridstack/gridstack.js/issues/1860) nested grid save inf loop fix
 
 ## 4.2.7 (2021-9-12)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -393,7 +393,7 @@ export class Utils {
     const ret = Utils.clone(obj);
     for (const key in ret) {
       // NOTE: we don't support function/circular dependencies so skip those properties for now...
-      if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__') {
+      if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__' && !skipFields.find(k => k === key)) {
         ret[key] = Utils.cloneDeep(obj[key]);
       }
     }
@@ -401,3 +401,5 @@ export class Utils {
   }
 }
 
+// list of fields we will skip during cloneDeep (nested objects, other internal)
+const skipFields = ['_isNested', 'el', 'grid', 'subGrid', 'engine'];


### PR DESCRIPTION
### Description
fix #1860 which was caused by #1793
* cloneDeep() will now skip clonning internal known objects we don't serialize (and delete later with removeInternalAndSame())

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
