### PR TITLE
dragging nested items no longer clipp

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -67,6 +67,7 @@ Change log
 
 ## 4.4.0-dev TBD
 * fix [#1901](https://github.com/gridstack/gridstack.js/pull/1901) error introduced for #1785 when re-loading with fewer objects
+* fix [#1902](https://github.com/gridstack/gridstack.js/pull/1902) nested.html: dragging between sub-grids show items clipped
 
 ## 4.4.0 (2021-12-21)
 * add [#1887](https://github.com/gridstack/gridstack.js/pull/1887) support for IE (new es5 folder) by [@SmileLifeIven](https://github.com/SmileLifeIven)

--- a/src/h5/dd-resizable.ts
+++ b/src/h5/dd-resizable.ts
@@ -17,7 +17,6 @@ export interface DDResizableOpt {
   maxWidth?: number;
   minHeight?: number;
   minWidth?: number;
-  basePosition?: 'fixed' | 'absolute';
   start?: (event: Event, ui: DDUIData) => void;
   stop?: (event: Event) => void;
   resize?: (event: Event, ui: DDUIData) => void;
@@ -206,9 +205,8 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
     if (window.getComputedStyle(this.el.parentElement).position.match(/static/)) {
       this.el.parentElement.style.position = 'relative';
     }
-    this.el.style.position = this.option.basePosition || 'absolute'; // or 'fixed'
+    this.el.style.position = 'absolute';
     this.el.style.opacity = '0.8';
-    this.el.style.zIndex = '1000';
     return this;
   }
 


### PR DESCRIPTION
### Description
* fix to make #992 better going forward as I'm focusing on nested grids again
* dragging sub item between grids no longer get clipped by parent
* removed basePosition.aboslute option as I'm not sure how we can make it work
(parent has position.relative which will clip us otherwise)
* nested.html you can drag pink items between grids (h5 case, JQ still clipps)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
