### PR TITLE
mobile touch support (dragging)

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -37,12 +37,12 @@
 
     <div class="row" style="margin-top: 20px">
       <div class="col-md-6">
-        <a onClick="toggleFloat(this, 0)" class="btn btn-primary" href="#">float: false</a>
+        <a onClick="toggleFloat(this, 0)" class="btn btn-primary" href="#">float: true</a>
         <a onClick="compact(0)" class="btn btn-primary" href="#">Compact</a>
         <div class="grid-stack" id="left_grid"></div>
       </div>
       <div class="col-md-6">
-        <a onClick="toggleFloat(this, 1)" class="btn btn-primary" href="#">float: true</a>
+        <a onClick="toggleFloat(this, 1)" class="btn btn-primary" href="#">float: false</a>
         <a onClick="compact(1)" class="btn btn-primary" href="#">Compact</a>
         <div class="grid-stack" id="right_grid"></div>
       </div>
@@ -55,14 +55,14 @@
       minRow: 1, // don't collapse when empty
       cellHeight: 70,
       disableOneColumnMode: true,
-      float: false,
+      float: true,
       // dragIn: '.sidebar .grid-stack-item', // add draggable to class
       // dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }, // clone
       removable: '.trash', // true or drag-out delete class
       acceptWidgets: function(el) { return true; } // function example, but can also be: true | false | '.someClass' value
     };
     let grids = GridStack.initAll(options);
-    grids[1].float(true);
+    grids[1].float(false);
 
     // new 4.x static method instead of setting up options on every grid (never been per grid really) but old options still works
     GridStack.setupDragIn('.sidebar .grid-stack-item', { revert: 'invalid', scroll: false, appendTo: 'body', helper: myClone });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "yarn --no-progress && rm -rf dist/* && grunt && yarn build:es6 && yarn build:es5 && yarn doc",
     "build:es6": "webpack && tsc --stripInternal",
     "build:es5": "webpack --config es5/webpack.config.js && tsc --stripInternal --project es5/tsconfig.json",
-    "w": "rm -rf dist/* && grunt && webpack",
+    "w": "webpack",
     "t": "rm -rf dist/* && grunt && tsc --stripInternal",
     "doc": "doctoc ./README.md && doctoc ./doc/README.md && doctoc ./doc/CHANGES.md",
     "test": "yarn lint && karma start karma.conf.js",

--- a/src/h5/dd-droppable.ts
+++ b/src/h5/dd-droppable.ts
@@ -8,6 +8,7 @@ import { DDManager } from './dd-manager';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { DDUtils } from './dd-utils';
 import { DDElementHost } from './dd-element';
+import { isTouch, pointerenter, pointerleave } from './touch';
 
 export interface DDDroppableOpt {
   accept?: string | ((el: HTMLElement) => boolean);
@@ -50,6 +51,10 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
     this.el.classList.remove('ui-droppable-disabled');
     this.el.addEventListener('mouseenter', this._mouseEnter);
     this.el.addEventListener('mouseleave', this._mouseLeave);
+    if (isTouch) {
+      this.el.addEventListener('pointerenter', pointerenter);
+      this.el.addEventListener('pointerleave', pointerleave);
+    }
   }
 
   public disable(forDestroy = false): void {
@@ -59,6 +64,10 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
     if (!forDestroy) this.el.classList.add('ui-droppable-disabled');
     this.el.removeEventListener('mouseenter', this._mouseEnter);
     this.el.removeEventListener('mouseleave', this._mouseLeave);
+    if (isTouch) {
+      this.el.removeEventListener('pointerenter', pointerenter);
+      this.el.removeEventListener('pointerleave', pointerleave);
+    }
   }
 
   public destroy(): void {

--- a/src/h5/dd-manager.ts
+++ b/src/h5/dd-manager.ts
@@ -10,6 +10,7 @@ import { DDDroppable } from './dd-droppable';
  * globals that are shared across Drag & Drop instances
  */
 export class DDManager {
+  
   /** true if a mouse down event was handled */
   public static mouseHandled: boolean;
 

--- a/src/h5/touch.ts
+++ b/src/h5/touch.ts
@@ -1,0 +1,199 @@
+/**
+ * touch.ts 5.1.1
+ * Copyright (c) 2021 Alain Dumesny - see GridStack root license
+ */
+
+import { DDManager } from "./dd-manager";
+
+/**
+ * Detect touch support - Windows Surface devices and other touch devices
+ */
+export const isTouch: boolean = ( 'ontouchstart' in document
+  || 'ontouchstart' in window
+  || !!window.TouchEvent
+  || ((window as any).DocumentTouch && document instanceof (window as any).DocumentTouch)
+  || navigator.maxTouchPoints > 0
+  || (navigator as any).msMaxTouchPoints > 0
+);
+
+
+// interface TouchCoord {x: number, y: number};
+
+class DDTouch {
+  public static touchHandled: boolean;
+  public static pointerLeaveTimeout: number;
+}
+
+/**
+* Get the x,y position of a touch event
+*/
+// function getTouchCoords(e: TouchEvent): TouchCoord {
+//   return {
+//     x: e.changedTouches[0].pageX,
+//     y: e.changedTouches[0].pageY
+//   };
+// }
+
+/**
+ * Simulate a mouse event based on a corresponding touch event
+ * @param {Object} e A touch event
+ * @param {String} simulatedType The corresponding mouse event
+ */
+function simulateMouseEvent(e: TouchEvent, simulatedType: string) {
+
+  // Ignore multi-touch events
+  if (e.touches.length > 1) return;
+
+  // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
+  if (e.cancelable) e.preventDefault();
+
+  const touch = e.changedTouches[0],
+      simulatedEvent = document.createEvent('MouseEvents');
+
+  // Initialize the simulated mouse event using the touch event's coordinates
+  simulatedEvent.initMouseEvent(
+    simulatedType,    // type
+    true,             // bubbles
+    true,             // cancelable
+    window,           // view
+    1,                // detail
+    touch.screenX,    // screenX
+    touch.screenY,    // screenY
+    touch.clientX,    // clientX
+    touch.clientY,    // clientY
+    false,            // ctrlKey
+    false,            // altKey
+    false,            // shiftKey
+    false,            // metaKey
+    0,                // button
+    null              // relatedTarget
+  );
+
+  // Dispatch the simulated event to the target element
+  e.target.dispatchEvent(simulatedEvent);
+}
+
+/**
+ * Simulate a mouse event based on a corresponding Pointer event
+ * @param {Object} e A pointer event
+ * @param {String} simulatedType The corresponding mouse event
+ */
+ function simulatePointerMouseEvent(e: PointerEvent, simulatedType: string) {
+
+  // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
+  if (e.cancelable) e.preventDefault();
+
+  const simulatedEvent = document.createEvent('MouseEvents');
+
+  // Initialize the simulated mouse event using the touch event's coordinates
+  simulatedEvent.initMouseEvent(
+    simulatedType,    // type
+    true,             // bubbles
+    true,             // cancelable
+    window,           // view
+    1,                // detail
+    e.screenX,    // screenX
+    e.screenY,    // screenY
+    e.clientX,    // clientX
+    e.clientY,    // clientY
+    false,            // ctrlKey
+    false,            // altKey
+    false,            // shiftKey
+    false,            // metaKey
+    0,                // button
+    null              // relatedTarget
+  );
+
+  // Dispatch the simulated event to the target element
+  e.target.dispatchEvent(simulatedEvent);
+}
+
+
+/**
+ * Handle the touchstart events
+ * @param {Object} e The widget element's touchstart event
+ */
+ export function touchstart(e: TouchEvent) {
+  // Ignore the event if another widget is already being handled
+  if (DDTouch.touchHandled) return;  DDTouch.touchHandled = true;
+
+  // Simulate the mouse events
+  // simulateMouseEvent(e, 'mouseover');
+  // simulateMouseEvent(e, 'mousemove');
+  simulateMouseEvent(e, 'mousedown');
+};
+
+/**
+ * Handle the touchmove events
+ * @param {Object} e The document's touchmove event
+ */
+export function touchmove(e: TouchEvent) {
+  // Ignore event if not handled by us
+  if (!DDTouch.touchHandled)  return;
+
+  simulateMouseEvent(e, 'mousemove');
+};
+
+/**
+ * Handle the touchend events
+ * @param {Object} e The document's touchend event
+ */
+export function touchend(e: TouchEvent) {
+
+  // Ignore event if not handled
+  if (!DDTouch.touchHandled) return;
+
+  // cancel delayed leave event when we release on ourself which happens BEFORE we get this!
+  if (DDTouch.pointerLeaveTimeout) {
+    window.clearTimeout(DDTouch.pointerLeaveTimeout);
+    delete DDTouch.pointerLeaveTimeout;
+  }
+
+  const wasDragging = !!DDManager.dragElement;
+
+  // Simulate the mouseup event
+  simulateMouseEvent(e, 'mouseup');
+  // simulateMouseEvent(event, 'mouseout');
+
+  // If the touch interaction did not move, it should trigger a click
+  if (!wasDragging) {
+     simulateMouseEvent(e, 'click');
+  }
+
+  // Unset the flag to allow other widgets to inherit the touch event
+  DDTouch.touchHandled = false;
+};
+
+/**
+ * Note we don't get touchenter/touchleave (which are deprecated)
+ * see https://stackoverflow.com/questions/27908339/js-touch-equivalent-for-mouseenter
+ * so instead of PointerEvent to still get enter/leave and send the matching mouse event.
+ */
+export function pointerdown(e: PointerEvent) {
+  (e.target as HTMLElement).releasePointerCapture(e.pointerId) // <- Important!
+}
+
+export function pointerenter(e: PointerEvent) {
+  // ignore the initial one we get on pointerdown on ourself
+  if (!DDManager.dragElement) {
+    // console.log('pointerenter ignored');
+    return;
+  }
+  // console.log('pointerenter');
+  simulatePointerMouseEvent(e, 'mouseenter');
+}
+
+export function pointerleave(e: PointerEvent) {
+  // ignore the leave on ourself we get before releasing the mouse over ourself
+  // by delaying sending the event and having the up event cancel us
+  if (!DDManager.dragElement) {
+    // console.log('pointerleave ignored');
+    return;
+  }
+  DDTouch.pointerLeaveTimeout = window.setTimeout(() => {
+    delete DDTouch.pointerLeaveTimeout;
+    // console.log('pointerleave delayed');
+    simulatePointerMouseEvent(e, 'mouseleave');
+  }, 10);
+}
+


### PR DESCRIPTION
### Description
Part II for #1757
* added support for mobile touch events, and tested two.html to work great on Android 10 Chrome - dragging between grids and insert/remove

TODO: do sizing (though handle. idealy we could support 2 finger at a later time ! :)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
