### PR TITLE
save full res in 1 column mode

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -65,6 +65,7 @@ Change log
 
 ## 4.3.0-dev (TBD)
 * fix [#1868](https://github.com/gridstack/gridstack.js/issues/1868) prevent swap during resize
+* fix [#1849](https://github.com/gridstack/gridstack.js/issues/1849) [#1816](https://github.com/gridstack/gridstack.js/issues/1816) save highest resolution in 1 column mode
 
 ## 4.3.0 (2021-10-15)
 * you can now swap items of different width if they are the same row/height. Thanks to [spektrummedia](http://spektrummedia.com) for sponsoring it.

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -667,14 +667,21 @@ export class GridStackEngine {
     return this;
   }
 
-  /** saves a copy of the current layout returning a list of widgets for serialization */
+  /** saves a copy of the largest column layout (eg 12 even when rendering oneColumnMode, so we don't loose orig layout),
+   * returning a list of widgets for serialization */
   public save(saveElement = true): GridStackNode[] {
+    // use the highest layout for any saved info so we can have full detail on reload #1849
+    let len = this._layouts?.length;
+    let layout = len && this.column !== (len - 1) ? this._layouts[len - 1] : null;
     let list: GridStackNode[] = [];
     this._sortNodes();
     this.nodes.forEach(n => {
-      let w: GridStackNode = {};
-      for (let key in n) { if (key[0] !== '_' && n[key] !== null && n[key] !== undefined ) w[key] = n[key]; }
-      // delete other internals
+      let wl = layout?.find(l => l._id === n._id);
+      let w: GridStackNode = {...n};
+      // use layout info instead if set
+      if (wl) { w.x = wl.x; w.y = wl.y; w.w = wl.w; }
+      // delete internals
+      for (let key in w) { if (key[0] === '_' || w[key] === null || w[key] === undefined ) delete w[key]; }
       delete w.grid;
       if (!saveElement) delete w.el;
       // delete default values (will be re-created on read)


### PR DESCRIPTION
### Description
fix #1849 #1816
* always save the layout with the highest resolution no matter what
current column count is (eg: 12 when in 1 column mode)
to make sure we keep full resolution on restore.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
