### PR TITLE
nested grid column:'auto' option

### DIFF
--- a/demo/nested.html
+++ b/demo/nested.html
@@ -9,11 +9,13 @@
   <link rel="stylesheet" href="../dist/gridstack-extra.min.css"/>
   <script src="../dist/gridstack-h5.js"></script>
   <style type="text/css">
-    .grid-stack .grid-stack {
-      background: rgba(255, 255, 255, 0.3);
+    /* make nested grids have slightly darker bg */
+    .grid-stack.grid-stack-nested {
+      background: #e4e4c1;
     }
-    .grid-stack .grid-stack .grid-stack-item-content {
-      background: lightpink;
+    /* make nested grid take almost all space (need some to tell them apart) so items inside can have similar to external size+margin */
+    .grid-stack > .grid-stack-item.grid-stack-nested > .grid-stack-item-content {
+      inset: 2px;
     }
     /* make nested grid take entire item content */
     .grid-stack-item-content .grid-stack {
@@ -25,11 +27,12 @@
 <body>
   <div class="container-fluid">
     <h1>Nested grids demo</h1>
-    <p>This example uses new v3.1 API to load the entire nested grid from JSON, and shows dragging between nested grid items (pink) vs dragging higher items (green)</p>
-    <p>Note: HTML5 release doesn't yet support 'dragOut:false' constrain so use JQ version if you need that (nested 2 case).</p>
+    <p>This example shows v5.x dragging between nested grids (dark yellow) and parent grid (bright yellow.)<br>
+      Uses v3.1 API to load the entire nested grid from JSON.<br>
+      Nested grids uses new <b>column:'auto'</b> to keep items same size during resize.</p>
     <a class="btn btn-primary" onClick="addNested()" href="#">Add Widget</a>
-    <a class="btn btn-primary" onClick="addNewWidget('.nested1')" href="#">Add Widget Grid1</a>
-    <a class="btn btn-primary" onClick="addNewWidget('.nested2')" href="#">Add Widget Grid2</a>
+    <a class="btn btn-primary" onClick="addNewWidget('.sub1')" href="#">Add Widget Grid1</a>
+    <a class="btn btn-primary" onClick="addNewWidget('.sub2')" href="#">Add Widget Grid2</a>
     <span>entire save/re-create:</span>
     <a class="btn btn-primary" onClick="save()" href="#">Save</a>
     <a class="btn btn-primary" onClick="destroy()" href="#">Destroy</a>
@@ -49,21 +52,21 @@
     let count = 0;
     [...sub1, ...sub2].forEach(d => d.content = String(count++));
     let subOptions = {
-      cellHeight: 30,
-      column: 4, // make sure to include gridstack-extra.min.css
+      cellHeight: 50,
+      column: 'auto', // size to match container. make sure to include gridstack-extra.min.css
       acceptWidgets: true, // will accept .grid-stack-item by default
-      minWidth: 300, // min to go 1 column mode (much smaller than default)
-      margin: 2
+      margin: 5,
     };
     let options = { // main grid options
-      cellHeight: 70,
+      cellHeight: 50,
+      margin: 5,
       minRow: 2, // don't collapse when empty
       acceptWidgets: true,
       id: 'main',
       children: [
         {y:0, content: 'regular item'},
-        {x:1, w:4, h:4, subGrid: {children: sub1, dragOut: true, id: 'sub1', ...subOptions}},
-        {x:5, w:4, h:4, subGrid: {children: sub2, id: 'sub2', ...subOptions}},
+        {x:1, w:4, h:4, subGrid: {children: sub1, dragOut: true, class: 'sub1', ...subOptions}},
+        {x:5, w:3, h:4, subGrid: {children: sub2, class: 'sub2', ...subOptions}},
       ]
     };
 
@@ -71,7 +74,7 @@
     let grid = GridStack.addGrid(document.querySelector('.container-fluid'), options);
 
     addNested = function() {
-      grid.addWidget({x:0, y:0, content:"new item"});
+      grid.addWidget({x:0, y:100, content:"new item"});
     }
 
     addNewWidget = function(selector) {

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -68,6 +68,7 @@ Change log
 
 ## 4.4.1-dev (TBD)
 * add [#992](https://github.com/gridstack/gridstack.js/issues/992) support dragging into and out of nested grids from parents! Thank you [@arclogos132](https://github.com/arclogos132) for sponsoring it.
+* add [#1910](https://github.com/gridstack/gridstack.js/pull/1910) new `column:'auto'` option to size nested grids to their parent grid item column count, keeping items the same size inside and outside. Thank you [@arclogos132](https://github.com/arclogos132) for also sponsoring it.
 * fix [#1902](https://github.com/gridstack/gridstack.js/pull/1902) nested.html: dragging between sub-grids show items clipped
 * fix [#1558](https://github.com/gridstack/gridstack.js/issues/1558) dragging between vertical grids causes too much growth, not follow mouse.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -34,7 +34,7 @@ gridstack.js API
   - [`cellHeight(val: number, update = true)`](#cellheightval-number-update--true)
   - [`cellWidth()`](#cellwidth)
   - [`commit()`](#commit)
-  - [`column(column: number, layout: ColumnOptions = 'moveScale')`](#columncolumn-number-layout-columnoptions--movescale)
+  - [`column(column: number | 'auto', layout: ColumnOptions = 'moveScale')`](#columncolumn-number--auto-layout-columnoptions--movescale)
   - [`destroy([removeDOM])`](#destroyremovedom)
   - [`disable()`](#disable)
   - [`enable()`](#enable)
@@ -43,6 +43,7 @@ gridstack.js API
   - [`float(val?)`](#floatval)
   - [`getCellHeight()`](#getcellheight)
   - [`getCellFromPixel(position[, useOffset])`](#getcellfrompixelposition-useoffset)
+  - [`getColumn(): number`](#getcolumn-number)
   - [`getGridItems(): GridItemHTMLElement[]`](#getgriditems-griditemhtmlelement)
   - [`getMargin()`](#getmargin)
   - [`isAreaEmpty(x, y, width, height)`](#isareaemptyx-y-width-height)
@@ -365,14 +366,14 @@ Gets current cell width (grid width / # of columns).
 
 Ends batch updates. Updates DOM nodes. You must call it after `batchUpdate()`.
 
-### `column(column: number, layout: ColumnOptions = 'moveScale')`
+### `column(column: number | 'auto', layout: ColumnOptions = 'moveScale')`
 
-set/get the number of columns in the grid. Will update existing widgets to conform to new number of columns,
+set the number of columns in the grid. Will update existing widgets to conform to new number of columns,
 as well as cache the original layout so you can revert back to previous positions without loss.
-Requires `gridstack-extra.css` or `gridstack-extra.min.css` for [2-11],
+Requires `gridstack-extra.css` (or minimized version) for [2-11],
 else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
 
-- `column` - Integer > 0 (default 12), if missing it will return the current count instead.
+- `column` - Integer > 0 (default 12), or 'auto' for nested grids to size themselves to the parent grid container (to make su-items the same size inside and outside)
 - `layout` - specify the type of re-layout that will happen (position, size, etc...).
 Note: items will never be outside of the current column boundaries. default ('moveScale'). Ignored for 1 column.
 Possible values: 'moveScale' | 'move' | 'scale' | 'none' | (column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void.
@@ -444,6 +445,10 @@ Parameters :
 - `useOffset` - if `true`, value will be based on offset vs position (Optional. Default `false`). Useful when grid is within `position: relative` element.
 
 Returns an object with properties `x` and `y` i.e. the column and row in the grid.
+
+### `getColumn(): number`
+
+returns the number of columns in the grid.
 
 ### `getGridItems(): GridItemHTMLElement[]`
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,8 +71,11 @@ export interface GridStackOptions {
   /** list of children item to create when calling load() or addGrid() */
   children?: GridStackWidget[];
 
-  /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns */
-  column?: number;
+  /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns.
+   * Note: for nested grids, it is recommended to use 'auto' which will always match the container grid-item current width (in column) to keep inside and outside
+   * items always to same. flag is ignored for non nested grids.
+   */
+  column?: number | 'auto';
 
   /** additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance.
   Note: only used by addGrid(), else your element should have the needed class */


### PR DESCRIPTION
### Description
* part of #1009
* we now have a new `column:'auto'` option which is used for nested grids to column size themselves to match their container (same # of column)
This make sure outside and inside items stay the same size
* this will eventually be required when creating grids on the fly dynamically (as good default)
* updated nested.html to showcase this

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
