### PR TITLE
prevent double nesting using gesture

### DIFF
--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -131,6 +131,8 @@ GridStack.prototype._setupAcceptWidget = function(this: GridStack): GridStack {
         // set accept drop to true on ourself (which we ignore) so we don't get "can't drop" icon in HTML5 mode while moving
         if (node?.grid === this) return true;
         if (!this.opts.acceptWidgets) return false;
+        // prevent deeper nesting until rest of 992 can be fixed
+        if (node?.subGrid) return false;
         // check for accept method or class matching
         let canAccept = true;
         if (typeof this.opts.acceptWidgets === 'function') {

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -293,6 +293,7 @@ export class GridStack {
     if (parentGridItemEl && parentGridItemEl.gridstackNode) {
       this.opts._isNested = parentGridItemEl.gridstackNode;
       this.opts._isNested.subGrid = this;
+      parentGridItemEl.classList.add('grid-stack-nested');
       this.el.classList.add('grid-stack-nested');
     }
 

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -8,6 +8,7 @@ import { DDManager } from './dd-manager';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { DDUtils } from './dd-utils';
 import { GridHTMLElement, GridStack } from '../gridstack';
+import { GridItemHTMLElement } from '../types';
 
 export interface DDDroppableOpt {
   accept?: string | ((el: HTMLElement) => boolean);
@@ -121,10 +122,12 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
     event.stopPropagation();
 
     // ignore leave events on our children (we get them when starting to drag our items)
-    // but exclude nested grids since we would still be leaving ourself
+    // but exclude nested grids since we would still be leaving ourself, 
+    // but don't handle leave if we're dragging a nested grid around
     if (!forceLeave) {
       let onChild = DDUtils.inside(event, this.el);
-      if (onChild) {
+      let drag: GridItemHTMLElement = DDManager.dragElement.el;
+      if (onChild && !drag.gridstackNode?.subGrid) { // dragging a nested grid ?
         let nestedEl = (this.el as GridHTMLElement).gridstack.engine.nodes.filter(n => n.subGrid).map(n => (n.subGrid as GridStack).el);
         onChild = !nestedEl.some(el => DDUtils.inside(event, el));
       }


### PR DESCRIPTION
### Description
* remaining fix for #992 to prevent a nested grid from going inside another until we can do the right thing down the line. Very broken otherwise
* also fixed heuristics to work like regular items (ignore enter/leave for sub grid dragging)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
