### PR TITLE
fix #418 Use of inline styles doesn't play nice with Content Security Policy

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -125,7 +125,6 @@ gridstack.js API
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)
 - `staticGrid` - removes drag|drop|resize (default `false`). If `true` widgets are not movable/resizable by the user, but code can still move and oneColumnMode will still work. You can use the smaller gridstack-static.js lib. A CSS class `grid-stack-static` is also added to the container.
-- `styleInHead` - if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`).
 
 ## Grid attributes
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -125,6 +125,7 @@ gridstack.js API
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)
 - `staticGrid` - removes drag|drop|resize (default `false`). If `true` widgets are not movable/resizable by the user, but code can still move and oneColumnMode will still work. You can use the smaller gridstack-static.js lib. A CSS class `grid-stack-static` is also added to the container.
+- `styleInHead` - if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`).
 
 ## Grid attributes
 

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -246,20 +246,7 @@ describe('gridstack', function() {
       expect(grid.getColumn()).toBe(12);
       grid.column(12);
       expect(grid.getColumn()).toBe(12);
-    }); 
-    it('should set construct CSS class', function() {
-      let grid = GridStack.init({column: 1});
-      expect(grid.el.classList.contains('grid-stack-1')).toBe(true);
-      grid.column(2);
-      expect(grid.el.classList.contains('grid-stack-1')).toBe(false);
-      expect(grid.el.classList.contains('grid-stack-2')).toBe(true);
-    }); 
-    it('should set CSS class', function() {
-      let grid = GridStack.init();
-      expect(grid.el.classList.contains('grid-stack')).toBe(true);
-      grid.column(1);
-      expect(grid.el.classList.contains('grid-stack-1')).toBe(true);
-    }); 
+    });
     it('should SMALL change column number, no relayout', function() {
       let options = {
         column: 12
@@ -1362,51 +1349,7 @@ describe('gridstack', function() {
       expect(grid.el.classList.contains('grid-stack-rtl')).toBe(false);
     });
   });
-  
-  describe('grid.opts.styleInHead', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should add STYLE to parent node as a default', function() {
-      var options = {
-        cellHeight: 80,
-        verticalMargin: 10,
-        float: false,
-      };
-      var grid = GridStack.init(options);
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('DIV'); // any to access private _styles
-    });
-    it('should add STYLE to HEAD if styleInHead === true', function() {
-      var options = {
-        cellHeight: 80,
-        verticalMargin: 10,
-        float: false,
-        styleInHead: true
-      };
-      var grid = GridStack.init(options);
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('HEAD'); // any to access private _styles
-    });
-  });
 
-  describe('grid.opts.styleInHead', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should add STYLE to parent node as a default', function() {
-      var grid = GridStack.init();
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('DIV');
-    });
-    it('should add STYLE to HEAD if styleInHead === true', function() {
-      var grid = GridStack.init({styleInHead: true});
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('HEAD');
-    });
-  });
 
   describe('grid.enableMove', function() {
     beforeEach(function() {

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -48,22 +48,6 @@ describe('gridstack utils', function() {
     });
   });
 
-  describe('test createStylesheet/removeStylesheet', function() {
-
-    it('should create/remove style DOM', function() {
-      let _id = 'test-123';
-      Utils.createStylesheet(_id);
-
-      let style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
-      expect(style).not.toBe(null);
-      // expect(style.prop('tagName')).toEqual('STYLE');
-
-      Utils.removeStylesheet(_id)
-      style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
-      expect(style).toBe(null);
-    });
-
-  });
 
   describe('test parseHeight', function() {
 

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -292,7 +292,9 @@ GridStack.prototype._setupAcceptWidget = function(this: GridStack): GridStack {
         } else {
           this.engine.removeNode(node);
         }
-        this._updateElementChildrenStyling(node.el);
+        if(!Utils.isConstructableStyleSheetSupported()) {
+          this._updateElementChildrenStyling(node.el);
+        }
       });
 
       return false; // prevent parent from receiving msg (which may be grid as well)

--- a/src/gridstack-dd.ts
+++ b/src/gridstack-dd.ts
@@ -292,6 +292,7 @@ GridStack.prototype._setupAcceptWidget = function(this: GridStack): GridStack {
         } else {
           this.engine.removeNode(node);
         }
+        this._updateElementChildrenStyling(node.el);
       });
 
       return false; // prevent parent from receiving msg (which may be grid as well)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1198,22 +1198,7 @@ export class GridStack {
 
       // these are done once only
       Utils.updateStyleOnElements(prefix, {'min-height': cellHeight+cellHeightUnit});
-      // content margins
-      let top: string = this.opts.marginTop + this.opts.marginUnit;
-      let bottom: string = this.opts.marginBottom + this.opts.marginUnit;
-      let right: string = this.opts.marginRight + this.opts.marginUnit;
-      let left: string = this.opts.marginLeft + this.opts.marginUnit;
-      let content = `${prefix} > .grid-stack-item-content`;
-      let placeholder = `.${this.opts._styleSheetClass} > .grid-stack-placeholder > .placeholder-content`;
-      Utils.updateStyleOnElements(content, {top, right, bottom, left});
-      Utils.updateStyleOnElements(placeholder, {top, right, bottom, left});
-      // resize handles offset (to match margin)
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-ne`, {right});
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-e`, {right});
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-se`, {right, bottom});
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-nw`, {left});
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-w`, {left});
-      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-sw`, {left, bottom});
+      this._updateElementChildrenStyling(undefined, prefix);
     }
 
     // apply position styling on all dirty node's elements
@@ -1232,22 +1217,40 @@ export class GridStack {
   }
 
   /** @internal update Styling  */
-  protected _updateElementChildrenStyling(el: HTMLElement): void {
+  protected _updateElementChildrenStyling(el?: HTMLElement, prefix?: string): void {
     let top: string = this.opts.marginTop + this.opts.marginUnit;
     let bottom: string = this.opts.marginBottom + this.opts.marginUnit;
     let right: string = this.opts.marginRight + this.opts.marginUnit;
     let left: string = this.opts.marginLeft + this.opts.marginUnit;
-    let content = `.grid-stack-item-content`;
+    let content: string;
     let placeholder = `.${this.opts._styleSheetClass} > .grid-stack-placeholder > .placeholder-content`;
-    Utils.updateStyleOnElements([el.querySelector(content) as HTMLElement], {top, right, bottom, left});
-    Utils.updateStyleOnElements(placeholder, {top, right, bottom, left});
-    // resize handles offset (to match margin)
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-ne`) as HTMLElement], {right});
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-e`) as HTMLElement], {right});
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-se`) as HTMLElement], {right, bottom});
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-nw`) as HTMLElement], {left});
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-w`) as HTMLElement], {left});
-    Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-sw`) as HTMLElement], {left, bottom});
+    if (el!==undefined) {
+      content = `.grid-stack-item-content`
+      // content margins
+      Utils.updateStyleOnElements([el.querySelector(content) as HTMLElement], {top, right, bottom, left});
+      Utils.updateStyleOnElements(placeholder, {top, right, bottom, left});
+      // resize handles offset (to match margin)
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-ne`) as HTMLElement], {right});
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-e`) as HTMLElement], {right});
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-se`) as HTMLElement], {right, bottom});
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-nw`) as HTMLElement], {left});
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-w`) as HTMLElement], {left});
+      Utils.updateStyleOnElements([el.querySelector(`.ui-resizable-sw`) as HTMLElement], {left, bottom});
+    }
+
+    if (prefix!= undefined) {
+      content = `${prefix} > .grid-stack-item-content`;
+      // content margins
+      Utils.updateStyleOnElements(content, {top, right, bottom, left});
+      Utils.updateStyleOnElements(placeholder, {top, right, bottom, left});
+      // resize handles offset (to match margin)
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-ne`, {right});
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-e`, {right});
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-se`, {right, bottom});
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-nw`, {left});
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-w`, {left});
+      Utils.updateStyleOnElements(`${prefix} > .ui-resizable-sw`, {left, bottom});
+    }
   }
 
   /** @internal */

--- a/src/h5/dd-draggable.ts
+++ b/src/h5/dd-draggable.ts
@@ -10,350 +10,350 @@ import { GridItemHTMLElement, DDUIData } from '../types';
 
 // TODO: merge with DDDragOpt ?
 export interface DDDraggableOpt {
-  appendTo?: string | HTMLElement;
-  containment?: string | HTMLElement; // TODO: not implemented yet
-  handle?: string;
-  revert?: string | boolean | unknown; // TODO: not implemented yet
-  scroll?: boolean; // nature support by HTML5 drag drop, can't be switch to off actually
-  helper?: string | HTMLElement | ((event: Event) => HTMLElement);
-  start?: (event: Event, ui: DDUIData) => void;
-  stop?: (event: Event) => void;
-  drag?: (event: Event, ui: DDUIData) => void;
-}
+   appendTo?: string | HTMLElement;
+   containment?: string | HTMLElement; // TODO: not implemented yet
+   handle?: string;
+   revert?: string | boolean | unknown; // TODO: not implemented yet
+   scroll?: boolean; // nature support by HTML5 drag drop, can't be switch to off actually
+   helper?: string | HTMLElement | ((event: Event) => HTMLElement);
+   start?: (event: Event, ui: DDUIData) => void;
+   stop?: (event: Event) => void;
+   drag?: (event: Event, ui: DDUIData) => void;
+ }
 
-interface DragOffset {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-  offsetLeft: number;
-  offsetTop: number;
-}
+ interface DragOffset {
+   left: number;
+   top: number;
+   width: number;
+   height: number;
+   offsetLeft: number;
+   offsetTop: number;
+ }
 
 export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt<DDDraggableOpt> {
-  public el: HTMLElement;
-  public option: DDDraggableOpt;
-  public helper: HTMLElement; // used by GridStackDDNative
+   public el: HTMLElement;
+   public option: DDDraggableOpt;
+   public helper: HTMLElement; // used by GridStackDDNative
 
-  /** @internal */
-  protected dragOffset: DragOffset;
-  /** @internal */
-  protected dragElementOriginStyle: Array<string>;
-  /** @internal */
-  protected dragFollowTimer: number;
-  /** @internal */
-  protected dragEl: HTMLElement;
-  /** @internal */
-  protected dragging = false;
-  /** @internal */
-  protected paintTimer: number;
-  /** @internal */
-  protected parentOriginStylePosition: string;
-  /** @internal */
-  protected helperContainment: HTMLElement;
-  /** @internal #1541 can't have {passive: true} on Safari as otherwise it reverts animate back to old location on drop */
-  protected static dragEventListenerOption = true; // DDUtils.isEventSupportPassiveOption ? { capture: true, passive: true } : true;
-  /** @internal properties we change during dragging, and restore back */
-  protected static originStyleProp = ['transition', 'pointerEvents', 'position',
-    'left', 'top', 'opacity', 'zIndex', 'width', 'height', 'willChange', 'min-width'];
+   /** @internal */
+   protected dragOffset: DragOffset;
+   /** @internal */
+   protected dragElementOriginStyle: Array<string>;
+   /** @internal */
+   protected dragFollowTimer: number;
+   /** @internal */
+   protected dragEl: HTMLElement;
+   /** @internal */
+   protected dragging = false;
+   /** @internal */
+   protected paintTimer: number;
+   /** @internal */
+   protected parentOriginStylePosition: string;
+   /** @internal */
+   protected helperContainment: HTMLElement;
+   /** @internal #1541 can't have {passive: true} on Safari as otherwise it reverts animate back to old location on drop */
+   protected static dragEventListenerOption = true; // DDUtils.isEventSupportPassiveOption ? { capture: true, passive: true } : true;
+   /** @internal properties we change during dragging, and restore back */
+   protected static originStyleProp = ['transition', 'pointerEvents', 'position',
+     'left', 'top', 'opacity', 'zIndex', 'width', 'height', 'willChange', 'min-width'];
 
-  constructor(el: HTMLElement, option: DDDraggableOpt = {}) {
-    super();
-    this.el = el;
-    this.option = option;
-    // get the element that is actually supposed to be dragged by
-    let className = option.handle.substring(1);
-    this.dragEl = el.classList.contains(className) ? el : el.querySelector(option.handle) || el;
-    // create var event binding so we can easily remove and still look like TS methods (unlike anonymous functions)
-    this._dragStart = this._dragStart.bind(this);
-    this._drag = this._drag.bind(this);
-    this._dragEnd = this._dragEnd.bind(this);
-    this.enable();
-  }
+   constructor(el: HTMLElement, option: DDDraggableOpt = {}) {
+     super();
+     this.el = el;
+     this.option = option;
+     // get the element that is actually supposed to be dragged by
+     let className = option.handle.substring(1);
+     this.dragEl = el.classList.contains(className) ? el : el.querySelector(option.handle) || el;
+     // create var event binding so we can easily remove and still look like TS methods (unlike anonymous functions)
+     this._dragStart = this._dragStart.bind(this);
+     this._drag = this._drag.bind(this);
+     this._dragEnd = this._dragEnd.bind(this);
+     this.enable();
+   }
 
-  public on(event: 'drag' | 'dragstart' | 'dragstop', callback: (event: DragEvent) => void): void {
-    super.on(event, callback);
-  }
+   public on(event: 'drag' | 'dragstart' | 'dragstop', callback: (event: DragEvent) => void): void {
+     super.on(event, callback);
+   }
 
-  public off(event: 'drag' | 'dragstart' | 'dragstop'): void {
-    super.off(event);
-  }
+   public off(event: 'drag' | 'dragstart' | 'dragstop'): void {
+     super.off(event);
+   }
 
-  public enable(): void {
-    super.enable();
-    this.dragEl.draggable = true;
-    this.dragEl.addEventListener('dragstart', this._dragStart);
-    this.el.classList.remove('ui-draggable-disabled');
-    this.el.classList.add('ui-draggable');
-  }
+   public enable(): void {
+     super.enable();
+     this.dragEl.draggable = true;
+     this.dragEl.addEventListener('dragstart', this._dragStart);
+     this.el.classList.remove('ui-draggable-disabled');
+     this.el.classList.add('ui-draggable');
+   }
 
-  public disable(forDestroy = false): void {
-    super.disable();
-    this.dragEl.removeAttribute('draggable');
-    this.dragEl.removeEventListener('dragstart', this._dragStart);
-    this.el.classList.remove('ui-draggable');
-    if (!forDestroy) this.el.classList.add('ui-draggable-disabled');
-  }
+   public disable(forDestroy = false): void {
+     super.disable();
+     this.dragEl.removeAttribute('draggable');
+     this.dragEl.removeEventListener('dragstart', this._dragStart);
+     this.el.classList.remove('ui-draggable');
+     if (!forDestroy) this.el.classList.add('ui-draggable-disabled');
+   }
 
-  public destroy(): void {
-    if (this.dragging) {
-      // Destroy while dragging should remove dragend listener and manually trigger
-      // dragend, otherwise dragEnd can't perform dragstop because eventRegistry is
-      // destroyed.
-      this._dragEnd({} as DragEvent);
-    }
-    this.disable(true);
-    delete this.el;
-    delete this.helper;
-    delete this.option;
-    super.destroy();
-  }
+   public destroy(): void {
+     if (this.dragging) {
+       // Destroy while dragging should remove dragend listener and manually trigger
+       // dragend, otherwise dragEnd can't perform dragstop because eventRegistry is
+       // destroyed.
+       this._dragEnd({} as DragEvent);
+     }
+     this.disable(true);
+     delete this.el;
+     delete this.helper;
+     delete this.option;
+     super.destroy();
+   }
 
-  public updateOption(opts: DDDraggableOpt): DDDraggable {
-    Object.keys(opts).forEach(key => this.option[key] = opts[key]);
-    return this;
-  }
+   public updateOption(opts: DDDraggableOpt): DDDraggable {
+     Object.keys(opts).forEach(key => this.option[key] = opts[key]);
+     return this;
+   }
 
-  /** @internal */
-  protected _dragStart(event: DragEvent): void {
-    DDManager.dragElement = this;
-    this.helper = this._createHelper(event);
-    this._setupHelperContainmentStyle();
-    this.dragOffset = this._getDragOffset(event, this.el, this.helperContainment);
-    const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dragstart' });
-    if (this.helper !== this.el) {
-      this._setupDragFollowNodeNotifyStart(ev);
-      // immediately set external helper initial position to avoid flickering behavior and unnecessary looping in `_packNodes()`
-      this._dragFollow(event);
-    } else {
-      this.dragFollowTimer = window.setTimeout(() => {
-        delete this.dragFollowTimer;
-        this._setupDragFollowNodeNotifyStart(ev);
-      }, 0);
-    }
-    this._cancelDragGhost(event);
-  }
+   /** @internal */
+   protected _dragStart(event: DragEvent): void {
+     DDManager.dragElement = this;
+     this.helper = this._createHelper(event);
+     this._setupHelperContainmentStyle();
+     this.dragOffset = this._getDragOffset(event, this.el, this.helperContainment);
+     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dragstart' });
+     if (this.helper !== this.el) {
+       this._setupDragFollowNodeNotifyStart(ev);
+       // immediately set external helper initial position to avoid flickering behavior and unnecessary looping in `_packNodes()`
+       this._dragFollow(event);
+     } else {
+       this.dragFollowTimer = window.setTimeout(() => {
+         delete this.dragFollowTimer;
+         this._setupDragFollowNodeNotifyStart(ev);
+       }, 0);
+     }
+     this._cancelDragGhost(event);
+   }
 
-  /** @internal */
-  protected _setupDragFollowNodeNotifyStart(ev: Event): DDDraggable {
-    this._setupHelperStyle();
-    document.addEventListener('dragover', this._drag, DDDraggable.dragEventListenerOption);
-    this.dragEl.addEventListener('dragend', this._dragEnd);
-    if (this.option.start) {
-      this.option.start(ev, this.ui());
-    }
-    this.dragging = true;
-    this.helper.classList.add('ui-draggable-dragging');
-    this.triggerEvent('dragstart', ev);
-    return this;
-  }
+   /** @internal */
+   protected _setupDragFollowNodeNotifyStart(ev: Event): DDDraggable {
+     this._setupHelperStyle();
+     document.addEventListener('dragover', this._drag, DDDraggable.dragEventListenerOption);
+     this.dragEl.addEventListener('dragend', this._dragEnd);
+     if (this.option.start) {
+       this.option.start(ev, this.ui());
+     }
+     this.dragging = true;
+     this.helper.classList.add('ui-draggable-dragging');
+     this.triggerEvent('dragstart', ev);
+     return this;
+   }
 
-  /** @internal */
-  protected _drag(event: DragEvent): void {
-    // Safari: prevent default to allow drop to happen instead of reverting back (with animation) and delaying dragend #1541
-    // https://stackoverflow.com/questions/61760755/how-to-fire-dragend-event-immediately
-    event.preventDefault();
-    this._dragFollow(event);
-    const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'drag' });
-    if (this.option.drag) {
-      this.option.drag(ev, this.ui());
-    }
-    this.triggerEvent('drag', ev);
-  }
+   /** @internal */
+   protected _drag(event: DragEvent): void {
+     // Safari: prevent default to allow drop to happen instead of reverting back (with animation) and delaying dragend #1541
+     // https://stackoverflow.com/questions/61760755/how-to-fire-dragend-event-immediately
+     event.preventDefault();
+     this._dragFollow(event);
+     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'drag' });
+     if (this.option.drag) {
+       this.option.drag(ev, this.ui());
+     }
+     this.triggerEvent('drag', ev);
+   }
 
-  /** @internal */
-  protected _dragEnd(event: DragEvent): void {
-    if (this.dragFollowTimer) {
-      clearTimeout(this.dragFollowTimer);
-      delete this.dragFollowTimer;
-      return;
-    } else {
-      if (this.paintTimer) {
-        cancelAnimationFrame(this.paintTimer);
-      }
-      document.removeEventListener('dragover', this._drag, DDDraggable.dragEventListenerOption);
-      this.dragEl.removeEventListener('dragend', this._dragEnd);
-    }
-    this.dragging = false;
-    this.helper.classList.remove('ui-draggable-dragging');
-    this.helperContainment.style.position = this.parentOriginStylePosition || null;
-    if (this.helper === this.el) {
-      this._removeHelperStyle();
-    } else {
-      this.helper.remove();
-    }
-    const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dragstop' });
-    if (this.option.stop) {
-      this.option.stop(ev); // Note: ui() not used by gridstack so don't pass
-    }
-    this.triggerEvent('dragstop', ev);
-    delete DDManager.dragElement;
-    delete this.helper;
-  }
+   /** @internal */
+   protected _dragEnd(event: DragEvent): void {
+     if (this.dragFollowTimer) {
+       clearTimeout(this.dragFollowTimer);
+       delete this.dragFollowTimer;
+       return;
+     } else {
+       if (this.paintTimer) {
+         cancelAnimationFrame(this.paintTimer);
+       }
+       document.removeEventListener('dragover', this._drag, DDDraggable.dragEventListenerOption);
+       this.dragEl.removeEventListener('dragend', this._dragEnd);
+     }
+     this.dragging = false;
+     this.helper.classList.remove('ui-draggable-dragging');
+     this.helperContainment.style.position = this.parentOriginStylePosition || null;
+     if (this.helper === this.el) {
+       this._removeHelperStyle();
+     } else {
+       this.helper.remove();
+     }
+     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dragstop' });
+     if (this.option.stop) {
+       this.option.stop(ev); // Note: ui() not used by gridstack so don't pass
+     }
+     this.triggerEvent('dragstop', ev);
+     delete DDManager.dragElement;
+     delete this.helper;
+   }
 
-  /** @internal create a clone copy (or user defined method) of the original drag item if set */
-  protected _createHelper(event: DragEvent): HTMLElement {
-    let helper = this.el;
-    if (typeof this.option.helper === 'function') {
-      helper = this.option.helper(event);
-    } else if (this.option.helper === 'clone') {
-      helper = DDUtils.clone(this.el);
-    }
-    if (!document.body.contains(helper)) {
-      DDUtils.appendTo(helper, this.option.appendTo === 'parent' ? this.el.parentNode : this.option.appendTo);
-    }
-    if (helper === this.el) {
-      this.dragElementOriginStyle = DDDraggable.originStyleProp.map(prop => this.el.style[prop]);
-    }
-    return helper;
-  }
+   /** @internal create a clone copy (or user defined method) of the original drag item if set */
+   protected _createHelper(event: DragEvent): HTMLElement {
+     let helper = this.el;
+     if (typeof this.option.helper === 'function') {
+       helper = this.option.helper(event);
+     } else if (this.option.helper === 'clone') {
+       helper = DDUtils.clone(this.el);
+     }
+     if (!document.body.contains(helper)) {
+       DDUtils.appendTo(helper, this.option.appendTo === 'parent' ? this.el.parentNode : this.option.appendTo);
+     }
+     if (helper === this.el) {
+       this.dragElementOriginStyle = DDDraggable.originStyleProp.map(prop => this.el.style[prop]);
+     }
+     return helper;
+   }
 
-  /** @internal */
-  protected _setupHelperStyle(): DDDraggable {
-    // TODO: set all at once with style.cssText += ... ? https://stackoverflow.com/questions/3968593
-    const rec = this.helper.getBoundingClientRect();
-    const style = this.helper.style;
-    style.pointerEvents = 'none';
-    style['min-width'] = 0; // since we no longer relative to our parent and we don't resize anyway (normally 100/#column %)
-    style.width = this.dragOffset.width + 'px';
-    style.height = this.dragOffset.height + 'px';
-    style.willChange = 'left, top';
-    style.position = 'fixed'; // let us drag between grids by not clipping as parent .grid-stack is position: 'relative'
-    style.left = rec.left + 'px';
-    style.top = rec.top + 'px';
-    style.transition = 'none'; // show up instantly
-    setTimeout(() => {
-      if (this.helper) {
-        style.transition = null; // recover animation
-      }
-    }, 0);
-    return this;
-  }
+   /** @internal */
+   protected _setupHelperStyle(): DDDraggable {
+     // TODO: set all at once with style.cssText += ... ? https://stackoverflow.com/questions/3968593
+     const rec = this.helper.getBoundingClientRect();
+     const style = this.helper.style;
+     style.pointerEvents = 'none';
+     style['min-width'] = 0; // since we no longer relative to our parent and we don't resize anyway (normally 100/#column %)
+     style.width = this.dragOffset.width + 'px';
+     style.height = this.dragOffset.height + 'px';
+     style.willChange = 'left, top';
+     style.position = 'fixed'; // let us drag between grids by not clipping as parent .grid-stack is position: 'relative'
+     style.left = rec.left + 'px';
+     style.top = rec.top + 'px';
+     style.transition = 'none'; // show up instantly
+     setTimeout(() => {
+       if (this.helper) {
+         style.transition = null; // recover animation
+       }
+     }, 0);
+     return this;
+   }
 
-  /** @internal */
-  protected _removeHelperStyle(): DDDraggable {
-    let node = (this.helper as GridItemHTMLElement)?.gridstackNode;
-    // don't bother restoring styles if we're gonna remove anyway...
-    if (this.dragElementOriginStyle && (!node || !node._isAboutToRemove)) {
-      let helper = this.helper;
-      // don't animate, otherwise we animate offseted when switching back to 'absolute' from 'fixed' 
-      let transition = this.dragElementOriginStyle['transition'] || null;
-      helper.style.transition = this.dragElementOriginStyle['transition'] = 'none';
-      DDDraggable.originStyleProp.forEach(prop => helper.style[prop] = this.dragElementOriginStyle[prop] || null);
-      setTimeout(() => helper.style.transition = transition, 50); // recover animation from saved vars after a pause (0 isn't enough #1973)
-    }
-    delete this.dragElementOriginStyle;
-    return this;
-  }
+   /** @internal */
+   protected _removeHelperStyle(): DDDraggable {
+     let node = (this.helper as GridItemHTMLElement)?.gridstackNode;
+     // don't bother restoring styles if we're gonna remove anyway...
+     if (this.dragElementOriginStyle && (!node || !node._isAboutToRemove)) {
+       let helper = this.helper;
+       // don't animate, otherwise we animate offseted when switching back to 'absolute' from 'fixed'
+       let transition = this.dragElementOriginStyle['transition'] || null;
+       helper.style.transition = this.dragElementOriginStyle['transition'] = 'none';
+       DDDraggable.originStyleProp.forEach(prop => helper.style[prop] = this.dragElementOriginStyle[prop] || null);
+       setTimeout(() => helper.style.transition = transition, 50); // recover animation from saved vars after a pause (0 isn't enough #1973)
+     }
+     delete this.dragElementOriginStyle;
+     return this;
+   }
 
-  /** @internal */
-  protected _dragFollow(event: DragEvent): void {
-    if (this.paintTimer) {
-      cancelAnimationFrame(this.paintTimer);
-    }
-    this.paintTimer = requestAnimationFrame(() => {
-      delete this.paintTimer;
-      const offset = this.dragOffset;
-      let containmentRect = { left: 0, top: 0 };
-      if (this.helper.style.position === 'absolute') {
-        const { left, top } = this.helperContainment.getBoundingClientRect();
-        containmentRect = { left, top };
-      }
-      this.helper.style.left = event.clientX + offset.offsetLeft - containmentRect.left + 'px';
-      this.helper.style.top = event.clientY + offset.offsetTop - containmentRect.top + 'px';
-    });
-  }
+   /** @internal */
+   protected _dragFollow(event: DragEvent): void {
+     if (this.paintTimer) {
+       cancelAnimationFrame(this.paintTimer);
+     }
+     this.paintTimer = requestAnimationFrame(() => {
+       delete this.paintTimer;
+       const offset = this.dragOffset;
+       let containmentRect = { left: 0, top: 0 };
+       if (this.helper.style.position === 'absolute') {
+         const { left, top } = this.helperContainment.getBoundingClientRect();
+         containmentRect = { left, top };
+       }
+       this.helper.style.left = event.clientX + offset.offsetLeft - containmentRect.left + 'px';
+       this.helper.style.top = event.clientY + offset.offsetTop - containmentRect.top + 'px';
+     });
+   }
 
-  /** @internal */
-  protected _setupHelperContainmentStyle(): DDDraggable {
-    this.helperContainment = this.helper.parentElement;
-    if (this.helper.style.position !== 'fixed') {
-      this.parentOriginStylePosition = this.helperContainment.style.position;
-      if (window.getComputedStyle(this.helperContainment).position.match(/static/)) {
-        this.helperContainment.style.position = 'relative';
-      }
-    }
-    return this;
-  }
+   /** @internal */
+   protected _setupHelperContainmentStyle(): DDDraggable {
+     this.helperContainment = this.helper.parentElement;
+     if (this.helper.style.position !== 'fixed') {
+       this.parentOriginStylePosition = this.helperContainment.style.position;
+       if (window.getComputedStyle(this.helperContainment).position.match(/static/)) {
+         this.helperContainment.style.position = 'relative';
+       }
+     }
+     return this;
+   }
 
-  /** @internal prevent the default ghost image to be created (which has wrong as we move the helper/element instead
-   * (legacy jquery UI code updates the top/left of the item).
-   * TODO: maybe use mouse event instead of HTML5 drag as we have to work around it anyway, or change code to not update
-   * the actual grid-item but move the ghost image around (and special case jq version) ?
-   **/
-  protected _cancelDragGhost(e: DragEvent): DDDraggable {
-    /* doesn't seem to do anything...
-    let t = e.dataTransfer;
-    t.effectAllowed = 'none';
-    t.dropEffect = 'none';
-    t.setData('text', '');
-    */
+   /** @internal prevent the default ghost image to be created (which has wrong as we move the helper/element instead
+    * (legacy jquery UI code updates the top/left of the item).
+    * TODO: maybe use mouse event instead of HTML5 drag as we have to work around it anyway, or change code to not update
+    * the actual grid-item but move the ghost image around (and special case jq version) ?
+    **/
+   protected _cancelDragGhost(e: DragEvent): DDDraggable {
+     /* doesn't seem to do anything...
+     let t = e.dataTransfer;
+     t.effectAllowed = 'none';
+     t.dropEffect = 'none';
+     t.setData('text', '');
+     */
 
-    // NOTE: according to spec (and required by Safari see #1540) the image has to be visible in the browser (in dom and not hidden) so make it a 1px div
-    let img = document.createElement('div');
-    img.style.width = '1px';
-    img.style.height = '1px';
-    img.style.position = 'fixed'; // prevent unwanted scrollbar
-    document.body.appendChild(img);
-    e.dataTransfer.setDragImage(img, 0, 0);
-    setTimeout(() => document.body.removeChild(img)); // nuke once drag had a chance to grab this 'image'
+     // NOTE: according to spec (and required by Safari see #1540) the image has to be visible in the browser (in dom and not hidden) so make it a 1px div
+     let img = document.createElement('div');
+     img.style.width = '1px';
+     img.style.height = '1px';
+     img.style.position = 'fixed'; // prevent unwanted scrollbar
+     document.body.appendChild(img);
+     e.dataTransfer.setDragImage(img, 0, 0);
+     setTimeout(() => document.body.removeChild(img)); // nuke once drag had a chance to grab this 'image'
 
-    e.stopPropagation();
-    return this;
-  }
+     e.stopPropagation();
+     return this;
+   }
 
-  /** @internal */
-  protected _getDragOffset(event: DragEvent, el: HTMLElement, parent: HTMLElement): DragOffset {
+   /** @internal */
+   protected _getDragOffset(event: DragEvent, el: HTMLElement, parent: HTMLElement): DragOffset {
 
-    // in case ancestor has transform/perspective css properties that change the viewpoint
-    let xformOffsetX = 0;
-    let xformOffsetY = 0;
-    if (parent) {
-      const testEl = document.createElement('div');
-      DDUtils.addElStyles(testEl, {
-        opacity: '0',
-        position: 'fixed',
-        top: 0 + 'px',
-        left: 0 + 'px',
-        width: '1px',
-        height: '1px',
-        zIndex: '-999999',
-      });
-      parent.appendChild(testEl);
-      const testElPosition = testEl.getBoundingClientRect();
-      parent.removeChild(testEl);
-      xformOffsetX = testElPosition.left;
-      xformOffsetY = testElPosition.top;
-      // TODO: scale ?
-    }
+     // in case ancestor has transform/perspective css properties that change the viewpoint
+     let xformOffsetX = 0;
+     let xformOffsetY = 0;
+     if (parent) {
+       const testEl = document.createElement('div');
+       DDUtils.addElStyles(testEl, {
+         opacity: '0',
+         position: 'fixed',
+         top: 0 + 'px',
+         left: 0 + 'px',
+         width: '1px',
+         height: '1px',
+         zIndex: '-999999',
+       });
+       parent.appendChild(testEl);
+       const testElPosition = testEl.getBoundingClientRect();
+       parent.removeChild(testEl);
+       xformOffsetX = testElPosition.left;
+       xformOffsetY = testElPosition.top;
+       // TODO: scale ?
+     }
 
-    const targetOffset = el.getBoundingClientRect();
-    return {
-      left: targetOffset.left,
-      top: targetOffset.top,
-      offsetLeft: - event.clientX + targetOffset.left - xformOffsetX,
-      offsetTop: - event.clientY + targetOffset.top - xformOffsetY,
-      width: targetOffset.width,
-      height: targetOffset.height
-    };
-  }
+     const targetOffset = el.getBoundingClientRect();
+     return {
+       left: targetOffset.left,
+       top: targetOffset.top,
+       offsetLeft: - event.clientX + targetOffset.left - xformOffsetX,
+       offsetTop: - event.clientY + targetOffset.top - xformOffsetY,
+       width: targetOffset.width,
+       height: targetOffset.height
+     };
+   }
 
-  /** @internal TODO: set to public as called by DDDroppable! */
-  public ui = (): DDUIData => {
-    const containmentEl = this.el.parentElement;
-    const containmentRect = containmentEl.getBoundingClientRect();
-    const offset = this.helper.getBoundingClientRect();
-    return {
-      position: { //Current CSS position of the helper as { top, left } object
-        top: offset.top - containmentRect.top,
-        left: offset.left - containmentRect.left
-      }
-      /* not used by GridStack for now...
-      helper: [this.helper], //The object arr representing the helper that's being dragged.
-      offset: { top: offset.top, left: offset.left } // Current offset position of the helper as { top, left } object.
-      */
-    };
-  }
+   /** @internal TODO: set to public as called by DDDroppable! */
+   public ui = (): DDUIData => {
+     const containmentEl = this.el.parentElement;
+     const containmentRect = containmentEl.getBoundingClientRect();
+     const offset = this.helper.getBoundingClientRect();
+     return {
+       position: { //Current CSS position of the helper as { top, left } object
+         top: offset.top - containmentRect.top,
+         left: offset.left - containmentRect.left
+       }
+       /* not used by GridStack for now...
+       helper: [this.helper], //The object arr representing the helper that's being dragged.
+       offset: { top: offset.top, left: offset.left } // Current offset position of the helper as { top, left } object.
+       */
+     };
+   }
 }
 
 

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -11,189 +11,189 @@ import { GridHTMLElement, GridStack } from '../gridstack';
 import { GridItemHTMLElement } from '../types';
 
 export interface DDDroppableOpt {
-  accept?: string | ((el: HTMLElement) => boolean);
-  drop?: (event: DragEvent, ui) => void;
-  over?: (event: DragEvent, ui) => void;
-  out?: (event: DragEvent, ui) => void;
-}
+   accept?: string | ((el: HTMLElement) => boolean);
+   drop?: (event: DragEvent, ui) => void;
+   over?: (event: DragEvent, ui) => void;
+   out?: (event: DragEvent, ui) => void;
+ }
 
 // TEST let count = 0;
 
 export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt<DDDroppableOpt> {
 
-  public accept: (el: HTMLElement) => boolean;
-  public el: HTMLElement;
-  public option: DDDroppableOpt;
+   public accept: (el: HTMLElement) => boolean;
+   public el: HTMLElement;
+   public option: DDDroppableOpt;
 
-  /** @internal */
-  protected moving: boolean;
-  protected static lastActive: DDDroppable;
+   /** @internal */
+   protected moving: boolean;
+   protected static lastActive: DDDroppable;
 
-  constructor(el: HTMLElement, opts: DDDroppableOpt = {}) {
-    super();
-    this.el = el;
-    this.option = opts;
-    // create var event binding so we can easily remove and still look like TS methods (unlike anonymous functions)
-    this._dragEnter = this._dragEnter.bind(this);
-    this._dragOver = this._dragOver.bind(this);
-    this._dragLeave = this._dragLeave.bind(this);
-    this._drop = this._drop.bind(this);
+   constructor(el: HTMLElement, opts: DDDroppableOpt = {}) {
+     super();
+     this.el = el;
+     this.option = opts;
+     // create var event binding so we can easily remove and still look like TS methods (unlike anonymous functions)
+     this._dragEnter = this._dragEnter.bind(this);
+     this._dragOver = this._dragOver.bind(this);
+     this._dragLeave = this._dragLeave.bind(this);
+     this._drop = this._drop.bind(this);
 
-    this.el.classList.add('ui-droppable');
-    this.el.addEventListener('dragenter', this._dragEnter);
-    this._setupAccept();
-  }
+     this.el.classList.add('ui-droppable');
+     this.el.addEventListener('dragenter', this._dragEnter);
+     this._setupAccept();
+   }
 
-  public on(event: 'drop' | 'dropover' | 'dropout', callback: (event: DragEvent) => void): void {
-    super.on(event, callback);
-  }
+   public on(event: 'drop' | 'dropover' | 'dropout', callback: (event: DragEvent) => void): void {
+     super.on(event, callback);
+   }
 
-  public off(event: 'drop' | 'dropover' | 'dropout'): void {
-    super.off(event);
-  }
+   public off(event: 'drop' | 'dropover' | 'dropout'): void {
+     super.off(event);
+   }
 
-  public enable(): void {
-    if (!this.disabled) return;
-    super.enable();
-    this.el.classList.remove('ui-droppable-disabled');
-    this.el.addEventListener('dragenter', this._dragEnter);
-  }
+   public enable(): void {
+     if (!this.disabled) return;
+     super.enable();
+     this.el.classList.remove('ui-droppable-disabled');
+     this.el.addEventListener('dragenter', this._dragEnter);
+   }
 
-  public disable(forDestroy=false): void {
-    if (this.disabled) return;
-    super.disable();
-    if (!forDestroy) this.el.classList.add('ui-droppable-disabled');
-    this.el.removeEventListener('dragenter', this._dragEnter);
-  }
+   public disable(forDestroy=false): void {
+     if (this.disabled) return;
+     super.disable();
+     if (!forDestroy) this.el.classList.add('ui-droppable-disabled');
+     this.el.removeEventListener('dragenter', this._dragEnter);
+   }
 
-  public destroy(): void {
-    this._removeLeaveCallbacks();
-    this.disable(true);
-    this.el.classList.remove('ui-droppable');
-    this.el.classList.remove('ui-droppable-disabled');
-    super.destroy();
-  }
+   public destroy(): void {
+     this._removeLeaveCallbacks();
+     this.disable(true);
+     this.el.classList.remove('ui-droppable');
+     this.el.classList.remove('ui-droppable-disabled');
+     super.destroy();
+   }
 
-  public updateOption(opts: DDDroppableOpt): DDDroppable {
-    Object.keys(opts).forEach(key => this.option[key] = opts[key]);
-    this._setupAccept();
-    return this;
-  }
+   public updateOption(opts: DDDroppableOpt): DDDroppable {
+     Object.keys(opts).forEach(key => this.option[key] = opts[key]);
+     this._setupAccept();
+     return this;
+   }
 
-  /** @internal called when the cursor enters our area - prepare for a possible drop and track leaving */
-  protected _dragEnter(event: DragEvent): void {
-    // TEST console.log(`${count++} Enter ${(this.el as GridHTMLElement).gridstack.opts.id}`);
-    if (!this._canDrop()) return;
-    event.preventDefault();
-    event.stopPropagation();
+   /** @internal called when the cursor enters our area - prepare for a possible drop and track leaving */
+   protected _dragEnter(event: DragEvent): void {
+     // TEST console.log(`${count++} Enter ${(this.el as GridHTMLElement).gridstack.opts.id}`);
+     if (!this._canDrop()) return;
+     event.preventDefault();
+     event.stopPropagation();
 
-    // ignore multiple 'dragenter' as we go over existing items
-    if (this.moving) return;
-    this.moving = true;
+     // ignore multiple 'dragenter' as we go over existing items
+     if (this.moving) return;
+     this.moving = true;
 
-    const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dropover' });
-    if (this.option.over) {
-      this.option.over(ev, this._ui(DDManager.dragElement))
-    }
-    this.triggerEvent('dropover', ev);
-    this.el.addEventListener('dragover', this._dragOver);
-    this.el.addEventListener('drop', this._drop);
-    this.el.addEventListener('dragleave', this._dragLeave);
-    // Update: removed that as it causes nested grids to no receive dragenter events when parent drags and sets this for #992. not seeing cursor flicker (chrome).
-    // this.el.classList.add('ui-droppable-over');
+     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dropover' });
+     if (this.option.over) {
+       this.option.over(ev, this._ui(DDManager.dragElement))
+     }
+     this.triggerEvent('dropover', ev);
+     this.el.addEventListener('dragover', this._dragOver);
+     this.el.addEventListener('drop', this._drop);
+     this.el.addEventListener('dragleave', this._dragLeave);
+     // Update: removed that as it causes nested grids to no receive dragenter events when parent drags and sets this for #992. not seeing cursor flicker (chrome).
+     // this.el.classList.add('ui-droppable-over');
 
-    // make sure when we enter this, that the last one gets a leave to correctly cleanup as we don't always do
-    if (DDDroppable.lastActive && DDDroppable.lastActive !== this) {
-      DDDroppable.lastActive._dragLeave(event, true);
-    }
-    DDDroppable.lastActive = this;
-  }
+     // make sure when we enter this, that the last one gets a leave to correctly cleanup as we don't always do
+     if (DDDroppable.lastActive && DDDroppable.lastActive !== this) {
+       DDDroppable.lastActive._dragLeave(event, true);
+     }
+     DDDroppable.lastActive = this;
+   }
 
-  /** @internal called when an moving to drop item is being dragged over - do nothing but eat the event */
-  protected _dragOver(event: DragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-  }
+   /** @internal called when an moving to drop item is being dragged over - do nothing but eat the event */
+   protected _dragOver(event: DragEvent): void {
+     event.preventDefault();
+     event.stopPropagation();
+   }
 
-  /** @internal called when the item is leaving our area, stop tracking if we had moving item */
-  protected _dragLeave(event: DragEvent, forceLeave?: boolean): void {
-    // TEST console.log(`${count++} Leave ${(this.el as GridHTMLElement).gridstack.opts.id}`);
-    event.preventDefault();
-    event.stopPropagation();
+   /** @internal called when the item is leaving our area, stop tracking if we had moving item */
+   protected _dragLeave(event: DragEvent, forceLeave?: boolean): void {
+     // TEST console.log(`${count++} Leave ${(this.el as GridHTMLElement).gridstack.opts.id}`);
+     event.preventDefault();
+     event.stopPropagation();
 
-    // ignore leave events on our children (we get them when starting to drag our items)
-    // but exclude nested grids since we would still be leaving ourself, 
-    // but don't handle leave if we're dragging a nested grid around
-    if (!forceLeave) {
-      let onChild = DDUtils.inside(event, this.el);
-      let drag: GridItemHTMLElement = DDManager.dragElement.el;
-      if (onChild && !drag.gridstackNode?.subGrid) { // dragging a nested grid ?
-        let nestedEl = (this.el as GridHTMLElement).gridstack.engine.nodes.filter(n => n.subGrid).map(n => (n.subGrid as GridStack).el);
-        onChild = !nestedEl.some(el => DDUtils.inside(event, el));
-      }
-      if (onChild) return;
-    }
+     // ignore leave events on our children (we get them when starting to drag our items)
+     // but exclude nested grids since we would still be leaving ourself,
+     // but don't handle leave if we're dragging a nested grid around
+     if (!forceLeave) {
+       let onChild = DDUtils.inside(event, this.el);
+       let drag: GridItemHTMLElement = DDManager.dragElement.el;
+       if (onChild && !drag.gridstackNode?.subGrid) { // dragging a nested grid ?
+         let nestedEl = (this.el as GridHTMLElement).gridstack.engine.nodes.filter(n => n.subGrid).map(n => (n.subGrid as GridStack).el);
+         onChild = !nestedEl.some(el => DDUtils.inside(event, el));
+       }
+       if (onChild) return;
+     }
 
-    if (this.moving) {
-      const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dropout' });
-      if (this.option.out) {
-        this.option.out(ev, this._ui(DDManager.dragElement))
-      }
-      this.triggerEvent('dropout', ev);
-    }
-    this._removeLeaveCallbacks();
+     if (this.moving) {
+       const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'dropout' });
+       if (this.option.out) {
+         this.option.out(ev, this._ui(DDManager.dragElement))
+       }
+       this.triggerEvent('dropout', ev);
+     }
+     this._removeLeaveCallbacks();
 
-    if (DDDroppable.lastActive === this) {
-      delete DDDroppable.lastActive;
-    }
-  }
+     if (DDDroppable.lastActive === this) {
+       delete DDDroppable.lastActive;
+     }
+   }
 
-  /** @internal item is being dropped on us - call the client drop event */
-  protected _drop(event: DragEvent): void {
-    if (!this.moving) return; // should not have received event...
-    event.preventDefault();
-    const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'drop' });
-    if (this.option.drop) {
-      this.option.drop(ev, this._ui(DDManager.dragElement))
-    }
-    this.triggerEvent('drop', ev);
-    this._removeLeaveCallbacks();
-  }
+   /** @internal item is being dropped on us - call the client drop event */
+   protected _drop(event: DragEvent): void {
+     if (!this.moving) return; // should not have received event...
+     event.preventDefault();
+     const ev = DDUtils.initEvent<DragEvent>(event, { target: this.el, type: 'drop' });
+     if (this.option.drop) {
+       this.option.drop(ev, this._ui(DDManager.dragElement))
+     }
+     this.triggerEvent('drop', ev);
+     this._removeLeaveCallbacks();
+   }
 
-  /** @internal called to remove callbacks when leaving or dropping */
-  protected _removeLeaveCallbacks() {
-    if (!this.moving) { return; }
-    delete this.moving;
-    this.el.removeEventListener('dragover', this._dragOver);
-    this.el.removeEventListener('drop', this._drop);
-    this.el.removeEventListener('dragleave', this._dragLeave);
-    // Update: removed that as it causes nested grids to no receive dragenter events when parent drags and sets this for #992. not seeing cursor flicker (chrome).
-    // this.el.classList.remove('ui-droppable-over');
-  }
+   /** @internal called to remove callbacks when leaving or dropping */
+   protected _removeLeaveCallbacks() {
+     if (!this.moving) { return; }
+     delete this.moving;
+     this.el.removeEventListener('dragover', this._dragOver);
+     this.el.removeEventListener('drop', this._drop);
+     this.el.removeEventListener('dragleave', this._dragLeave);
+     // Update: removed that as it causes nested grids to no receive dragenter events when parent drags and sets this for #992. not seeing cursor flicker (chrome).
+     // this.el.classList.remove('ui-droppable-over');
+   }
 
-  /** @internal */
-  protected _canDrop(): boolean {
-    return DDManager.dragElement && (!this.accept || this.accept(DDManager.dragElement.el));
-  }
+   /** @internal */
+   protected _canDrop(): boolean {
+     return DDManager.dragElement && (!this.accept || this.accept(DDManager.dragElement.el));
+   }
 
-  /** @internal */
-  protected _setupAccept(): DDDroppable {
-    if (this.option.accept && typeof this.option.accept === 'string') {
-      this.accept = (el: HTMLElement) => {
-        return el.matches(this.option.accept as string)
-      }
-    } else {
-      this.accept = this.option.accept as ((el: HTMLElement) => boolean);
-    }
-    return this;
-  }
+   /** @internal */
+   protected _setupAccept(): DDDroppable {
+     if (this.option.accept && typeof this.option.accept === 'string') {
+       this.accept = (el: HTMLElement) => {
+         return el.matches(this.option.accept as string)
+       }
+     } else {
+       this.accept = this.option.accept as ((el: HTMLElement) => boolean);
+     }
+     return this;
+   }
 
-  /** @internal */
-  protected _ui(drag: DDDraggable) {
-    return {
-      draggable: drag.el,
-      ...drag.ui()
-    };
-  }
+   /** @internal */
+   protected _ui(drag: DDDraggable) {
+     return {
+       draggable: drag.el,
+       ...drag.ui()
+     };
+   }
 }
 

--- a/src/h5/dd-resizable.ts
+++ b/src/h5/dd-resizable.ts
@@ -11,322 +11,326 @@ import { DDUIData, Rect, Size } from '../types';
 
 // TODO: merge with DDDragOpt
 export interface DDResizableOpt {
-  autoHide?: boolean;
-  handles?: string;
-  maxHeight?: number;
-  maxWidth?: number;
-  minHeight?: number;
-  minWidth?: number;
-  start?: (event: Event, ui: DDUIData) => void;
-  stop?: (event: Event) => void;
-  resize?: (event: Event, ui: DDUIData) => void;
-}
+   autoHide?: boolean;
+   handles?: string;
+   maxHeight?: number;
+   maxWidth?: number;
+   minHeight?: number;
+   minWidth?: number;
+   start?: (event: Event, ui: DDUIData) => void;
+   stop?: (event: Event) => void;
+   resize?: (event: Event, ui: DDUIData) => void;
+ }
 
 export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt<DDResizableOpt> {
 
-  // have to be public else complains for HTMLElementExtendOpt ?
-  public el: HTMLElement;
-  public option: DDResizableOpt;
+   // have to be public else complains for HTMLElementExtendOpt ?
+   public el: HTMLElement;
+   public option: DDResizableOpt;
 
-  /** @internal */
-  protected handlers: DDResizableHandle[];
-  /** @internal */
-  protected originalRect: Rect;
-  /** @internal */
-  protected temporalRect: Rect;
-  /** @internal */
-  protected scrollY: number;
-  /** @internal */
-  protected scrolled: number;
-  /** @internal */
-  protected scrollEl: HTMLElement;
-  /** @internal */
-  protected startEvent: MouseEvent;
-  /** @internal value saved in the same order as _originStyleProp[] */
-  protected elOriginStyleVal: string[];
-  /** @internal */
-  protected parentOriginStylePosition: string;
-  /** @internal */
-  protected static _originStyleProp = ['width', 'height', 'position', 'left', 'top', 'opacity', 'zIndex'];
+   /** @internal */
+   protected handlers: DDResizableHandle[];
+   /** @internal */
+   protected originalRect: Rect;
+   /** @internal */
+   protected temporalRect: Rect;
+   /** @internal */
+   protected scrollY: number;
+   /** @internal */
+   protected scrolled: number;
+   /** @internal */
+   protected scrollEl: HTMLElement;
+   /** @internal */
+   protected startEvent: MouseEvent;
+   /** @internal value saved in the same order as _originStyleProp[] */
+   protected elOriginStyleVal: string[];
+   /** @internal */
+   protected parentOriginStylePosition: string;
+   /** @internal */
+   protected static _originStyleProp = ['width', 'height', 'position', 'left', 'top', 'opacity', 'zIndex'];
 
-  constructor(el: HTMLElement, opts: DDResizableOpt = {}) {
-    super();
-    this.el = el;
-    this.option = opts;
-    this.enable();
-    this._setupAutoHide();
-    this._setupHandlers();
-  }
+   constructor(el: HTMLElement, opts: DDResizableOpt = {}) {
+     super();
+     this.el = el;
+     this.option = opts;
+     this.enable();
+     this._setupAutoHide();
+     this._setupHandlers();
+   }
 
-  public on(event: 'resizestart' | 'resize' | 'resizestop', callback: (event: DragEvent) => void): void {
-    super.on(event, callback);
-  }
+   public on(event: 'resizestart' | 'resize' | 'resizestop', callback: (event: DragEvent) => void): void {
+     super.on(event, callback);
+   }
 
-  public off(event: 'resizestart' | 'resize' | 'resizestop'): void {
-    super.off(event);
-  }
+   public off(event: 'resizestart' | 'resize' | 'resizestop'): void {
+     super.off(event);
+   }
 
-  public enable(): void {
-    super.enable();
-    this.el.classList.add('ui-resizable');
-    this.el.classList.remove('ui-resizable-disabled');
-  }
+   public enable(): void {
+     super.enable();
+     this.el.classList.add('ui-resizable');
+     this.el.classList.remove('ui-resizable-disabled');
+   }
 
-  public disable(): void {
-    super.disable();
-    this.el.classList.add('ui-resizable-disabled');
-    this.el.classList.remove('ui-resizable');
-  }
+   public disable(): void {
+     super.disable();
+     this.el.classList.add('ui-resizable-disabled');
+     this.el.classList.remove('ui-resizable');
+   }
 
-  public destroy(): void {
-    this._removeHandlers();
-    if (this.option.autoHide) {
-      this.el.removeEventListener('mouseover', this._showHandlers);
-      this.el.removeEventListener('mouseout', this._hideHandlers);
-    }
-    this.el.classList.remove('ui-resizable');
-    delete this.el;
-    super.destroy();
-  }
+   public destroy(): void {
+     this._removeHandlers();
+     if (this.option.autoHide) {
+       this.el.removeEventListener('mouseover', this._showHandlers);
+       this.el.removeEventListener('mouseout', this._hideHandlers);
+     }
+     this.el.classList.remove('ui-resizable');
+     delete this.el;
+     super.destroy();
+   }
 
-  public updateOption(opts: DDResizableOpt): DDResizable {
-    let updateHandles = (opts.handles && opts.handles !== this.option.handles);
-    let updateAutoHide = (opts.autoHide && opts.autoHide !== this.option.autoHide);
-    Object.keys(opts).forEach(key => this.option[key] = opts[key]);
-    if (updateHandles) {
-      this._removeHandlers();
-      this._setupHandlers();
-    }
-    if (updateAutoHide) {
-      this._setupAutoHide();
-    }
-    return this;
-  }
+   public updateOption(opts: DDResizableOpt): DDResizable {
+     let updateHandles = (opts.handles && opts.handles !== this.option.handles);
+     let updateAutoHide = (opts.autoHide && opts.autoHide !== this.option.autoHide);
+     Object.keys(opts).forEach(key => this.option[key] = opts[key]);
+     if (updateHandles) {
+       this._removeHandlers();
+       this._setupHandlers();
+     }
+     if (updateAutoHide) {
+       this._setupAutoHide();
+     }
+     return this;
+   }
 
-  /** @internal */
-  protected _setupAutoHide(): DDResizable {
-    if (this.option.autoHide) {
-      this.el.classList.add('ui-resizable-autohide');
-      // use mouseover/mouseout instead of mouseenter/mouseleave to get better performance;
-      this.el.addEventListener('mouseover', this._showHandlers);
-      this.el.addEventListener('mouseout', this._hideHandlers);
-    } else {
-      this.el.classList.remove('ui-resizable-autohide');
-      this.el.removeEventListener('mouseover', this._showHandlers);
-      this.el.removeEventListener('mouseout', this._hideHandlers);
-    }
-    return this;
-  }
+   /** @internal */
+   protected _setupAutoHide(): DDResizable {
+     if (this.option.autoHide) {
+       this.el.classList.add('ui-resizable-autohide');
+       // use mouseover/mouseout instead of mouseenter/mouseleave to get better performance;
+       this.el.addEventListener('mouseover', this._showHandlers);
+       this.el.addEventListener('mouseout', this._hideHandlers);
+     } else {
+       this.el.classList.remove('ui-resizable-autohide');
+       this.el.removeEventListener('mouseover', this._showHandlers);
+       this.el.removeEventListener('mouseout', this._hideHandlers);
+     }
+     return this;
+   }
 
-  /** @internal */
-  protected _showHandlers = () => {
-    this.el.classList.remove('ui-resizable-autohide');
-  }
+   /** @internal */
+   protected _showHandlers = () => {
+     this.el.classList.remove('ui-resizable-autohide');
+   }
 
-  /** @internal */
-  protected _hideHandlers = () => {
-    this.el.classList.add('ui-resizable-autohide');
-  }
+   /** @internal */
+   protected _hideHandlers = () => {
+     this.el.classList.add('ui-resizable-autohide');
+   }
 
-  /** @internal */
-  protected _setupHandlers(): DDResizable {
-    let handlerDirection = this.option.handles || 'e,s,se';
-    if (handlerDirection === 'all') {
-      handlerDirection = 'n,e,s,w,se,sw,ne,nw';
-    }
-    this.handlers = handlerDirection.split(',')
-      .map(dir => dir.trim())
-      .map(dir => new DDResizableHandle(this.el, dir, {
-        start: (event: MouseEvent) => {
-          this._resizeStart(event);
-        },
-        stop: (event: MouseEvent) => {
-          this._resizeStop(event);
-        },
-        move: (event: MouseEvent) => {
-          this._resizing(event, dir);
-        }
-      }));
-    return this;
-  }
+   /** @internal */
+   protected _setupHandlers(): DDResizable {
+     let handlerDirection = this.option.handles || 'e,s,se';
+     if (handlerDirection === 'all') {
+       handlerDirection = 'n,e,s,w,se,sw,ne,nw';
+     }
+     this.handlers = handlerDirection.split(',')
+       .map(dir => dir.trim())
+       .map(dir => new DDResizableHandle(this.el, dir, {
+         start: (event: MouseEvent) => {
+           this._resizeStart(event);
+         },
+         stop: (event: MouseEvent) => {
+           this._resizeStop(event);
+         },
+         move: (event: MouseEvent) => {
+           this._resizing(event, dir);
+         }
+       }));
+     return this;
+   }
 
-  /** @internal */
-  protected _resizeStart(event: MouseEvent): DDResizable {
-    this.originalRect = this.el.getBoundingClientRect();
-    this.scrollEl = Utils.getScrollElement(this.el);
-    this.scrollY = this.scrollEl.scrollTop;
-    this.scrolled = 0;
-    this.startEvent = event;
-    this._setupHelper();
-    this._applyChange();
-    const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resizestart', target: this.el });
-    if (this.option.start) {
-      this.option.start(ev, this._ui());
-    }
-    this.el.classList.add('ui-resizable-resizing');
-    this.triggerEvent('resizestart', ev);
-    return this;
-  }
+   /** @internal */
+   protected _resizeStart(event: MouseEvent): DDResizable {
+     this.originalRect = this.el.getBoundingClientRect();
+     this.scrollEl = Utils.getScrollElement(this.el);
+     this.scrollY = this.scrollEl.scrollTop;
+     this.scrolled = 0;
+     this.startEvent = event;
+     this._setupHelper();
+     this._applyChange();
+     const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resizestart', target: this.el });
+     if (this.option.start) {
+       this.option.start(ev, this._ui());
+     }
+     this.el.classList.add('ui-resizable-resizing');
+     this.triggerEvent('resizestart', ev);
+     return this;
+   }
 
-  /** @internal */
-  protected _resizing(event: MouseEvent, dir: string): DDResizable {
-    this.scrolled = this.scrollEl.scrollTop - this.scrollY;
-    this.temporalRect = this._getChange(event, dir);
-    this._applyChange();
-    const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resize', target: this.el });
-    if (this.option.resize) {
-      this.option.resize(ev, this._ui());
-    }
-    this.triggerEvent('resize', ev);
-    return this;
-  }
+   /** @internal */
+   protected _resizing(event: MouseEvent, dir: string): DDResizable {
+     this.scrolled = this.scrollEl.scrollTop - this.scrollY;
+     this.temporalRect = this._getChange(event, dir);
+     this._applyChange();
+     const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resize', target: this.el });
+     if (this.option.resize) {
+       this.option.resize(ev, this._ui());
+     }
+     this.triggerEvent('resize', ev);
+     return this;
+   }
 
-  /** @internal */
-  protected _resizeStop(event: MouseEvent): DDResizable {
-    const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resizestop', target: this.el });
-    if (this.option.stop) {
-      this.option.stop(ev); // Note: ui() not used by gridstack so don't pass
-    }
-    this.el.classList.remove('ui-resizable-resizing');
-    this.triggerEvent('resizestop', ev);
-    this._cleanHelper();
-    delete this.startEvent;
-    delete this.originalRect;
-    delete this.temporalRect;
-    delete this.scrollY;
-    delete this.scrolled;
-    return this;
-  }
+   /** @internal */
+   protected _resizeStop(event: MouseEvent): DDResizable {
+     const ev = DDUtils.initEvent<MouseEvent>(event, { type: 'resizestop', target: this.el });
+     if (this.option.stop) {
+       this.option.stop(ev); // Note: ui() not used by gridstack so don't pass
+     }
+     this.el.classList.remove('ui-resizable-resizing');
+     this.triggerEvent('resizestop', ev);
+     this._cleanHelper();
+     delete this.startEvent;
+     delete this.originalRect;
+     delete this.temporalRect;
+     delete this.scrollY;
+     delete this.scrolled;
+     return this;
+   }
 
-  /** @internal */
-  protected _setupHelper(): DDResizable {
-    this.elOriginStyleVal = DDResizable._originStyleProp.map(prop => this.el.style[prop]);
-    this.parentOriginStylePosition = this.el.parentElement.style.position;
-    if (window.getComputedStyle(this.el.parentElement).position.match(/static/)) {
-      this.el.parentElement.style.position = 'relative';
-    }
-    this.el.style.position = 'absolute';
-    this.el.style.opacity = '0.8';
-    return this;
-  }
+   /** @internal */
+   protected _setupHelper(): DDResizable {
+     this.elOriginStyleVal = DDResizable._originStyleProp.map(prop => this.el.style[prop]);
+     this.parentOriginStylePosition = this.el.parentElement.style.position;
+     if (window.getComputedStyle(this.el.parentElement).position.match(/static/)) {
+       this.el.parentElement.style.position = 'relative';
+     }
+     this.el.style.position = 'absolute';
+     this.el.style.opacity = '0.8';
+     return this;
+   }
 
-  /** @internal */
-  protected _cleanHelper(): DDResizable {
-    DDResizable._originStyleProp.forEach((prop, i) => {
-      this.el.style[prop] = this.elOriginStyleVal[i] || null;
-    });
-    this.el.parentElement.style.position = this.parentOriginStylePosition || null;
-    return this;
-  }
+   /** @internal */
+   protected _cleanHelper(): DDResizable {
+     // don't restore position, width and, height styles when constructable stylesheet is not supported we are updating these directly on elements
+     if (!Utils.isConstructableStyleSheetSupported()) {
+       DDResizable._originStyleProp = DDResizable._originStyleProp.filter(x => !["left", "right", "top", "bottom", "position", "height", "width"].includes(x));
+     }
+     DDResizable._originStyleProp.forEach((prop, i) => {
+       this.el.style[prop] = this.elOriginStyleVal[i] || null;
+     });
+     this.el.parentElement.style.position = this.parentOriginStylePosition || null;
+     return this;
+   }
 
-  /** @internal */
-  protected _getChange(event: MouseEvent, dir: string): Rect {
-    const oEvent = this.startEvent;
-    const newRect = { // Note: originalRect is a complex object, not a simple Rect, so copy out.
-      width: this.originalRect.width,
-      height: this.originalRect.height + this.scrolled,
-      left: this.originalRect.left,
-      top: this.originalRect.top - this.scrolled
-    };
-    
-    const offsetX = event.clientX - oEvent.clientX;
-    const offsetY = event.clientY - oEvent.clientY;
+   /** @internal */
+   protected _getChange(event: MouseEvent, dir: string): Rect {
+     const oEvent = this.startEvent;
+     const newRect = { // Note: originalRect is a complex object, not a simple Rect, so copy out.
+       width: this.originalRect.width,
+       height: this.originalRect.height + this.scrolled,
+       left: this.originalRect.left,
+       top: this.originalRect.top - this.scrolled
+     };
 
-    if (dir.indexOf('e') > -1) {
-      newRect.width += offsetX;
-    } else if (dir.indexOf('w') > -1) {
-      newRect.width -= offsetX;
-      newRect.left += offsetX;
-    }
-    if (dir.indexOf('s') > -1) {
-      newRect.height += offsetY;
-    } else if (dir.indexOf('n') > -1) {
-      newRect.height -= offsetY;
-      newRect.top += offsetY
-    }
-    const constrain = this._constrainSize(newRect.width, newRect.height);
-    if (Math.round(newRect.width) !== Math.round(constrain.width)) { // round to ignore slight round-off errors
-      if (dir.indexOf('w') > -1) {
-        newRect.left += newRect.width - constrain.width;
-      }
-      newRect.width = constrain.width;
-    }
-    if (Math.round(newRect.height) !== Math.round(constrain.height)) {
-      if (dir.indexOf('n') > -1) {
-        newRect.top += newRect.height - constrain.height;
-      }
-      newRect.height = constrain.height;
-    }
-    return newRect;
-  }
+     const offsetX = event.clientX - oEvent.clientX;
+     const offsetY = event.clientY - oEvent.clientY;
 
-  /** @internal constrain the size to the set min/max values */
-  protected _constrainSize(oWidth: number, oHeight: number): Size {
-    const maxWidth = this.option.maxWidth || Number.MAX_SAFE_INTEGER;
-    const minWidth = this.option.minWidth || oWidth;
-    const maxHeight = this.option.maxHeight || Number.MAX_SAFE_INTEGER;
-    const minHeight = this.option.minHeight || oHeight;
-    const width = Math.min(maxWidth, Math.max(minWidth, oWidth));
-    const height = Math.min(maxHeight, Math.max(minHeight, oHeight));
-    return { width, height };
-  }
+     if (dir.indexOf('e') > -1) {
+       newRect.width += offsetX;
+     } else if (dir.indexOf('w') > -1) {
+       newRect.width -= offsetX;
+       newRect.left += offsetX;
+     }
+     if (dir.indexOf('s') > -1) {
+       newRect.height += offsetY;
+     } else if (dir.indexOf('n') > -1) {
+       newRect.height -= offsetY;
+       newRect.top += offsetY
+     }
+     const constrain = this._constrainSize(newRect.width, newRect.height);
+     if (Math.round(newRect.width) !== Math.round(constrain.width)) { // round to ignore slight round-off errors
+       if (dir.indexOf('w') > -1) {
+         newRect.left += newRect.width - constrain.width;
+       }
+       newRect.width = constrain.width;
+     }
+     if (Math.round(newRect.height) !== Math.round(constrain.height)) {
+       if (dir.indexOf('n') > -1) {
+         newRect.top += newRect.height - constrain.height;
+       }
+       newRect.height = constrain.height;
+     }
+     return newRect;
+   }
 
-  /** @internal */
-  protected _applyChange(): DDResizable {
-    let containmentRect = { left: 0, top: 0, width: 0, height: 0 };
-    if (this.el.style.position === 'absolute') {
-      const containmentEl = this.el.parentElement;
-      const { left, top } = containmentEl.getBoundingClientRect();
-      containmentRect = { left, top, width: 0, height: 0 };
-    }
-    if (!this.temporalRect) return this;
-    Object.keys(this.temporalRect).forEach(key => {
-      const value = this.temporalRect[key];
-      this.el.style[key] = value - containmentRect[key] + 'px';
-    });
-    return this;
-  }
+   /** @internal constrain the size to the set min/max values */
+   protected _constrainSize(oWidth: number, oHeight: number): Size {
+     const maxWidth = this.option.maxWidth || Number.MAX_SAFE_INTEGER;
+     const minWidth = this.option.minWidth || oWidth;
+     const maxHeight = this.option.maxHeight || Number.MAX_SAFE_INTEGER;
+     const minHeight = this.option.minHeight || oHeight;
+     const width = Math.min(maxWidth, Math.max(minWidth, oWidth));
+     const height = Math.min(maxHeight, Math.max(minHeight, oHeight));
+     return { width, height };
+   }
 
-  /** @internal */
-  protected _removeHandlers(): DDResizable {
-    this.handlers.forEach(handle => handle.destroy());
-    delete this.handlers;
-    return this;
-  }
+   /** @internal */
+   protected _applyChange(): DDResizable {
+     let containmentRect = { left: 0, top: 0, width: 0, height: 0 };
+     if (this.el.style.position === 'absolute') {
+       const containmentEl = this.el.parentElement;
+       const { left, top } = containmentEl.getBoundingClientRect();
+       containmentRect = { left, top, width: 0, height: 0 };
+     }
+     if (!this.temporalRect) return this;
+     Object.keys(this.temporalRect).forEach(key => {
+       const value = this.temporalRect[key];
+       this.el.style[key] = value - containmentRect[key] + 'px';
+     });
+     return this;
+   }
 
-  /** @internal */
-  protected _ui = (): DDUIData => {
-    const containmentEl = this.el.parentElement;
-    const containmentRect = containmentEl.getBoundingClientRect();
-    const newRect = { // Note: originalRect is a complex object, not a simple Rect, so copy out.
-      width: this.originalRect.width,
-      height: this.originalRect.height + this.scrolled,
-      left: this.originalRect.left,
-      top: this.originalRect.top - this.scrolled
-    };
-    const rect = this.temporalRect || newRect;
-    return {
-      position: {
-        left: rect.left - containmentRect.left,
-        top: rect.top - containmentRect.top
-      },
-      size: {
-        width: rect.width,
-        height: rect.height
-      }
-      /* Gridstack ONLY needs position set above... keep around in case.
-      element: [this.el], // The object representing the element to be resized
-      helper: [], // TODO: not support yet - The object representing the helper that's being resized
-      originalElement: [this.el],// we don't wrap here, so simplify as this.el //The object representing the original element before it is wrapped
-      originalPosition: { // The position represented as { left, top } before the resizable is resized
-        left: this.originalRect.left - containmentRect.left,
-        top: this.originalRect.top - containmentRect.top
-      },
-      originalSize: { // The size represented as { width, height } before the resizable is resized
-        width: this.originalRect.width,
-        height: this.originalRect.height
-      }
-      */
-    };
-  }
+   /** @internal */
+   protected _removeHandlers(): DDResizable {
+     this.handlers.forEach(handle => handle.destroy());
+     delete this.handlers;
+     return this;
+   }
+
+   /** @internal */
+   protected _ui = (): DDUIData => {
+     const containmentEl = this.el.parentElement;
+     const containmentRect = containmentEl.getBoundingClientRect();
+     const newRect = { // Note: originalRect is a complex object, not a simple Rect, so copy out.
+       width: this.originalRect.width,
+       height: this.originalRect.height + this.scrolled,
+       left: this.originalRect.left,
+       top: this.originalRect.top - this.scrolled
+     };
+     const rect = this.temporalRect || newRect;
+     return {
+       position: {
+         left: rect.left - containmentRect.left,
+         top: rect.top - containmentRect.top
+       },
+       size: {
+         width: rect.width,
+         height: rect.height
+       }
+       /* Gridstack ONLY needs position set above... keep around in case.
+       element: [this.el], // The object representing the element to be resized
+       helper: [], // TODO: not support yet - The object representing the helper that's being resized
+       originalElement: [this.el],// we don't wrap here, so simplify as this.el //The object representing the original element before it is wrapped
+       originalPosition: { // The position represented as { left, top } before the resizable is resized
+         left: this.originalRect.left - containmentRect.left,
+         top: this.originalRect.top - containmentRect.top
+       },
+       originalSize: { // The size represented as { width, height } before the resizable is resized
+         width: this.originalRect.width,
+         height: this.originalRect.height
+       }
+       */
+     };
+   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,357 +8,360 @@ import { GridStackEngine } from './gridstack-engine';
 
 
 /** different layout options when changing # of columns,
- * including a custom function that takes new/old column count, and array of new/old positions
- * Note: new list may be partially already filled if we have a cache of the layout at that size and new items were added later.
- */
+  * including a custom function that takes new/old column count, and array of new/old positions
+  * Note: new list may be partially already filled if we have a cache of the layout at that size and new items were added later.
+  */
 export type ColumnOptions = 'moveScale' | 'move' | 'scale' | 'none' |
-  ((column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void);
+   ((column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void);
 
 export type numberOrString = number | string;
 export interface GridItemHTMLElement extends HTMLElement {
-  /** pointer to grid node instance */
-  gridstackNode?: GridStackNode;
-  /** @internal */
-  _gridstackNodeOrig?: GridStackNode;
-}
+   /** pointer to grid node instance */
+   gridstackNode?: GridStackNode;
+   /** @internal */
+   _gridstackNodeOrig?: GridStackNode;
+ }
 
 export type GridStackElement = string | HTMLElement | GridItemHTMLElement;
 
 export type GridStackEventHandlerCallback = (event: Event, arg2?: GridItemHTMLElement | GridStackNode | GridStackNode[], newNode?: GridStackNode) => void;
 
 /**
- * Defines the options for a Grid
- */
+  * Defines the options for a Grid
+  */
 export interface GridStackOptions {
-  /**
-   * accept widgets dragged from other grids or from outside (default: `false`). Can be:
-   * `true` (uses `'.grid-stack-item'` class filter) or `false`,
-   * string for explicit class name,
-   * function returning a boolean. See [example](http://gridstack.github.io/gridstack.js/demo/two.html)
-   */
-  acceptWidgets?: boolean | string | ((element: Element) => boolean);
+   /**
+    * accept widgets dragged from other grids or from outside (default: `false`). Can be:
+    * `true` (uses `'.grid-stack-item'` class filter) or `false`,
+    * string for explicit class name,
+    * function returning a boolean. See [example](http://gridstack.github.io/gridstack.js/demo/two.html)
+    */
+   acceptWidgets?: boolean | string | ((element: Element) => boolean);
 
-  /** possible values (default: `false` only show on hover)
-    * `true` the resizing handles are always shown even if the user is not hovering over the widget
-    * advance condition such as this mobile browser agent check:
-    `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
-    See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html) */
-  alwaysShowResizeHandle?: boolean;
+   /** possible values (default: `false` only show on hover)
+     * `true` the resizing handles are always shown even if the user is not hovering over the widget
+     * advance condition such as this mobile browser agent check:
+     `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
+     See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html) */
+   alwaysShowResizeHandle?: boolean;
 
-  /** turns animation on (default?: true) */
-  animate?: boolean;
+   /** turns animation on (default?: true) */
+   animate?: boolean;
 
-  /** if false gridstack will not initialize existing items (default?: true) */
-  auto?: boolean;
+   /** if false gridstack will not initialize existing items (default?: true) */
+   auto?: boolean;
 
-  /**
-   * one cell height (default?: 'auto'). Can be:
-   *  an integer (px)
-   *  a string (ex: '100px', '10em', '10rem'). Note: % doesn't right - see demo/cell-height.html
-   *  0, in which case the library will not generate styles for rows. Everything must be defined in your own CSS files.
-   *  'auto' - height will be calculated for square cells (width / column) and updated live as you resize the window - also see `cellHeightThrottle`
-   *  'initial' - similar to 'auto' (start at square cells) but stay that size during window resizing.
-   */
-  cellHeight?: numberOrString;
+   /**
+    * one cell height (default?: 'auto'). Can be:
+    *  an integer (px)
+    *  a string (ex: '100px', '10em', '10rem'). Note: % doesn't right - see demo/cell-height.html
+    *  0, in which case the library will not generate styles for rows. Everything must be defined in your own CSS files.
+    *  'auto' - height will be calculated for square cells (width / column) and updated live as you resize the window - also see `cellHeightThrottle`
+    *  'initial' - similar to 'auto' (start at square cells) but stay that size during window resizing.
+    */
+   cellHeight?: numberOrString;
 
-  /** throttle time delay (in ms) used when cellHeight='auto' to improve performance vs usability (default?: 100).
-   * A value of 0 will make it instant at a cost of re-creating the CSS file at ever window resize event!
-   * */
-  cellHeightThrottle?: number;
+   /** throttle time delay (in ms) used when cellHeight='auto' to improve performance vs usability (default?: 100).
+    * A value of 0 will make it instant at a cost of re-creating the CSS file at ever window resize event!
+    * */
+   cellHeightThrottle?: number;
 
-  /** (internal) unit for cellHeight (default? 'px') which is set when a string cellHeight with a unit is passed (ex: '10rem') */
-  cellHeightUnit?: string;
+   /** (internal) unit for cellHeight (default? 'px') which is set when a string cellHeight with a unit is passed (ex: '10rem') */
+   cellHeightUnit?: string;
 
-  /** list of children item to create when calling load() or addGrid() */
-  children?: GridStackWidget[];
+   /** list of children item to create when calling load() or addGrid() */
+   children?: GridStackWidget[];
 
-  /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns.
-   * Note: for nested grids, it is recommended to use 'auto' which will always match the container grid-item current width (in column) to keep inside and outside
-   * items always to same. flag is not supported for regular non-nested grids.
-   */
-  column?: number | 'auto';
+   /** number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns.
+    * Note: for nested grids, it is recommended to use 'auto' which will always match the container grid-item current width (in column) to keep inside and outside
+    * items always to same. flag is not supported for regular non-nested grids.
+    */
+   column?: number | 'auto';
 
-  /** additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance.
-  Note: only used by addGrid(), else your element should have the needed class */
-  class?: string;
+   /** additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance.
+   Note: only used by addGrid(), else your element should have the needed class */
+   class?: string;
 
-  /** disallows dragging of widgets (default?: false) */
-  disableDrag?: boolean;
+   /** disallows dragging of widgets (default?: false) */
+   disableDrag?: boolean;
 
-  /** disables the onColumnMode when the grid width is less than oneColumnSize (default?: false) */
-  disableOneColumnMode?: boolean;
+   /** disables the onColumnMode when the grid width is less than oneColumnSize (default?: false) */
+   disableOneColumnMode?: boolean;
 
-  /** disallows resizing of widgets (default?: false). */
-  disableResize?: boolean;
+   /** disallows resizing of widgets (default?: false). */
+   disableResize?: boolean;
 
-  /** allows to override UI draggable options. (default?: { handle?: '.grid-stack-item-content', scroll?: true, appendTo?: 'body', containment: null }) */
-  draggable?: DDDragOpt;
+   /** allows to override UI draggable options. (default?: { handle?: '.grid-stack-item-content', scroll?: true, appendTo?: 'body', containment: null }) */
+   draggable?: DDDragOpt;
 
-  /** allows to drag external items using this selector - see dragInOptions. (default: undefined) */
-  dragIn?: string;
+   /** allows to drag external items using this selector - see dragInOptions. (default: undefined) */
+   dragIn?: string;
 
-  /** allows to drag external items using these options. See `GridStack.setupDragIn()` instead (not per grid really).
-   * (default?: { handle: '.grid-stack-item-content', revert: 'invalid', scroll: false, appendTo: 'body' })
-   * helper can be 'clone' or your own function (set what the drag/dropped item will be instead)
-   */
-  dragInOptions?: DDDragInOpt;
+   /** allows to drag external items using these options. See `GridStack.setupDragIn()` instead (not per grid really).
+    * (default?: { handle: '.grid-stack-item-content', revert: 'invalid', scroll: false, appendTo: 'body' })
+    * helper can be 'clone' or your own function (set what the drag/dropped item will be instead)
+    */
+   dragInOptions?: DDDragInOpt;
 
-  /** let user drag nested grid items out of a parent or not (default false) */
-  dragOut?: boolean;
+   /** let user drag nested grid items out of a parent or not (default false) */
+   dragOut?: boolean;
 
-  /** the type of engine to create (so you can subclass) default to GridStackEngine */
-  engineClass?: typeof GridStackEngine;
+   /** the type of engine to create (so you can subclass) default to GridStackEngine */
+   engineClass?: typeof GridStackEngine;
 
-  /** enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html) */
-  float?: boolean;
+   /** enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html) */
+   float?: boolean;
 
-  /** draggable handle selector (default?: '.grid-stack-item-content') */
-  handle?: string;
+   /** draggable handle selector (default?: '.grid-stack-item-content') */
+   handle?: string;
 
-  /** draggable handle class (e.g. 'grid-stack-item-content'). If set 'handle' is ignored (default?: null) */
-  handleClass?: string;
+   /** draggable handle class (e.g. 'grid-stack-item-content'). If set 'handle' is ignored (default?: null) */
+   handleClass?: string;
 
-  /** id used to debug grid instance, not currently stored in DOM attributes */
-  id?: numberOrString;
+   /** id used to debug grid instance, not currently stored in DOM attributes */
+   id?: numberOrString;
 
-  /** additional widget class (default?: 'grid-stack-item') */
-  itemClass?: string;
+   /** additional widget class (default?: 'grid-stack-item') */
+   itemClass?: string;
 
-  /**
-   * gap between grid item and content (default?: 10). This will set all 4 sides and support the CSS formats below
-   *  an integer (px)
-   *  a string with possible units (ex: '2em', '20px', '2rem')
-   *  string with space separated values (ex: '5px 10px 0 20px' for all 4 sides, or '5em 10em' for top/bottom and left/right pairs like CSS).
-   * Note: all sides must have same units (last one wins, default px)
-   */
-  margin?: numberOrString;
+   /**
+    * gap between grid item and content (default?: 10). This will set all 4 sides and support the CSS formats below
+    *  an integer (px)
+    *  a string with possible units (ex: '2em', '20px', '2rem')
+    *  string with space separated values (ex: '5px 10px 0 20px' for all 4 sides, or '5em 10em' for top/bottom and left/right pairs like CSS).
+    * Note: all sides must have same units (last one wins, default px)
+    */
+   margin?: numberOrString;
 
-  /** OLD way to optionally set each side - use margin: '5px 10px 0 20px' instead. Used internally to store each side. */
-  marginTop?: numberOrString;
-  marginRight?: numberOrString;
-  marginBottom?: numberOrString;
-  marginLeft?: numberOrString;
+   /** OLD way to optionally set each side - use margin: '5px 10px 0 20px' instead. Used internally to store each side. */
+   marginTop?: numberOrString;
+   marginRight?: numberOrString;
+   marginBottom?: numberOrString;
+   marginLeft?: numberOrString;
 
-  /** (internal) unit for margin (default? 'px') set when `margin` is set as string with unit (ex: 2rem') */
-  marginUnit?: string;
+   /** (internal) unit for margin (default? 'px') set when `margin` is set as string with unit (ex: 2rem') */
+   marginUnit?: string;
 
-  /** maximum rows amount. Default? is 0 which means no maximum rows */
-  maxRow?: number;
+   /** maximum rows amount. Default? is 0 which means no maximum rows */
+   maxRow?: number;
 
-  /** minimum rows amount. Default is `0`. You can also do this with `min-height` CSS attribute
-   * on the grid div in pixels, which will round to the closest row.
-   */
-  minRow?: number;
+   /** minimum rows amount. Default is `0`. You can also do this with `min-height` CSS attribute
+    * on the grid div in pixels, which will round to the closest row.
+    */
+   minRow?: number;
 
-  /** minimal width before grid will be shown in one column mode (default?: 768) */
-  oneColumnSize?: number;
+   /** minimal width before grid will be shown in one column mode (default?: 768) */
+   oneColumnSize?: number;
 
-  /**
-   * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column
-   * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
-   */
-  oneColumnModeDomSort?: boolean;
+   /**
+    * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column
+    * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
+    */
+   oneColumnModeDomSort?: boolean;
 
-  /** class for placeholder (default?: 'grid-stack-placeholder') */
-  placeholderClass?: string;
+   /** class for placeholder (default?: 'grid-stack-placeholder') */
+   placeholderClass?: string;
 
-  /** placeholder default content (default?: '') */
-  placeholderText?: string;
+   /** placeholder default content (default?: '') */
+   placeholderText?: string;
 
-  /** allows to override UI resizable options. (default?: { autoHide: true, handles: 'se' }) */
-  resizable?: DDResizeOpt;
+   /** allows to override UI resizable options. (default?: { autoHide: true, handles: 'se' }) */
+   resizable?: DDResizeOpt;
 
-  /**
-   * if true widgets could be removed by dragging outside of the grid. It could also be a selector string (ex: ".trash"),
-   * in this case widgets will be removed by dropping them there (default?: false)
-   * See example (http://gridstack.github.io/gridstack.js/demo/two.html)
-   */
-  removable?: boolean | string;
+   /**
+    * if true widgets could be removed by dragging outside of the grid. It could also be a selector string (ex: ".trash"),
+    * in this case widgets will be removed by dropping them there (default?: false)
+    * See example (http://gridstack.github.io/gridstack.js/demo/two.html)
+    */
+   removable?: boolean | string;
 
-  /** allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) */
-  removableOptions?: DDRemoveOpt;
+   /** allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) */
+   removableOptions?: DDRemoveOpt;
 
-  /** fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) */
-  row?: number;
+   /** fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) */
+   row?: number;
 
-  /**
-   * if true turns grid to RTL. Possible values are true, false, 'auto' (default?: 'auto')
-   * See [example](http://gridstack.github.io/gridstack.js/demo/rtl.html)
-   */
-  rtl?: boolean | 'auto';
+   /**
+    * if true turns grid to RTL. Possible values are true, false, 'auto' (default?: 'auto')
+    * See [example](http://gridstack.github.io/gridstack.js/demo/rtl.html)
+    */
+   rtl?: boolean | 'auto';
 
-  /**
-   * makes grid static (default?: false). If `true` widgets are not movable/resizable.
-   * You don't even need draggable/resizable. A CSS class
-   * 'grid-stack-static' is also added to the element.
-   */
-  staticGrid?: boolean;
+   /**
+    * makes grid static (default?: false). If `true` widgets are not movable/resizable.
+    * You don't even need draggable/resizable. A CSS class
+    * 'grid-stack-static' is also added to the element.
+    */
+   staticGrid?: boolean;
 
-  /** @internal point to a parent grid item if we're nested */
-  _isNested?: GridStackNode;
-  /** @internal unique class name for our generated CSS style sheet */
-  _styleSheetClass?: string;
-}
+   /** if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`). */
+   styleInHead?: boolean;
+
+   /** @internal point to a parent grid item if we're nested */
+   _isNested?: GridStackNode;
+   /** @internal unique class name for our generated CSS style sheet */
+   _styleSheetClass?: string;
+ }
 
 /** options used during GridStackEngine.moveNode() */
 export interface GridStackMoveOpts extends GridStackPosition {
-  /** node to skip collision */
-  skip?: GridStackNode;
-  /** do we pack (default true) */
-  pack?: boolean;
-  /** true if we are calling this recursively to prevent simple swap or coverage collision - default false*/
-  nested?: boolean;
-  /** vars to calculate other cells coordinates */
-  cellWidth?: number;
-  cellHeight?: number;
-  marginTop?: number;
-  marginBottom?: number;
-  marginLeft?: number;
-  marginRight?: number;
-  /** position in pixels of the currently dragged items (for overlap check) */
-  rect?: GridStackPosition;
-  /** true if we're live resizing */
-  resizing?: boolean;
-}
+   /** node to skip collision */
+   skip?: GridStackNode;
+   /** do we pack (default true) */
+   pack?: boolean;
+   /** true if we are calling this recursively to prevent simple swap or coverage collision - default false*/
+   nested?: boolean;
+   /** vars to calculate other cells coordinates */
+   cellWidth?: number;
+   cellHeight?: number;
+   marginTop?: number;
+   marginBottom?: number;
+   marginLeft?: number;
+   marginRight?: number;
+   /** position in pixels of the currently dragged items (for overlap check) */
+   rect?: GridStackPosition;
+   /** true if we're live resizing */
+   resizing?: boolean;
+ }
 
 export interface GridStackPosition {
-  /** widget position x (default?: 0) */
-  x?: number;
-  /** widget position y (default?: 0) */
-  y?: number;
-  /** widget dimension width (default?: 1) */
-  w?: number;
-  /** widget dimension height (default?: 1) */
-  h?: number;
-}
+   /** widget position x (default?: 0) */
+   x?: number;
+   /** widget position y (default?: 0) */
+   y?: number;
+   /** widget dimension width (default?: 1) */
+   w?: number;
+   /** widget dimension height (default?: 1) */
+   h?: number;
+ }
 
 /**
- * GridStack Widget creation options
- */
+  * GridStack Widget creation options
+  */
 export interface GridStackWidget extends GridStackPosition {
-  /** if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) */
-  autoPosition?: boolean;
-  /** minimum width allowed during resize/creation (default?: undefined = un-constrained) */
-  minW?: number;
-  /** maximum width allowed during resize/creation (default?: undefined = un-constrained) */
-  maxW?: number;
-  /** minimum height allowed during resize/creation (default?: undefined = un-constrained) */
-  minH?: number;
-  /** maximum height allowed during resize/creation (default?: undefined = un-constrained) */
-  maxH?: number;
-  /** prevent resizing (default?: undefined = un-constrained) */
-  noResize?: boolean;
-  /** prevents moving (default?: undefined = un-constrained) */
-  noMove?: boolean;
-  /** prevents being moved by others during their (default?: undefined = un-constrained) */
-  locked?: boolean;
-  /** widgets can have their own custom resize handles. For example 'e,w' will make that particular widget only resize east and west. See `resizable: {handles: string}` option */
-  resizeHandles?: string;
-  /** value for `gs-id` stored on the widget (default?: undefined) */
-  id?: numberOrString;
-  /** html to append inside as content */
-  content?: string;
-  /** optional nested grid options and list of children, which then turns into actual instance at runtime */
-  subGrid?: GridStackOptions | GridStack;
-}
+   /** if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) */
+   autoPosition?: boolean;
+   /** minimum width allowed during resize/creation (default?: undefined = un-constrained) */
+   minW?: number;
+   /** maximum width allowed during resize/creation (default?: undefined = un-constrained) */
+   maxW?: number;
+   /** minimum height allowed during resize/creation (default?: undefined = un-constrained) */
+   minH?: number;
+   /** maximum height allowed during resize/creation (default?: undefined = un-constrained) */
+   maxH?: number;
+   /** prevent resizing (default?: undefined = un-constrained) */
+   noResize?: boolean;
+   /** prevents moving (default?: undefined = un-constrained) */
+   noMove?: boolean;
+   /** prevents being moved by others during their (default?: undefined = un-constrained) */
+   locked?: boolean;
+   /** widgets can have their own custom resize handles. For example 'e,w' will make that particular widget only resize east and west. See `resizable: {handles: string}` option */
+   resizeHandles?: string;
+   /** value for `gs-id` stored on the widget (default?: undefined) */
+   id?: numberOrString;
+   /** html to append inside as content */
+   content?: string;
+   /** optional nested grid options and list of children, which then turns into actual instance at runtime */
+   subGrid?: GridStackOptions | GridStack;
+ }
 
 /** Drag&Drop resize options */
 export interface DDResizeOpt {
-  /** do resize handle hide by default until mouse over ? - default: true */
-  autoHide?: boolean;
-  /**
-   * sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east)
-   * Note: it is not recommended to resize from the top sides as weird side effect may occur.
-  */
-  handles?: string;
-}
+   /** do resize handle hide by default until mouse over ? - default: true */
+   autoHide?: boolean;
+   /**
+    * sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east)
+    * Note: it is not recommended to resize from the top sides as weird side effect may occur.
+   */
+   handles?: string;
+ }
 
 /** Drag&Drop remove options */
 export interface DDRemoveOpt {
-  /** class that can be removed (default?: '.' + opts.itemClass) */
-  accept?: string;
-}
+   /** class that can be removed (default?: '.' + opts.itemClass) */
+   accept?: string;
+ }
 
 /** Drag&Drop dragging options */
 export interface DDDragOpt {
-  /** class selector of items that can be dragged. default to '.grid-stack-item-content' */
-  handle?: string;
-  /** default to `true` */
-  scroll?: boolean;
-  /** default to 'body' */
-  appendTo?: string;
-  /** parent constraining where item can be dragged out from (default: null = no constrain) */
-  containment?: string;
-}
+   /** class selector of items that can be dragged. default to '.grid-stack-item-content' */
+   handle?: string;
+   /** default to `true` */
+   scroll?: boolean;
+   /** default to 'body' */
+   appendTo?: string;
+   /** parent constraining where item can be dragged out from (default: null = no constrain) */
+   containment?: string;
+ }
 export interface DDDragInOpt extends DDDragOpt {
-    /** used when dragging item from the outside, and canceling (ex: 'invalid' or your own method)*/
-    revert?: string | ((event: Event) => HTMLElement);
-    /** helper function when dropping (ex: 'clone' or your own method) */
-    helper?: string | ((event: Event) => HTMLElement);
-}
+     /** used when dragging item from the outside, and canceling (ex: 'invalid' or your own method)*/
+     revert?: string | ((event: Event) => HTMLElement);
+     /** helper function when dropping (ex: 'clone' or your own method) */
+     helper?: string | ((event: Event) => HTMLElement);
+ }
 
 export interface Size {
-  width: number;
-  height: number;
-}
+   width: number;
+   height: number;
+ }
 export interface Position {
-  top: number;
-  left: number;
-}
+   top: number;
+   left: number;
+ }
 export interface Rect extends Size, Position {}
 
 /** data that is passed during drag and resizing callbacks */
 export interface DDUIData {
-  position?: Position;
-  size?: Size;
-  /* fields not used by GridStack but sent by jq ? leave in case we go back to them...
-  originalPosition? : Position;
-  offset?: Position;
-  originalSize?: Size;
-  element?: HTMLElement[];
-  helper?: HTMLElement[];
-  originalElement?: HTMLElement[];
-  */
-}
+   position?: Position;
+   size?: Size;
+   /* fields not used by GridStack but sent by jq ? leave in case we go back to them...
+   originalPosition? : Position;
+   offset?: Position;
+   originalSize?: Size;
+   element?: HTMLElement[];
+   helper?: HTMLElement[];
+   originalElement?: HTMLElement[];
+   */
+ }
 
 /**
- * internal descriptions describing the items in the grid
- */
+  * internal descriptions describing the items in the grid
+  */
 export interface GridStackNode extends GridStackWidget {
-  /** pointer back to HTML element */
-  el?: GridItemHTMLElement;
-  /** pointer back to Grid instance */
-  grid?: GridStack;
-  /** @internal internal id used to match when cloning engines or saving column layouts */
-  _id?: number;
-  /** @internal */
-  _dirty?: boolean;
-  /** @internal */
-  _updating?: boolean;
-  /** @internal true when over trash/another grid so we don't bother removing drag CSS style that would animate back to old position */
-  _isAboutToRemove?: boolean;
-  /** @internal true if item came from outside of the grid -> actual item need to be moved over */
-  _isExternal?: boolean;
-  /** @internal moving vs resizing */
-  _moving?: boolean;
-  /** @internal true if we jumped down past item below (one time jump so we don't have to totally pass it) */
-  _skipDown?: boolean;
-  /** @internal original values before a drag/size */
-  _orig?: GridStackPosition;
-  /** @internal position in pixels used during collision check  */
-  _rect?: GridStackPosition;
-  /** @internal top/left pixel location before a drag so we can detect direction of move from last position*/
-  _lastUiPosition?: Position;
-  /** @internal set on the item being dragged/resized remember the last positions we've tried (but failed) so we don't try again during drag/resize */
-  _lastTried?: GridStackPosition;
-  /** @internal position willItFit() will use to position the item */
-  _willFitPos?: GridStackPosition;
-  /** @internal last drag Y pixel position used to incrementally update V scroll bar */
-  _prevYPix?: number;
-  /** @internal true if we've remove the item from ourself (dragging out) but might revert it back (release on nothing -> goes back) */
-  _temporaryRemoved?: boolean;
-  /** @internal true if we should remove DOM element on _notify() rather than clearing _id (old way) */
-  _removeDOM?: boolean;
-  /** @internal */
-  _initDD?: boolean;
-}
+   /** pointer back to HTML element */
+   el?: GridItemHTMLElement;
+   /** pointer back to Grid instance */
+   grid?: GridStack;
+   /** @internal internal id used to match when cloning engines or saving column layouts */
+   _id?: number;
+   /** @internal */
+   _dirty?: boolean;
+   /** @internal */
+   _updating?: boolean;
+   /** @internal true when over trash/another grid so we don't bother removing drag CSS style that would animate back to old position */
+   _isAboutToRemove?: boolean;
+   /** @internal true if item came from outside of the grid -> actual item need to be moved over */
+   _isExternal?: boolean;
+   /** @internal moving vs resizing */
+   _moving?: boolean;
+   /** @internal true if we jumped down past item below (one time jump so we don't have to totally pass it) */
+   _skipDown?: boolean;
+   /** @internal original values before a drag/size */
+   _orig?: GridStackPosition;
+   /** @internal position in pixels used during collision check  */
+   _rect?: GridStackPosition;
+   /** @internal top/left pixel location before a drag so we can detect direction of move from last position*/
+   _lastUiPosition?: Position;
+   /** @internal set on the item being dragged/resized remember the last positions we've tried (but failed) so we don't try again during drag/resize */
+   _lastTried?: GridStackPosition;
+   /** @internal position willItFit() will use to position the item */
+   _willFitPos?: GridStackPosition;
+   /** @internal last drag Y pixel position used to incrementally update V scroll bar */
+   _prevYPix?: number;
+   /** @internal true if we've remove the item from ourself (dragging out) but might revert it back (release on nothing -> goes back) */
+   _temporaryRemoved?: boolean;
+   /** @internal true if we should remove DOM element on _notify() rather than clearing _id (old way) */
+   _removeDOM?: boolean;
+   /** @internal */
+   _initDD?: boolean;
+ }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /**
- * types.ts 5.1.0-dev
- * Copyright (c) 2021 Alain Dumesny - see GridStack root license
- */
+* types.ts 5.1.0-dev
+* Copyright (c) 2021 Alain Dumesny - see GridStack root license
+*/
 
 import { GridStack } from './gridstack';
 import { GridStackEngine } from './gridstack-engine';
@@ -193,9 +193,6 @@ export interface GridStackOptions {
    * 'grid-stack-static' is also added to the element.
    */
   staticGrid?: boolean;
-
-  /** if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`). */
-  styleInHead?: boolean;
 
   /** @internal point to a parent grid item if we're nested */
   _isNested?: GridStackNode;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 /**
- * utils.ts 5.1.0-dev
- * Copyright (c) 2021 Alain Dumesny - see GridStack root license
- */
+* utils.ts 5.1.0-dev
+* Copyright (c) 2021 Alain Dumesny - see GridStack root license
+*/
 
 import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
@@ -44,7 +44,7 @@ export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, 
   if (oldAttr !== null) {
     el.setAttribute(newName, oldAttr);
     console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
-       newName + '`. It will be **completely** removed in v1.0');
+      newName + '`. It will be **completely** removed in v1.0');
   }
 }
 
@@ -115,41 +115,42 @@ export class Utils {
   }
 
   /** update CSS style on elements with given selector */
-  static updateStyleOnElements(selector: string, styles: {[props: string]: string |  string[] }): void {
-    const elements = Utils.getElements(selector);
+  static updateStyleOnElements(selector: string | HTMLElement[], styles: {[props: string]: string |  string[] }): void {
+    const elements = typeof selector === 'string' ? Utils.getElements(selector) : selector;
     for (const el  of elements) {
-      Utils.addElementStyle(el, styles)
+      Utils.addElementStyle(el, styles);
     }
   }
 
   /** update CSS style on element */
   static addElementStyle(el: HTMLElement, styles: {[props: string]: string |  string[] }): void {
-    if (styles instanceof Object) {
+    if(!el) {
+      return;
+    }
+    if (styles) {
       for (const s in styles) {
         if (styles.hasOwnProperty(s)) {
-          if (Array.isArray(styles[s])) {
-            // support fallback value
-            (styles[s] as string[]).forEach(val => {
-              el.style[s] = val;
-            });
-          } else {
-            el.style[s] = styles[s];
-          }
+          el.style[s] = styles[s];
         }
       }
     }
   }
 
   /** update position style on element */
-  static updatePositionStyleOnWidget(el: HTMLElement, getHeight:(rows: number) => string): void {
+  static updatePositionStyleOnWidget(el: HTMLElement, cellHeight: number, cellHeightUnit: string): void {
     const h = Utils.toNumber(el.getAttribute('gs-h'));
     const minH= Utils.toNumber(el.getAttribute('gs-min-h'));
     const maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
     const y = Utils.toNumber(el.getAttribute('gs-y'));
-    el.style.height = getHeight(h);
-    el.style.minHeight = getHeight(minH);
-    el.style.maxHeight = getHeight(maxH);
-    el.style.top = getHeight(y);
+    el.style.height = Utils.getCSSHeight(h, cellHeight, cellHeightUnit);
+    el.style.minHeight = Utils.getCSSHeight(minH, cellHeight, cellHeightUnit);
+    el.style.maxHeight = Utils.getCSSHeight(maxH, cellHeight, cellHeightUnit);
+    el.style.top = Utils.getCSSHeight(y, cellHeight, cellHeightUnit);
+  }
+
+  /** returns CSS height of a given row */
+  static getCSSHeight(rows: number, cellHeight: number, cellHeightUnit: string): string {
+    return  (rows * cellHeight as number) + cellHeightUnit;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,401 +3,400 @@
  * Copyright (c) 2021 Alain Dumesny - see GridStack root license
  */
 
- import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
+import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
- export interface HeightData {
+export interface HeightData {
    h: number;
    unit: string;
  }
- 
- /** checks for obsolete method names */
- // eslint-disable-next-line
+
+/** checks for obsolete method names */
+// eslint-disable-next-line
  export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
-   let wrapper = (...args) => {
-     console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
+  let wrapper = (...args) => {
+    console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
      'with `' + newName + '`. It will be **completely** removed in v1.0');
-     return f.apply(self, args);
-   }
-   wrapper.prototype = f.prototype;
-   return wrapper;
- }
- 
- /** checks for obsolete grid options (can be used for any fields, but msg is about options) */
- export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: string, rev: string): void {
-   if (opts[oldName] !== undefined) {
-     opts[newName] = opts[oldName];
-     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
+    return f.apply(self, args);
+  }
+  wrapper.prototype = f.prototype;
+  return wrapper;
+}
+
+/** checks for obsolete grid options (can be used for any fields, but msg is about options) */
+export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: string, rev: string): void {
+  if (opts[oldName] !== undefined) {
+    opts[newName] = opts[oldName];
+    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
        newName + '`. It will be **completely** removed in v1.0');
-   }
- }
- 
- /** checks for obsolete grid options which are gone */
- export function obsoleteOptsDel(opts: GridStackOptions, oldName: string, rev: string, info: string): void {
-   if (opts[oldName] !== undefined) {
-     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
-   }
- }
- 
- /** checks for obsolete Jquery element attributes */
- export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, rev: string): void {
-   let oldAttr = el.getAttribute(oldName);
-   if (oldAttr !== null) {
-     el.setAttribute(newName, oldAttr);
-     console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
+  }
+}
+
+/** checks for obsolete grid options which are gone */
+export function obsoleteOptsDel(opts: GridStackOptions, oldName: string, rev: string, info: string): void {
+  if (opts[oldName] !== undefined) {
+    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
+  }
+}
+
+/** checks for obsolete Jquery element attributes */
+export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, rev: string): void {
+  let oldAttr = el.getAttribute(oldName);
+  if (oldAttr !== null) {
+    el.setAttribute(newName, oldAttr);
+    console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
        newName + '`. It will be **completely** removed in v1.0');
-   }
- }
- 
- /**
+  }
+}
+
+/**
   * Utility methods
   */
- export class Utils {
- 
-   /** convert a potential selector into actual list of html elements */
-   static getElements(els: GridStackElement): HTMLElement[] {
-     if (typeof els === 'string') {
-       let list = document.querySelectorAll(els);
-       if (!list.length && els[0] !== '.' && els[0] !== '#') {
-         list = document.querySelectorAll('.' + els);
-         if (!list.length) { list = document.querySelectorAll('#' + els) }
-       }
-       return Array.from(list) as HTMLElement[];
-     }
-     return [els];
-   }
- 
-   /** convert a potential selector into actual single element */
-   static getElement(els: GridStackElement): HTMLElement {
-     if (typeof els === 'string') {
-       if (!els.length) return null;
-       if (els[0] === '#') {
-         return document.getElementById(els.substring(1));
-       }
-       if (els[0] === '.' || els[0] === '[') {
-         return document.querySelector(els);
-       }
- 
-       // if we start with a digit, assume it's an id (error calling querySelector('#1')) as class are not valid CSS
-       if(!isNaN(+els[0])) { // start with digit
-         return document.getElementById(els);
-       }
- 
-       // finally try string, then id then class
-       let el = document.querySelector(els);
-       if (!el) { el = document.getElementById(els) }
-       if (!el) { el = document.querySelector('.' + els) }
-       return el as HTMLElement;
-     }
-     return els;
-   }
- 
-   /** returns true if a and b overlap */
-   static isIntercepted(a: GridStackPosition, b: GridStackPosition): boolean {
-     return !(a.y >= b.y + b.h || a.y + a.h <= b.y || a.x + a.w <= b.x || a.x >= b.x + b.w);
-   }
- 
-   /** returns true if a and b touch edges or corners */
-   static isTouching(a: GridStackPosition, b: GridStackPosition): boolean {
-     return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
-   }
-   /**
+export class Utils {
+
+  /** convert a potential selector into actual list of html elements */
+  static getElements(els: GridStackElement): HTMLElement[] {
+    if (typeof els === 'string') {
+      let list = document.querySelectorAll(els);
+      if (!list.length && els[0] !== '.' && els[0] !== '#') {
+        list = document.querySelectorAll('.' + els);
+        if (!list.length) { list = document.querySelectorAll('#' + els) }
+      }
+      return Array.from(list) as HTMLElement[];
+    }
+    return [els];
+  }
+
+  /** convert a potential selector into actual single element */
+  static getElement(els: GridStackElement): HTMLElement {
+    if (typeof els === 'string') {
+      if (!els.length) return null;
+      if (els[0] === '#') {
+        return document.getElementById(els.substring(1));
+      }
+      if (els[0] === '.' || els[0] === '[') {
+        return document.querySelector(els);
+      }
+
+      // if we start with a digit, assume it's an id (error calling querySelector('#1')) as class are not valid CSS
+      if(!isNaN(+els[0])) { // start with digit
+        return document.getElementById(els);
+      }
+
+      // finally try string, then id then class
+      let el = document.querySelector(els);
+      if (!el) { el = document.getElementById(els) }
+      if (!el) { el = document.querySelector('.' + els) }
+      return el as HTMLElement;
+    }
+    return els;
+  }
+
+  /** returns true if a and b overlap */
+  static isIntercepted(a: GridStackPosition, b: GridStackPosition): boolean {
+    return !(a.y >= b.y + b.h || a.y + a.h <= b.y || a.x + a.w <= b.x || a.x >= b.x + b.w);
+  }
+
+  /** returns true if a and b touch edges or corners */
+  static isTouching(a: GridStackPosition, b: GridStackPosition): boolean {
+    return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
+  }
+  /**
     * Sorts array of nodes
     * @param nodes array to sort
     * @param dir 1 for asc, -1 for desc (optional)
     * @param width width of the grid. If undefined the width will be calculated automatically (optional).
     **/
-   static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
-     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
-     if (dir === -1)
-       return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));
-     else
-       return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
-   }
- 
-   /** update CSS style on elements with given selector */
-   static updateStyleOnElements(selector: string, styles: {[props: string]: string |  string[] }): void {
-     const elements = Utils.getElements(selector);
-     for (const el  of elements) {
-       Utils.addElementStyle(el, styles)
-     }
-   }
- 
-   /** update CSS style on element */
-   static addElementStyle(el: HTMLElement, styles: {[props: string]: string |  string[] }): void {
-     if (styles instanceof Object) {
-       for (const s in styles) {
-         if (styles.hasOwnProperty(s)) {
-           if (Array.isArray(styles[s])) {
-             // support fallback value
-             (styles[s] as string[]).forEach(val => {
-               el.style[s] = val;
-             });
-           } else {
-             el.style[s] = styles[s];
-           }
-         }
-       }
-     }
-   }
- 
-   /** update position style on element */
-   static updatePositionStyleOnWidget(el: HTMLElement, getHeight:(rows: number) => string): void {
-     const h = Utils.toNumber(el.getAttribute('gs-h'));
-     const minH= Utils.toNumber(el.getAttribute('gs-min-h'));
-     const maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
-     const y = Utils.toNumber(el.getAttribute('gs-y'));
-     el.style.height = getHeight(h);
-     el.style.minHeight = getHeight(minH);
-     el.style.maxHeight = getHeight(maxH);
-     el.style.top = getHeight(y);
-   }
- 
-   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-   static toBool(v: unknown): boolean {
-     if (typeof v === 'boolean') {
-       return v;
-     }
-     if (typeof v === 'string') {
-       v = v.toLowerCase();
-       return !(v === '' || v === 'no' || v === 'false' || v === '0');
-     }
-     return Boolean(v);
-   }
- 
-   static toNumber(value: null | string): number {
-     return (value === null || value.length === 0) ? undefined : Number(value);
-   }
- 
-   static parseHeight(val: numberOrString): HeightData {
-     let h: number;
-     let unit = 'px';
-     if (typeof val === 'string') {
-       let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
-       if (!match) {
-         throw new Error('Invalid height');
-       }
-       unit = match[2] || 'px';
-       h = parseFloat(match[1]);
-     } else {
-       h = val;
-     }
-     return { h, unit };
-   }
- 
-   /** copies unset fields in target to use the given default sources values */
-   // eslint-disable-next-line
+  static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
+    column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
+    if (dir === -1)
+      return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));
+    else
+      return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
+  }
+
+  /** update CSS style on elements with given selector */
+  static updateStyleOnElements(selector: string, styles: {[props: string]: string |  string[] }): void {
+    const elements = Utils.getElements(selector);
+    for (const el  of elements) {
+      Utils.addElementStyle(el, styles)
+    }
+  }
+
+  /** update CSS style on element */
+  static addElementStyle(el: HTMLElement, styles: {[props: string]: string |  string[] }): void {
+    if (styles instanceof Object) {
+      for (const s in styles) {
+        if (styles.hasOwnProperty(s)) {
+          if (Array.isArray(styles[s])) {
+            // support fallback value
+            (styles[s] as string[]).forEach(val => {
+              el.style[s] = val;
+            });
+          } else {
+            el.style[s] = styles[s];
+          }
+        }
+      }
+    }
+  }
+
+  /** update position style on element */
+  static updatePositionStyleOnWidget(el: HTMLElement, getHeight:(rows: number) => string): void {
+    const h = Utils.toNumber(el.getAttribute('gs-h'));
+    const minH= Utils.toNumber(el.getAttribute('gs-min-h'));
+    const maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
+    const y = Utils.toNumber(el.getAttribute('gs-y'));
+    el.style.height = getHeight(h);
+    el.style.minHeight = getHeight(minH);
+    el.style.maxHeight = getHeight(maxH);
+    el.style.top = getHeight(y);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static toBool(v: unknown): boolean {
+    if (typeof v === 'boolean') {
+      return v;
+    }
+    if (typeof v === 'string') {
+      v = v.toLowerCase();
+      return !(v === '' || v === 'no' || v === 'false' || v === '0');
+    }
+    return Boolean(v);
+  }
+
+  static toNumber(value: null | string): number {
+    return (value === null || value.length === 0) ? undefined : Number(value);
+  }
+
+  static parseHeight(val: numberOrString): HeightData {
+    let h: number;
+    let unit = 'px';
+    if (typeof val === 'string') {
+      let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
+      if (!match) {
+        throw new Error('Invalid height');
+      }
+      unit = match[2] || 'px';
+      h = parseFloat(match[1]);
+    } else {
+      h = val;
+    }
+    return { h, unit };
+  }
+
+  /** copies unset fields in target to use the given default sources values */
+  // eslint-disable-next-line
    static defaults(target, ...sources): {} {
- 
-     sources.forEach(source => {
-       for (const key in source) {
-         if (!source.hasOwnProperty(key)) return;
-         if (target[key] === null || target[key] === undefined) {
-           target[key] = source[key];
-         } else if (typeof source[key] === 'object' && typeof target[key] === 'object') {
-           // property is an object, recursively add it's field over... #1373
-           this.defaults(target[key], source[key]);
-         }
-       }
-     });
- 
-     return target;
-   }
- 
-   /** given 2 objects return true if they have the same values. Checks for Object {} having same fields and values (just 1 level down) */
-   static same(a: unknown, b: unknown): boolean {
-     if (typeof a !== 'object')  return a == b;
-     if (typeof a !== typeof b) return false;
-     // else we have object, check just 1 level deep for being same things...
-     if (Object.keys(a).length !== Object.keys(b).length) return false;
-     for (const key in a) {
-       if (a[key] !== b[key]) return false;
-     }
-     return true;
-   }
- 
-   /** copies over b size & position (GridStackPosition), and possibly min/max as well */
-   static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
-     a.x = b.x;
-     a.y = b.y;
-     a.w = b.w;
-     a.h = b.h;
-     if (doMinMax) {
-       if (b.minW) a.minW = b.minW;
-       if (b.minH) a.minH = b.minH;
-       if (b.maxW) a.maxW = b.maxW;
-       if (b.maxH) a.maxH = b.maxH;
-     }
-     return a;
-   }
- 
-   /** true if a and b has same size & position */
-   static samePos(a: GridStackPosition, b: GridStackPosition): boolean {
-     return a && b && a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
-   }
- 
-   /** removes field from the first object if same as the second objects (like diffing) and internal '_' for saving */
-   static removeInternalAndSame(a: unknown, b: unknown):void {
-     if (typeof a !== 'object' || typeof b !== 'object') return;
-     for (let key in a) {
-       let val = a[key];
-       if (key[0] === '_' || val === b[key]) {
-         delete a[key]
-       } else if (val && typeof val === 'object' && b[key] !== undefined) {
-         for (let i in val) {
-           if (val[i] === b[key][i] || i[0] === '_') { delete val[i] }
-         }
-         if (!Object.keys(val).length) { delete a[key] }
-       }
-     }
-   }
- 
-   /** return the closest parent (or itself) matching the given class */
-   static closestByClass(el: HTMLElement, name: string): HTMLElement {
-     while (el) {
-       if (el.classList.contains(name)) return el;
-       el = el.parentElement
-     }
-     return null;
-   }
- 
-   /** delay calling the given function for given delay, preventing new calls from happening while waiting */
-   static throttle(func: () => void, delay: number): () => void {
-     let isWaiting = false;
-     return (...args) => {
-       if (!isWaiting) {
-         isWaiting = true;
-         setTimeout(() => { func(...args); isWaiting = false; }, delay);
-       }
-     }
-   }
- 
-   static removePositioningStyles(el: HTMLElement): void {
-     let style = el.style;
-     if (style.position) {
-       style.removeProperty('position');
-     }
-     if (style.left) {
-       style.removeProperty('left');
-     }
-     if (style.top) {
-       style.removeProperty('top');
-     }
-     if (style.width) {
-       style.removeProperty('width');
-     }
-     if (style.height) {
-       style.removeProperty('height');
-     }
-   }
- 
-   /** @internal returns the passed element if scrollable, else the closest parent that will, up to the entire document scrolling element */
-   static getScrollElement(el?: HTMLElement): HTMLElement {
-     if (!el) return document.scrollingElement as HTMLElement || document.documentElement; // IE support
-     const style = getComputedStyle(el);
-     const overflowRegex = /(auto|scroll)/;
- 
-     if (overflowRegex.test(style.overflow + style.overflowY)) {
-       return el;
-     } else {
-       return this.getScrollElement(el.parentElement);
-     }
-   }
- 
-   /** @internal */
-   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
-     // is widget in view?
-     let rect = el.getBoundingClientRect();
-     let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
-     if (rect.top < 0 ||
+
+    sources.forEach(source => {
+      for (const key in source) {
+        if (!source.hasOwnProperty(key)) return;
+        if (target[key] === null || target[key] === undefined) {
+          target[key] = source[key];
+        } else if (typeof source[key] === 'object' && typeof target[key] === 'object') {
+          // property is an object, recursively add it's field over... #1373
+          this.defaults(target[key], source[key]);
+        }
+      }
+    });
+
+    return target;
+  }
+
+  /** given 2 objects return true if they have the same values. Checks for Object {} having same fields and values (just 1 level down) */
+  static same(a: unknown, b: unknown): boolean {
+    if (typeof a !== 'object')  return a == b;
+    if (typeof a !== typeof b) return false;
+    // else we have object, check just 1 level deep for being same things...
+    if (Object.keys(a).length !== Object.keys(b).length) return false;
+    for (const key in a) {
+      if (a[key] !== b[key]) return false;
+    }
+    return true;
+  }
+
+  /** copies over b size & position (GridStackPosition), and possibly min/max as well */
+  static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
+    a.x = b.x;
+    a.y = b.y;
+    a.w = b.w;
+    a.h = b.h;
+    if (doMinMax) {
+      if (b.minW) a.minW = b.minW;
+      if (b.minH) a.minH = b.minH;
+      if (b.maxW) a.maxW = b.maxW;
+      if (b.maxH) a.maxH = b.maxH;
+    }
+    return a;
+  }
+
+  /** true if a and b has same size & position */
+  static samePos(a: GridStackPosition, b: GridStackPosition): boolean {
+    return a && b && a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+  }
+
+  /** removes field from the first object if same as the second objects (like diffing) and internal '_' for saving */
+  static removeInternalAndSame(a: unknown, b: unknown):void {
+    if (typeof a !== 'object' || typeof b !== 'object') return;
+    for (let key in a) {
+      let val = a[key];
+      if (key[0] === '_' || val === b[key]) {
+        delete a[key]
+      } else if (val && typeof val === 'object' && b[key] !== undefined) {
+        for (let i in val) {
+          if (val[i] === b[key][i] || i[0] === '_') { delete val[i] }
+        }
+        if (!Object.keys(val).length) { delete a[key] }
+      }
+    }
+  }
+
+  /** return the closest parent (or itself) matching the given class */
+  static closestByClass(el: HTMLElement, name: string): HTMLElement {
+    while (el) {
+      if (el.classList.contains(name)) return el;
+      el = el.parentElement
+    }
+    return null;
+  }
+
+  /** delay calling the given function for given delay, preventing new calls from happening while waiting */
+  static throttle(func: () => void, delay: number): () => void {
+    let isWaiting = false;
+    return (...args) => {
+      if (!isWaiting) {
+        isWaiting = true;
+        setTimeout(() => { func(...args); isWaiting = false; }, delay);
+      }
+    }
+  }
+
+  static removePositioningStyles(el: HTMLElement): void {
+    let style = el.style;
+    if (style.position) {
+      style.removeProperty('position');
+    }
+    if (style.left) {
+      style.removeProperty('left');
+    }
+    if (style.top) {
+      style.removeProperty('top');
+    }
+    if (style.width) {
+      style.removeProperty('width');
+    }
+    if (style.height) {
+      style.removeProperty('height');
+    }
+  }
+
+  /** @internal returns the passed element if scrollable, else the closest parent that will, up to the entire document scrolling element */
+  static getScrollElement(el?: HTMLElement): HTMLElement {
+    if (!el) return document.scrollingElement as HTMLElement || document.documentElement; // IE support
+    const style = getComputedStyle(el);
+    const overflowRegex = /(auto|scroll)/;
+
+    if (overflowRegex.test(style.overflow + style.overflowY)) {
+      return el;
+    } else {
+      return this.getScrollElement(el.parentElement);
+    }
+  }
+
+  /** @internal */
+  static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
+    // is widget in view?
+    let rect = el.getBoundingClientRect();
+    let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
+    if (rect.top < 0 ||
        rect.bottom > innerHeightOrClientHeight
-     ) {
-       // set scrollTop of first parent that scrolls
-       // if parent is larger than el, set as low as possible
-       // to get entire widget on screen
-       let offsetDiffDown = rect.bottom - innerHeightOrClientHeight;
-       let offsetDiffUp = rect.top;
-       let scrollEl = this.getScrollElement(el);
-       if (scrollEl !== null) {
-         let prevScroll = scrollEl.scrollTop;
-         if (rect.top < 0 && distance < 0) {
-           // moving up
-           if (el.offsetHeight > innerHeightOrClientHeight) {
-             scrollEl.scrollTop += distance;
-           } else {
-             scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
-           }
-         } else if (distance > 0) {
-           // moving down
-           if (el.offsetHeight > innerHeightOrClientHeight) {
-             scrollEl.scrollTop += distance;
-           } else {
-             scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
-           }
-         }
-         // move widget y by amount scrolled
-         position.top += scrollEl.scrollTop - prevScroll;
-       }
-     }
-   }
- 
-   /**
+    ) {
+      // set scrollTop of first parent that scrolls
+      // if parent is larger than el, set as low as possible
+      // to get entire widget on screen
+      let offsetDiffDown = rect.bottom - innerHeightOrClientHeight;
+      let offsetDiffUp = rect.top;
+      let scrollEl = this.getScrollElement(el);
+      if (scrollEl !== null) {
+        let prevScroll = scrollEl.scrollTop;
+        if (rect.top < 0 && distance < 0) {
+          // moving up
+          if (el.offsetHeight > innerHeightOrClientHeight) {
+            scrollEl.scrollTop += distance;
+          } else {
+            scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
+          }
+        } else if (distance > 0) {
+          // moving down
+          if (el.offsetHeight > innerHeightOrClientHeight) {
+            scrollEl.scrollTop += distance;
+          } else {
+            scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
+          }
+        }
+        // move widget y by amount scrolled
+        position.top += scrollEl.scrollTop - prevScroll;
+      }
+    }
+  }
+
+  /**
     * @internal Function used to scroll the page.
     *
     * @param event `MouseEvent` that triggers the resize
     * @param el `HTMLElement` that's being resized
     * @param distance Distance from the V edges to start scrolling
     */
-   static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
-     const scrollEl = this.getScrollElement(el);
-     const height = scrollEl.clientHeight;
-     // #1727 event.clientY is relative to viewport, so must compare this against position of scrollEl getBoundingClientRect().top
-     // #1745 Special situation if scrollEl is document 'html': here browser spec states that
-     // clientHeight is height of viewport, but getBoundingClientRect() is rectangle of html element;
-     // this discrepancy arises because in reality scrollbar is attached to viewport, not html element itself.
-     const offsetTop = (scrollEl === this.getScrollElement()) ? 0 : scrollEl.getBoundingClientRect().top;
-     const pointerPosY = event.clientY - offsetTop;
-     const top = pointerPosY < distance;
-     const bottom = pointerPosY > height - distance;
- 
-     if (top) {
-       // This also can be done with a timeout to keep scrolling while the mouse is
-       // in the scrolling zone. (will have smoother behavior)
-       scrollEl.scrollBy({ behavior: 'smooth', top: pointerPosY - distance});
-     } else if (bottom) {
-       scrollEl.scrollBy({ behavior: 'smooth', top: distance - (height - pointerPosY)});
-     }
-   }
- 
-   /** single level clone, returning a new object with same top fields. This will share sub objects and arrays */
-   static clone<T>(obj: T): T {
-     if (obj === null || obj === undefined || typeof(obj) !== 'object') {
-       return obj;
-     }
-     // return Object.assign({}, obj);
-     if (obj instanceof Array) {
-       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-       return [...obj] as any;
-     }
-     return {...obj};
-   }
- 
-   /**
+  static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
+    const scrollEl = this.getScrollElement(el);
+    const height = scrollEl.clientHeight;
+    // #1727 event.clientY is relative to viewport, so must compare this against position of scrollEl getBoundingClientRect().top
+    // #1745 Special situation if scrollEl is document 'html': here browser spec states that
+    // clientHeight is height of viewport, but getBoundingClientRect() is rectangle of html element;
+    // this discrepancy arises because in reality scrollbar is attached to viewport, not html element itself.
+    const offsetTop = (scrollEl === this.getScrollElement()) ? 0 : scrollEl.getBoundingClientRect().top;
+    const pointerPosY = event.clientY - offsetTop;
+    const top = pointerPosY < distance;
+    const bottom = pointerPosY > height - distance;
+
+    if (top) {
+      // This also can be done with a timeout to keep scrolling while the mouse is
+      // in the scrolling zone. (will have smoother behavior)
+      scrollEl.scrollBy({ behavior: 'smooth', top: pointerPosY - distance});
+    } else if (bottom) {
+      scrollEl.scrollBy({ behavior: 'smooth', top: distance - (height - pointerPosY)});
+    }
+  }
+
+  /** single level clone, returning a new object with same top fields. This will share sub objects and arrays */
+  static clone<T>(obj: T): T {
+    if (obj === null || obj === undefined || typeof(obj) !== 'object') {
+      return obj;
+    }
+    // return Object.assign({}, obj);
+    if (obj instanceof Array) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return [...obj] as any;
+    }
+    return {...obj};
+  }
+
+  /**
     * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
     * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
     */
-   static cloneDeep<T>(obj: T): T {
-     // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
-     const ret = Utils.clone(obj);
-     for (const key in ret) {
-       // NOTE: we don't support function/circular dependencies so skip those properties for now...
-       if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__' && !skipFields.find(k => k === key)) {
-         ret[key] = Utils.cloneDeep(obj[key]);
-       }
-     }
-     return ret;
-   }
- }
- 
- // list of fields we will skip during cloneDeep (nested objects, other internal)
- const skipFields = ['_isNested', 'el', 'grid', 'subGrid', 'engine'];
- 
+  static cloneDeep<T>(obj: T): T {
+    // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
+    const ret = Utils.clone(obj);
+    for (const key in ret) {
+      // NOTE: we don't support function/circular dependencies so skip those properties for now...
+      if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__' && !skipFields.find(k => k === key)) {
+        ret[key] = Utils.cloneDeep(obj[key]);
+      }
+    }
+    return ret;
+  }
+}
+
+// list of fields we will skip during cloneDeep (nested objects, other internal)
+const skipFields = ['_isNested', 'el', 'grid', 'subGrid', 'engine'];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,404 +3,401 @@
  * Copyright (c) 2021 Alain Dumesny - see GridStack root license
  */
 
-import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
+ import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
-export interface HeightData {
-  h: number;
-  unit: string;
-}
-
-/** checks for obsolete method names */
-// eslint-disable-next-line
-export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
-  let wrapper = (...args) => {
-    console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
-    'with `' + newName + '`. It will be **completely** removed in v1.0');
-    return f.apply(self, args);
-  }
-  wrapper.prototype = f.prototype;
-  return wrapper;
-}
-
-/** checks for obsolete grid options (can be used for any fields, but msg is about options) */
-export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: string, rev: string): void {
-  if (opts[oldName] !== undefined) {
-    opts[newName] = opts[oldName];
-    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
-      newName + '`. It will be **completely** removed in v1.0');
-  }
-}
-
-/** checks for obsolete grid options which are gone */
-export function obsoleteOptsDel(opts: GridStackOptions, oldName: string, rev: string, info: string): void {
-  if (opts[oldName] !== undefined) {
-    console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
-  }
-}
-
-/** checks for obsolete Jquery element attributes */
-export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, rev: string): void {
-  let oldAttr = el.getAttribute(oldName);
-  if (oldAttr !== null) {
-    el.setAttribute(newName, oldAttr);
-    console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
-      newName + '`. It will be **completely** removed in v1.0');
-  }
-}
-
-/**
- * Utility methods
- */
-export class Utils {
-
-  /** convert a potential selector into actual list of html elements */
-  static getElements(els: GridStackElement): HTMLElement[] {
-    if (typeof els === 'string') {
-      let list = document.querySelectorAll(els);
-      if (!list.length && els[0] !== '.' && els[0] !== '#') {
-        list = document.querySelectorAll('.' + els);
-        if (!list.length) { list = document.querySelectorAll('#' + els) }
-      }
-      return Array.from(list) as HTMLElement[];
-    }
-    return [els];
-  }
-
-  /** convert a potential selector into actual single element */
-  static getElement(els: GridStackElement): HTMLElement {
-    if (typeof els === 'string') {
-      if (!els.length) return null;
-      if (els[0] === '#') {
-        return document.getElementById(els.substring(1));
-      }
-      if (els[0] === '.' || els[0] === '[') {
-        return document.querySelector(els);
-      }
-
-      // if we start with a digit, assume it's an id (error calling querySelector('#1')) as class are not valid CSS
-      if(!isNaN(+els[0])) { // start with digit
-        return document.getElementById(els);
-      }
-
-      // finally try string, then id then class
-      let el = document.querySelector(els);
-      if (!el) { el = document.getElementById(els) }
-      if (!el) { el = document.querySelector('.' + els) }
-      return el as HTMLElement;
-    }
-    return els;
-  }
-
-  /** returns true if a and b overlap */
-  static isIntercepted(a: GridStackPosition, b: GridStackPosition): boolean {
-    return !(a.y >= b.y + b.h || a.y + a.h <= b.y || a.x + a.w <= b.x || a.x >= b.x + b.w);
-  }
-
-  /** returns true if a and b touch edges or corners */
-  static isTouching(a: GridStackPosition, b: GridStackPosition): boolean {
-    return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
-  }
-  /**
-   * Sorts array of nodes
-   * @param nodes array to sort
-   * @param dir 1 for asc, -1 for desc (optional)
-   * @param width width of the grid. If undefined the width will be calculated automatically (optional).
-   **/
-  static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
-    column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
-    if (dir === -1)
-      return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));
-    else
-      return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
-  }
-
-  /**
-   * creates a style sheet with style id under given parent
-   * @param id will set the 'gs-style-id' attribute to that id
-   * @param parent to insert the stylesheet as first child,
-   * if none supplied it will be appended to the document head instead.
-   */
-  static createStylesheet(id: string, parent?: HTMLElement): CSSStyleSheet {
-    let style: HTMLStyleElement = document.createElement('style');
-    style.setAttribute('type', 'text/css');
-    style.setAttribute('gs-style-id', id);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((style as any).styleSheet) { // TODO: only CSSImportRule have that and different beast ??
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (style as any).styleSheet.cssText = '';
-    } else {
-      style.appendChild(document.createTextNode('')); // WebKit hack
-    }
-    if (!parent) {
-      // default to head
-      parent = document.getElementsByTagName('head')[0];
-      parent.appendChild(style);
-    } else {
-      parent.insertBefore(style, parent.firstChild);
-    }
-    return style.sheet as CSSStyleSheet;
-  }
-
-  /** removed the given stylesheet id */
-  static removeStylesheet(id: string): void {
-    let el = document.querySelector('STYLE[gs-style-id=' + id + ']');
-    if (el && el.parentNode) el.remove();
-  }
-
-  /** inserts a CSS rule */
-  static addCSSRule(sheet: CSSStyleSheet, selector: string, rules: string): void {
-    if (typeof sheet.addRule === 'function') {
-      sheet.addRule(selector, rules);
-    } else if (typeof sheet.insertRule === 'function') {
-      sheet.insertRule(`${selector}{${rules}}`);
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static toBool(v: unknown): boolean {
-    if (typeof v === 'boolean') {
-      return v;
-    }
-    if (typeof v === 'string') {
-      v = v.toLowerCase();
-      return !(v === '' || v === 'no' || v === 'false' || v === '0');
-    }
-    return Boolean(v);
-  }
-
-  static toNumber(value: null | string): number {
-    return (value === null || value.length === 0) ? undefined : Number(value);
-  }
-
-  static parseHeight(val: numberOrString): HeightData {
-    let h: number;
-    let unit = 'px';
-    if (typeof val === 'string') {
-      let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
-      if (!match) {
-        throw new Error('Invalid height');
-      }
-      unit = match[2] || 'px';
-      h = parseFloat(match[1]);
-    } else {
-      h = val;
-    }
-    return { h, unit };
-  }
-
-  /** copies unset fields in target to use the given default sources values */
-  // eslint-disable-next-line
-  static defaults(target, ...sources): {} {
-
-    sources.forEach(source => {
-      for (const key in source) {
-        if (!source.hasOwnProperty(key)) return;
-        if (target[key] === null || target[key] === undefined) {
-          target[key] = source[key];
-        } else if (typeof source[key] === 'object' && typeof target[key] === 'object') {
-          // property is an object, recursively add it's field over... #1373
-          this.defaults(target[key], source[key]);
-        }
-      }
-    });
-
-    return target;
-  }
-
-  /** given 2 objects return true if they have the same values. Checks for Object {} having same fields and values (just 1 level down) */
-  static same(a: unknown, b: unknown): boolean {
-    if (typeof a !== 'object')  return a == b;
-    if (typeof a !== typeof b) return false;
-    // else we have object, check just 1 level deep for being same things...
-    if (Object.keys(a).length !== Object.keys(b).length) return false;
-    for (const key in a) {
-      if (a[key] !== b[key]) return false;
-    }
-    return true;
-  }
-
-  /** copies over b size & position (GridStackPosition), and possibly min/max as well */
-  static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
-    a.x = b.x;
-    a.y = b.y;
-    a.w = b.w;
-    a.h = b.h;
-    if (doMinMax) {
-      if (b.minW) a.minW = b.minW;
-      if (b.minH) a.minH = b.minH;
-      if (b.maxW) a.maxW = b.maxW;
-      if (b.maxH) a.maxH = b.maxH;
-    }
-    return a;
-  }
-
-  /** true if a and b has same size & position */
-  static samePos(a: GridStackPosition, b: GridStackPosition): boolean {
-    return a && b && a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
-  }
-
-  /** removes field from the first object if same as the second objects (like diffing) and internal '_' for saving */
-  static removeInternalAndSame(a: unknown, b: unknown):void {
-    if (typeof a !== 'object' || typeof b !== 'object') return;
-    for (let key in a) {
-      let val = a[key];
-      if (key[0] === '_' || val === b[key]) {
-        delete a[key]
-      } else if (val && typeof val === 'object' && b[key] !== undefined) {
-        for (let i in val) {
-          if (val[i] === b[key][i] || i[0] === '_') { delete val[i] }
-        }
-        if (!Object.keys(val).length) { delete a[key] }
-      }
-    }
-  }
-
-  /** return the closest parent (or itself) matching the given class */
-  static closestByClass(el: HTMLElement, name: string): HTMLElement {
-    while (el) {
-      if (el.classList.contains(name)) return el;
-      el = el.parentElement
-    }
-    return null;
-  }
-
-  /** delay calling the given function for given delay, preventing new calls from happening while waiting */
-  static throttle(func: () => void, delay: number): () => void {
-    let isWaiting = false;
-    return (...args) => {
-      if (!isWaiting) {
-        isWaiting = true;
-        setTimeout(() => { func(...args); isWaiting = false; }, delay);
-      }
-    }
-  }
-
-  static removePositioningStyles(el: HTMLElement): void {
-    let style = el.style;
-    if (style.position) {
-      style.removeProperty('position');
-    }
-    if (style.left) {
-      style.removeProperty('left');
-    }
-    if (style.top) {
-      style.removeProperty('top');
-    }
-    if (style.width) {
-      style.removeProperty('width');
-    }
-    if (style.height) {
-      style.removeProperty('height');
-    }
-  }
-
-  /** @internal returns the passed element if scrollable, else the closest parent that will, up to the entire document scrolling element */
-  static getScrollElement(el?: HTMLElement): HTMLElement {
-    if (!el) return document.scrollingElement as HTMLElement || document.documentElement; // IE support
-    const style = getComputedStyle(el);
-    const overflowRegex = /(auto|scroll)/;
-
-    if (overflowRegex.test(style.overflow + style.overflowY)) {
-      return el;
-    } else {
-      return this.getScrollElement(el.parentElement);
-    }
-  }
-
-  /** @internal */
-  static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
-    // is widget in view?
-    let rect = el.getBoundingClientRect();
-    let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
-    if (rect.top < 0 ||
-      rect.bottom > innerHeightOrClientHeight
-    ) {
-      // set scrollTop of first parent that scrolls
-      // if parent is larger than el, set as low as possible
-      // to get entire widget on screen
-      let offsetDiffDown = rect.bottom - innerHeightOrClientHeight;
-      let offsetDiffUp = rect.top;
-      let scrollEl = this.getScrollElement(el);
-      if (scrollEl !== null) {
-        let prevScroll = scrollEl.scrollTop;
-        if (rect.top < 0 && distance < 0) {
-          // moving up
-          if (el.offsetHeight > innerHeightOrClientHeight) {
-            scrollEl.scrollTop += distance;
-          } else {
-            scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
-          }
-        } else if (distance > 0) {
-          // moving down
-          if (el.offsetHeight > innerHeightOrClientHeight) {
-            scrollEl.scrollTop += distance;
-          } else {
-            scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
-          }
-        }
-        // move widget y by amount scrolled
-        position.top += scrollEl.scrollTop - prevScroll;
-      }
-    }
-  }
-
-  /**
-   * @internal Function used to scroll the page.
-   *
-   * @param event `MouseEvent` that triggers the resize
-   * @param el `HTMLElement` that's being resized
-   * @param distance Distance from the V edges to start scrolling
-   */
-  static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
-    const scrollEl = this.getScrollElement(el);
-    const height = scrollEl.clientHeight;
-    // #1727 event.clientY is relative to viewport, so must compare this against position of scrollEl getBoundingClientRect().top
-    // #1745 Special situation if scrollEl is document 'html': here browser spec states that
-    // clientHeight is height of viewport, but getBoundingClientRect() is rectangle of html element;
-    // this discrepancy arises because in reality scrollbar is attached to viewport, not html element itself.
-    const offsetTop = (scrollEl === this.getScrollElement()) ? 0 : scrollEl.getBoundingClientRect().top;
-    const pointerPosY = event.clientY - offsetTop;
-    const top = pointerPosY < distance;
-    const bottom = pointerPosY > height - distance;
-
-    if (top) {
-      // This also can be done with a timeout to keep scrolling while the mouse is
-      // in the scrolling zone. (will have smoother behavior)
-      scrollEl.scrollBy({ behavior: 'smooth', top: pointerPosY - distance});
-    } else if (bottom) {
-      scrollEl.scrollBy({ behavior: 'smooth', top: distance - (height - pointerPosY)});
-    }
-  }
-
-  /** single level clone, returning a new object with same top fields. This will share sub objects and arrays */
-  static clone<T>(obj: T): T {
-    if (obj === null || obj === undefined || typeof(obj) !== 'object') {
-      return obj;
-    }
-    // return Object.assign({}, obj);
-    if (obj instanceof Array) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return [...obj] as any;
-    }
-    return {...obj};
-  }
-
-  /**
-   * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
-   * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
-   */
-  static cloneDeep<T>(obj: T): T {
-    // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
-    const ret = Utils.clone(obj);
-    for (const key in ret) {
-      // NOTE: we don't support function/circular dependencies so skip those properties for now...
-      if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__' && !skipFields.find(k => k === key)) {
-        ret[key] = Utils.cloneDeep(obj[key]);
-      }
-    }
-    return ret;
-  }
-}
-
-// list of fields we will skip during cloneDeep (nested objects, other internal)
-const skipFields = ['_isNested', 'el', 'grid', 'subGrid', 'engine'];
+ export interface HeightData {
+   h: number;
+   unit: string;
+ }
+ 
+ /** checks for obsolete method names */
+ // eslint-disable-next-line
+ export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
+   let wrapper = (...args) => {
+     console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
+     'with `' + newName + '`. It will be **completely** removed in v1.0');
+     return f.apply(self, args);
+   }
+   wrapper.prototype = f.prototype;
+   return wrapper;
+ }
+ 
+ /** checks for obsolete grid options (can be used for any fields, but msg is about options) */
+ export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: string, rev: string): void {
+   if (opts[oldName] !== undefined) {
+     opts[newName] = opts[oldName];
+     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
+       newName + '`. It will be **completely** removed in v1.0');
+   }
+ }
+ 
+ /** checks for obsolete grid options which are gone */
+ export function obsoleteOptsDel(opts: GridStackOptions, oldName: string, rev: string, info: string): void {
+   if (opts[oldName] !== undefined) {
+     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + info);
+   }
+ }
+ 
+ /** checks for obsolete Jquery element attributes */
+ export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, rev: string): void {
+   let oldAttr = el.getAttribute(oldName);
+   if (oldAttr !== null) {
+     el.setAttribute(newName, oldAttr);
+     console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
+       newName + '`. It will be **completely** removed in v1.0');
+   }
+ }
+ 
+ /**
+  * Utility methods
+  */
+ export class Utils {
+ 
+   /** convert a potential selector into actual list of html elements */
+   static getElements(els: GridStackElement): HTMLElement[] {
+     if (typeof els === 'string') {
+       let list = document.querySelectorAll(els);
+       if (!list.length && els[0] !== '.' && els[0] !== '#') {
+         list = document.querySelectorAll('.' + els);
+         if (!list.length) { list = document.querySelectorAll('#' + els) }
+       }
+       return Array.from(list) as HTMLElement[];
+     }
+     return [els];
+   }
+ 
+   /** convert a potential selector into actual single element */
+   static getElement(els: GridStackElement): HTMLElement {
+     if (typeof els === 'string') {
+       if (!els.length) return null;
+       if (els[0] === '#') {
+         return document.getElementById(els.substring(1));
+       }
+       if (els[0] === '.' || els[0] === '[') {
+         return document.querySelector(els);
+       }
+ 
+       // if we start with a digit, assume it's an id (error calling querySelector('#1')) as class are not valid CSS
+       if(!isNaN(+els[0])) { // start with digit
+         return document.getElementById(els);
+       }
+ 
+       // finally try string, then id then class
+       let el = document.querySelector(els);
+       if (!el) { el = document.getElementById(els) }
+       if (!el) { el = document.querySelector('.' + els) }
+       return el as HTMLElement;
+     }
+     return els;
+   }
+ 
+   /** returns true if a and b overlap */
+   static isIntercepted(a: GridStackPosition, b: GridStackPosition): boolean {
+     return !(a.y >= b.y + b.h || a.y + a.h <= b.y || a.x + a.w <= b.x || a.x >= b.x + b.w);
+   }
+ 
+   /** returns true if a and b touch edges or corners */
+   static isTouching(a: GridStackPosition, b: GridStackPosition): boolean {
+     return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
+   }
+   /**
+    * Sorts array of nodes
+    * @param nodes array to sort
+    * @param dir 1 for asc, -1 for desc (optional)
+    * @param width width of the grid. If undefined the width will be calculated automatically (optional).
+    **/
+   static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
+     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
+     if (dir === -1)
+       return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));
+     else
+       return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
+   }
+ 
+   /** update CSS style on elements with given selector */
+   static updateStyleOnElements(selector: string, styles: {[props: string]: string |  string[] }): void {
+     const elements = Utils.getElements(selector);
+     for (const el  of elements) {
+       Utils.addElementStyle(el, styles)
+     }
+   }
+ 
+   /** update CSS style on element */
+   static addElementStyle(el: HTMLElement, styles: {[props: string]: string |  string[] }): void {
+     if (styles instanceof Object) {
+       for (const s in styles) {
+         if (styles.hasOwnProperty(s)) {
+           if (Array.isArray(styles[s])) {
+             // support fallback value
+             (styles[s] as string[]).forEach(val => {
+               el.style[s] = val;
+             });
+           } else {
+             el.style[s] = styles[s];
+           }
+         }
+       }
+     }
+   }
+ 
+   /** update position style on element */
+   static updatePositionStyleOnWidget(el: HTMLElement, getHeight:(rows: number) => string): void {
+     const h = Utils.toNumber(el.getAttribute('gs-h'));
+     const minH= Utils.toNumber(el.getAttribute('gs-min-h'));
+     const maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
+     const y = Utils.toNumber(el.getAttribute('gs-y'));
+     el.style.height = getHeight(h);
+     el.style.minHeight = getHeight(minH);
+     el.style.maxHeight = getHeight(maxH);
+     el.style.top = getHeight(y);
+   }
+ 
+   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   static toBool(v: unknown): boolean {
+     if (typeof v === 'boolean') {
+       return v;
+     }
+     if (typeof v === 'string') {
+       v = v.toLowerCase();
+       return !(v === '' || v === 'no' || v === 'false' || v === '0');
+     }
+     return Boolean(v);
+   }
+ 
+   static toNumber(value: null | string): number {
+     return (value === null || value.length === 0) ? undefined : Number(value);
+   }
+ 
+   static parseHeight(val: numberOrString): HeightData {
+     let h: number;
+     let unit = 'px';
+     if (typeof val === 'string') {
+       let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
+       if (!match) {
+         throw new Error('Invalid height');
+       }
+       unit = match[2] || 'px';
+       h = parseFloat(match[1]);
+     } else {
+       h = val;
+     }
+     return { h, unit };
+   }
+ 
+   /** copies unset fields in target to use the given default sources values */
+   // eslint-disable-next-line
+   static defaults(target, ...sources): {} {
+ 
+     sources.forEach(source => {
+       for (const key in source) {
+         if (!source.hasOwnProperty(key)) return;
+         if (target[key] === null || target[key] === undefined) {
+           target[key] = source[key];
+         } else if (typeof source[key] === 'object' && typeof target[key] === 'object') {
+           // property is an object, recursively add it's field over... #1373
+           this.defaults(target[key], source[key]);
+         }
+       }
+     });
+ 
+     return target;
+   }
+ 
+   /** given 2 objects return true if they have the same values. Checks for Object {} having same fields and values (just 1 level down) */
+   static same(a: unknown, b: unknown): boolean {
+     if (typeof a !== 'object')  return a == b;
+     if (typeof a !== typeof b) return false;
+     // else we have object, check just 1 level deep for being same things...
+     if (Object.keys(a).length !== Object.keys(b).length) return false;
+     for (const key in a) {
+       if (a[key] !== b[key]) return false;
+     }
+     return true;
+   }
+ 
+   /** copies over b size & position (GridStackPosition), and possibly min/max as well */
+   static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
+     a.x = b.x;
+     a.y = b.y;
+     a.w = b.w;
+     a.h = b.h;
+     if (doMinMax) {
+       if (b.minW) a.minW = b.minW;
+       if (b.minH) a.minH = b.minH;
+       if (b.maxW) a.maxW = b.maxW;
+       if (b.maxH) a.maxH = b.maxH;
+     }
+     return a;
+   }
+ 
+   /** true if a and b has same size & position */
+   static samePos(a: GridStackPosition, b: GridStackPosition): boolean {
+     return a && b && a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+   }
+ 
+   /** removes field from the first object if same as the second objects (like diffing) and internal '_' for saving */
+   static removeInternalAndSame(a: unknown, b: unknown):void {
+     if (typeof a !== 'object' || typeof b !== 'object') return;
+     for (let key in a) {
+       let val = a[key];
+       if (key[0] === '_' || val === b[key]) {
+         delete a[key]
+       } else if (val && typeof val === 'object' && b[key] !== undefined) {
+         for (let i in val) {
+           if (val[i] === b[key][i] || i[0] === '_') { delete val[i] }
+         }
+         if (!Object.keys(val).length) { delete a[key] }
+       }
+     }
+   }
+ 
+   /** return the closest parent (or itself) matching the given class */
+   static closestByClass(el: HTMLElement, name: string): HTMLElement {
+     while (el) {
+       if (el.classList.contains(name)) return el;
+       el = el.parentElement
+     }
+     return null;
+   }
+ 
+   /** delay calling the given function for given delay, preventing new calls from happening while waiting */
+   static throttle(func: () => void, delay: number): () => void {
+     let isWaiting = false;
+     return (...args) => {
+       if (!isWaiting) {
+         isWaiting = true;
+         setTimeout(() => { func(...args); isWaiting = false; }, delay);
+       }
+     }
+   }
+ 
+   static removePositioningStyles(el: HTMLElement): void {
+     let style = el.style;
+     if (style.position) {
+       style.removeProperty('position');
+     }
+     if (style.left) {
+       style.removeProperty('left');
+     }
+     if (style.top) {
+       style.removeProperty('top');
+     }
+     if (style.width) {
+       style.removeProperty('width');
+     }
+     if (style.height) {
+       style.removeProperty('height');
+     }
+   }
+ 
+   /** @internal returns the passed element if scrollable, else the closest parent that will, up to the entire document scrolling element */
+   static getScrollElement(el?: HTMLElement): HTMLElement {
+     if (!el) return document.scrollingElement as HTMLElement || document.documentElement; // IE support
+     const style = getComputedStyle(el);
+     const overflowRegex = /(auto|scroll)/;
+ 
+     if (overflowRegex.test(style.overflow + style.overflowY)) {
+       return el;
+     } else {
+       return this.getScrollElement(el.parentElement);
+     }
+   }
+ 
+   /** @internal */
+   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
+     // is widget in view?
+     let rect = el.getBoundingClientRect();
+     let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
+     if (rect.top < 0 ||
+       rect.bottom > innerHeightOrClientHeight
+     ) {
+       // set scrollTop of first parent that scrolls
+       // if parent is larger than el, set as low as possible
+       // to get entire widget on screen
+       let offsetDiffDown = rect.bottom - innerHeightOrClientHeight;
+       let offsetDiffUp = rect.top;
+       let scrollEl = this.getScrollElement(el);
+       if (scrollEl !== null) {
+         let prevScroll = scrollEl.scrollTop;
+         if (rect.top < 0 && distance < 0) {
+           // moving up
+           if (el.offsetHeight > innerHeightOrClientHeight) {
+             scrollEl.scrollTop += distance;
+           } else {
+             scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
+           }
+         } else if (distance > 0) {
+           // moving down
+           if (el.offsetHeight > innerHeightOrClientHeight) {
+             scrollEl.scrollTop += distance;
+           } else {
+             scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
+           }
+         }
+         // move widget y by amount scrolled
+         position.top += scrollEl.scrollTop - prevScroll;
+       }
+     }
+   }
+ 
+   /**
+    * @internal Function used to scroll the page.
+    *
+    * @param event `MouseEvent` that triggers the resize
+    * @param el `HTMLElement` that's being resized
+    * @param distance Distance from the V edges to start scrolling
+    */
+   static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
+     const scrollEl = this.getScrollElement(el);
+     const height = scrollEl.clientHeight;
+     // #1727 event.clientY is relative to viewport, so must compare this against position of scrollEl getBoundingClientRect().top
+     // #1745 Special situation if scrollEl is document 'html': here browser spec states that
+     // clientHeight is height of viewport, but getBoundingClientRect() is rectangle of html element;
+     // this discrepancy arises because in reality scrollbar is attached to viewport, not html element itself.
+     const offsetTop = (scrollEl === this.getScrollElement()) ? 0 : scrollEl.getBoundingClientRect().top;
+     const pointerPosY = event.clientY - offsetTop;
+     const top = pointerPosY < distance;
+     const bottom = pointerPosY > height - distance;
+ 
+     if (top) {
+       // This also can be done with a timeout to keep scrolling while the mouse is
+       // in the scrolling zone. (will have smoother behavior)
+       scrollEl.scrollBy({ behavior: 'smooth', top: pointerPosY - distance});
+     } else if (bottom) {
+       scrollEl.scrollBy({ behavior: 'smooth', top: distance - (height - pointerPosY)});
+     }
+   }
+ 
+   /** single level clone, returning a new object with same top fields. This will share sub objects and arrays */
+   static clone<T>(obj: T): T {
+     if (obj === null || obj === undefined || typeof(obj) !== 'object') {
+       return obj;
+     }
+     // return Object.assign({}, obj);
+     if (obj instanceof Array) {
+       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       return [...obj] as any;
+     }
+     return {...obj};
+   }
+ 
+   /**
+    * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
+    * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
+    */
+   static cloneDeep<T>(obj: T): T {
+     // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
+     const ret = Utils.clone(obj);
+     for (const key in ret) {
+       // NOTE: we don't support function/circular dependencies so skip those properties for now...
+       if (ret.hasOwnProperty(key) && typeof(ret[key]) === 'object' && key.substring(0, 2) !== '__' && !skipFields.find(k => k === key)) {
+         ret[key] = Utils.cloneDeep(obj[key]);
+       }
+     }
+     return ret;
+   }
+ }
+ 
+ // list of fields we will skip during cloneDeep (nested objects, other internal)
+ const skipFields = ['_isNested', 'el', 'grid', 'subGrid', 'engine'];
+ 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,16 +6,16 @@
 import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
 export interface HeightData {
-   h: number;
-   unit: string;
- }
+  h: number;
+  unit: string;
+}
 
 /** checks for obsolete method names */
 // eslint-disable-next-line
- export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
+export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
   let wrapper = (...args) => {
     console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
-     'with `' + newName + '`. It will be **completely** removed in v1.0');
+    'with `' + newName + '`. It will be **completely** removed in v1.0');
     return f.apply(self, args);
   }
   wrapper.prototype = f.prototype;
@@ -27,7 +27,7 @@ export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: s
   if (opts[oldName] !== undefined) {
     opts[newName] = opts[oldName];
     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
-       newName + '`. It will be **completely** removed in v1.0');
+      newName + '`. It will be **completely** removed in v1.0');
   }
 }
 
@@ -49,8 +49,8 @@ export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, 
 }
 
 /**
-  * Utility methods
-  */
+ * Utility methods
+ */
 export class Utils {
 
   /** convert a potential selector into actual list of html elements */
@@ -101,11 +101,11 @@ export class Utils {
     return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
   }
   /**
-    * Sorts array of nodes
-    * @param nodes array to sort
-    * @param dir 1 for asc, -1 for desc (optional)
-    * @param width width of the grid. If undefined the width will be calculated automatically (optional).
-    **/
+   * Sorts array of nodes
+   * @param nodes array to sort
+   * @param dir 1 for asc, -1 for desc (optional)
+   * @param width width of the grid. If undefined the width will be calculated automatically (optional).
+   **/
   static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
     if (dir === -1)
@@ -186,7 +186,7 @@ export class Utils {
 
   /** copies unset fields in target to use the given default sources values */
   // eslint-disable-next-line
-   static defaults(target, ...sources): {} {
+  static defaults(target, ...sources): {} {
 
     sources.forEach(source => {
       for (const key in source) {
@@ -309,7 +309,7 @@ export class Utils {
     let rect = el.getBoundingClientRect();
     let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
     if (rect.top < 0 ||
-       rect.bottom > innerHeightOrClientHeight
+      rect.bottom > innerHeightOrClientHeight
     ) {
       // set scrollTop of first parent that scrolls
       // if parent is larger than el, set as low as possible
@@ -341,12 +341,12 @@ export class Utils {
   }
 
   /**
-    * @internal Function used to scroll the page.
-    *
-    * @param event `MouseEvent` that triggers the resize
-    * @param el `HTMLElement` that's being resized
-    * @param distance Distance from the V edges to start scrolling
-    */
+   * @internal Function used to scroll the page.
+   *
+   * @param event `MouseEvent` that triggers the resize
+   * @param el `HTMLElement` that's being resized
+   * @param distance Distance from the V edges to start scrolling
+   */
   static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
     const scrollEl = this.getScrollElement(el);
     const height = scrollEl.clientHeight;
@@ -382,9 +382,9 @@ export class Utils {
   }
 
   /**
-    * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
-    * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
-    */
+   * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
+   * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
+   */
   static cloneDeep<T>(obj: T): T {
     // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
     const ret = Utils.clone(obj);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,16 +6,16 @@
 import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
 export interface HeightData {
-  h: number;
-  unit: string;
-}
+   h: number;
+   unit: string;
+ }
 
 /** checks for obsolete method names */
 // eslint-disable-next-line
-export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
+ export function obsolete(self, f, oldName: string, newName: string, rev: string): (...args: any[]) => any {
   let wrapper = (...args) => {
     console.warn('gridstack.js: Function `' + oldName + '` is deprecated in ' + rev + ' and has been replaced ' +
-    'with `' + newName + '`. It will be **completely** removed in v1.0');
+     'with `' + newName + '`. It will be **completely** removed in v1.0');
     return f.apply(self, args);
   }
   wrapper.prototype = f.prototype;
@@ -27,7 +27,7 @@ export function obsoleteOpts(opts: GridStackOptions, oldName: string, newName: s
   if (opts[oldName] !== undefined) {
     opts[newName] = opts[oldName];
     console.warn('gridstack.js: Option `' + oldName + '` is deprecated in ' + rev + ' and has been replaced with `' +
-      newName + '`. It will be **completely** removed in v1.0');
+       newName + '`. It will be **completely** removed in v1.0');
   }
 }
 
@@ -44,13 +44,13 @@ export function obsoleteAttr(el: HTMLElement, oldName: string, newName: string, 
   if (oldAttr !== null) {
     el.setAttribute(newName, oldAttr);
     console.warn('gridstack.js: attribute `' + oldName + '`=' + oldAttr + ' is deprecated on this object in ' + rev + ' and has been replaced with `' +
-      newName + '`. It will be **completely** removed in v1.0');
+       newName + '`. It will be **completely** removed in v1.0');
   }
 }
 
 /**
- * Utility methods
- */
+  * Utility methods
+  */
 export class Utils {
 
   /** convert a potential selector into actual list of html elements */
@@ -101,11 +101,11 @@ export class Utils {
     return Utils.isIntercepted(a, {x: b.x-0.5, y: b.y-0.5, w: b.w+1, h: b.h+1})
   }
   /**
-   * Sorts array of nodes
-   * @param nodes array to sort
-   * @param dir 1 for asc, -1 for desc (optional)
-   * @param width width of the grid. If undefined the width will be calculated automatically (optional).
-   **/
+    * Sorts array of nodes
+    * @param nodes array to sort
+    * @param dir 1 for asc, -1 for desc (optional)
+    * @param width width of the grid. If undefined the width will be calculated automatically (optional).
+    **/
   static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
     if (dir === -1)
@@ -114,6 +114,49 @@ export class Utils {
       return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
   }
 
+  /**
+    * creates a style sheet with style id under given parent
+    * @param id will set the 'gs-style-id' attribute to that id
+    * @param parent to insert the stylesheet as first child,
+    * if none supplied it will be appended to the document head instead.
+    */
+  static createStylesheet(parent?: HTMLElement): CSSStyleSheet {
+    let stylesheet: CSSStyleSheet = new CSSStyleSheet();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const location: any = parent? parent.getRootNode() : document;
+    if(!location.adoptedStyleSheets || location.adoptedStyleSheets.length === 0) {
+      location.adoptedStyleSheets = [stylesheet];
+    } else {
+      location.adoptedStyleSheets = [...location.adoptedStyleSheets, stylesheet];
+    }
+    return stylesheet;
+  }
+
+  /** removed the given stylesheet id */
+  static removeStylesheet(stylesheet: CSSStyleSheet): void {
+    const styles = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const docObj: any = document;
+    docObj.adoptedStyleSheets.forEach((style: CSSStyleSheet) => {
+      styles.push(style);
+    });
+    styles.splice(styles.indexOf(stylesheet),1);
+    docObj.adoptedStyleSheets = styles;
+  }
+
+  /** inserts a CSS rule */
+  static addCSSRule(sheet: any, selector: string, rules: string): void {
+    if (typeof sheet.replaceSync === 'function') {
+      sheet.replaceSync(Utils.concatCSSRules(sheet, selector, rules));
+    }
+  }
+
+  /** concat css rules in existing stylesheet */
+  static concatCSSRules(sheet: CSSStyleSheet, selector: string, rules: string): string {
+    return Object.values(sheet.cssRules).reduce((acc: string, curr: CSSRule) => {
+      return acc + curr.cssText;
+    }, '') + ' ' + selector + '{' + rules + '}';
+  }
   /** update CSS style on elements with given selector */
   static updateStyleOnElements(selector: string | HTMLElement[], styles: {[props: string]: string |  string[] }): void {
     const elements = typeof selector === 'string' ? Utils.getElements(selector) : selector;
@@ -153,6 +196,18 @@ export class Utils {
     return  (rows * cellHeight as number) + cellHeightUnit;
   }
 
+  static isConstructableStyleSheetSupported(): boolean {
+    try {
+      let stylesheet =  new CSSStyleSheet();
+      if ('replaceSync' in stylesheet) {
+        return true;
+      }
+      return false;
+    } catch (error) {
+      return false;
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static toBool(v: unknown): boolean {
     if (typeof v === 'boolean') {
@@ -187,7 +242,7 @@ export class Utils {
 
   /** copies unset fields in target to use the given default sources values */
   // eslint-disable-next-line
-  static defaults(target, ...sources): {} {
+   static defaults(target, ...sources): {} {
 
     sources.forEach(source => {
       for (const key in source) {
@@ -310,7 +365,7 @@ export class Utils {
     let rect = el.getBoundingClientRect();
     let innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
     if (rect.top < 0 ||
-      rect.bottom > innerHeightOrClientHeight
+       rect.bottom > innerHeightOrClientHeight
     ) {
       // set scrollTop of first parent that scrolls
       // if parent is larger than el, set as low as possible
@@ -342,12 +397,12 @@ export class Utils {
   }
 
   /**
-   * @internal Function used to scroll the page.
-   *
-   * @param event `MouseEvent` that triggers the resize
-   * @param el `HTMLElement` that's being resized
-   * @param distance Distance from the V edges to start scrolling
-   */
+    * @internal Function used to scroll the page.
+    *
+    * @param event `MouseEvent` that triggers the resize
+    * @param el `HTMLElement` that's being resized
+    * @param distance Distance from the V edges to start scrolling
+    */
   static updateScrollResize(event: MouseEvent, el: HTMLElement, distance: number): void {
     const scrollEl = this.getScrollElement(el);
     const height = scrollEl.clientHeight;
@@ -383,9 +438,9 @@ export class Utils {
   }
 
   /**
-   * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
-   * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
-   */
+    * Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
+    * Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
+    */
   static cloneDeep<T>(obj: T): T {
     // return JSON.parse(JSON.stringify(obj)); // doesn't work with date format ?
     const ret = Utils.clone(obj);


### PR DESCRIPTION
fix #418
### Description
* updating styles directly on HTMLELement style description rather than updating dynamic stylesheets
* removing logic related to dynamic stylesheets as they aren't required and violate CSP strict style-src rule
* removed UTs related to Dynamic stylesheets

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
