### PR TITLE
mobile support tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,21 +295,19 @@ GridStack.init({
 
 ## Touch devices support
 
-gridstack v3.2 jq version compiles touch support (html5 version does not yet support `touchmove` events. This will be added in a future release), so it works out of the box, no need for anything.
-You **used** to need [jQuery UI Touch Punch](https://github.com/RWAP/jquery-ui-touch-punch) to make jQuery UI Draggable/Resizable
-work on touch-based devices (now distributed as `dist/jq/jquery.ui.touch-punch.js` for reference).
+gridstack v6+ now support mobile out of the box, with the addition of native touch event (along with mouse event) for drag&drop and resize.
+Older versions (3.2+) required the jq version with added touch punch, but doesn't work well with nested grids.
 
-
-This option will be useful:
+This option is now the default:
 
 ```js
 let options = {
-  alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  alwaysShowResizeHandle: 'mobile' // which defaults to /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 };
 GridStack.init(options);
 ```
 
-See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html). If you're still experiencing issues on touch devices please check [#444](https://github.com/gridstack/gridstack.js/issues/444)
+See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html).
 
 # gridstack.js for specific frameworks
 

--- a/demo/mobile.html
+++ b/demo/mobile.html
@@ -19,7 +19,6 @@
     let grid = GridStack.init({
       column: 3,
       disableOneColumnMode: true,
-      alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
     });
     grid.load([{x:0, y:0, content: '1'}, {x:1, y:0, h:2, content: '2'}, {x:2, y:0, content: '3'}])
   </script>

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -67,7 +67,6 @@
       minRow: 2, // don't collapse when empty
       disableOneColumnMode: true,
       acceptWidgets: true,
-      alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
       id: 'main',
       children: [
         {x:0, y:0, content: 'regular item'},

--- a/demo/website.html
+++ b/demo/website.html
@@ -364,13 +364,11 @@
     ];
 
     var simpleGrid = GridStack.init({
-      alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
       margin: 5,
     }, '#simple-grid');
     simpleGrid.load(simple);
 
     var advGrid = GridStack.init({
-      alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
       margin: 5,
       acceptWidgets: true,
       dragIn: '.newWidget',  // class that can be dragged from outside

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -72,6 +72,7 @@ Change log
 ## 6.0.0-beta (TBD)
 * converted previous HTML5 `draggable=true` based code to simple Mouse Events and Touch mobile support for drag&Drop.
 * removed all jquery-ui related code, and D7D plugging as we only support native events now
+* `alwaysShowResizeHandle` now support `'mobile'` which is the default, making it much easier (see doc)
 * changed `commit()` to be `batchUpdate(false)` to make it easier to turn batch on/off. updated doc. old API remains for now
 
 ## 5.1.1 (2022-06-16)

--- a/doc/README.md
+++ b/doc/README.md
@@ -70,11 +70,15 @@ gridstack.js API
    * `true` (uses `'.grid-stack-item'` class filter) or `false`
    * string for explicit class name
    * `function (i: number, element: Element): boolean` See [example](http://gridstack.github.io/gridstack.js/demo/two.html)
-- `alwaysShowResizeHandle` - possible values (default: `false` only show on hover)
-   * `true` the resizing handles are always shown even if the user is not hovering over the widget
-   * advance condition such as this mobile browser agent check:
-   `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
-   See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html)
+- `alwaysShowResizeHandle` - possible values (default: `mobile`) - does not apply to non-resizable widgets
+  * `false` the resizing handles are only shown while hovering over a widget
+  * `true` the resizing handles are always shown
+  * `'mobile'` if running on a mobile device, default to `true` (since there is no hovering per say), else `false`.
+  this uses this condition on browser agent check:
+  `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
+  See [mobile](http://gridstack.github.io/gridstack.js/demo/mobile.html)
+
+
 - `animate` - turns animation on to smooth transitions (default: `true`)
 - `auto` - if `false` gridstack will not initialize existing items (default: `true`)
 - `cellHeight`- one cell height (default?: 'auto'). Can be:
@@ -118,7 +122,7 @@ gridstack.js API
 - `oneColumnModeDomSort` - set to `true` if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: `false`)
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)
 - `placeholderText` - placeholder default content (default: `''`)
-- `resizable` - allows to override resizable options. (default: `{autoHide: true, handles: 'se'}`). `handles` can be any combo of `n,ne,e,se,s,sw,w,nw` or `all`.
+- `resizable` - allows to override resizable options. (default: `{handles: 'se'}`). `handles` can be any combo of `n,ne,e,se,s,sw,w,nw` or `all`.
 - `removable` - if `true` widgets could be removed by dragging outside of the grid. It could also be a selector string, in this case widgets will be removed by dropping them there (default: `false`) See [example](http://gridstackjs.com/demo/two.html)
 - `removeTimeout` - time in milliseconds before widget is being removed while dragging outside of the grid. (default: `2000`)
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)

--- a/src/dd-gridstack.ts
+++ b/src/dd-gridstack.ts
@@ -48,9 +48,10 @@ export class DDGridStack {
       } else {
         const grid = dEl.el.gridstackNode.grid;
         let handles = dEl.el.getAttribute('gs-resize-handles') ? dEl.el.getAttribute('gs-resize-handles') : grid.opts.resizable.handles;
+        let autoHide = !grid.opts.alwaysShowResizeHandle;
         dEl.setupResizable({
           ...grid.opts.resizable,
-          ...{ handles: handles },
+          ...{ handles, autoHide },
           ...{
             start: opts.start,
             stop: opts.stop,

--- a/src/dd-touch.ts
+++ b/src/dd-touch.ts
@@ -7,6 +7,8 @@ import { DDManager } from './dd-manager';
 
 /**
  * Detect touch support - Windows Surface devices and other touch devices
+ * should we use this instead ? (what we had for always showing resize handles)
+ * /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
  */
 export const isTouch: boolean = ( 'ontouchstart' in document
   || 'ontouchstart' in window
@@ -15,7 +17,6 @@ export const isTouch: boolean = ( 'ontouchstart' in document
   || navigator.maxTouchPoints > 0
   || (navigator as any).msMaxTouchPoints > 0
 );
-
 
 // interface TouchCoord {x: number, y: number};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,14 @@ export interface GridStackOptions {
    */
   acceptWidgets?: boolean | string | ((element: Element) => boolean);
 
-  /** possible values (default: `false` only show on hover)
-    * `true` the resizing handles are always shown even if the user is not hovering over the widget
-    * advance condition such as this mobile browser agent check:
+  /** possible values (default: `mobile`) - does not apply to non-resizable widgets
+    * `false` the resizing handles are only shown while hovering over a widget
+    * `true` the resizing handles are always shown
+    * 'mobile' if running on a mobile device, default to `true` (since there is no hovering per say), else `false`.
+    * this uses this condition on browser agent check:
     `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
     See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html) */
-  alwaysShowResizeHandle?: boolean;
+  alwaysShowResizeHandle?: true | false | 'mobile';
 
   /** turns animation on (default?: true) */
   animate?: boolean;
@@ -165,7 +167,7 @@ export interface GridStackOptions {
   /** placeholder default content (default?: '') */
   placeholderText?: string;
 
-  /** allows to override UI resizable options. (default?: { autoHide: true, handles: 'se' }) */
+  /** allows to override UI resizable options. (default?: { handles: 'se' }) */
   resizable?: DDResizeOpt;
 
   /**
@@ -267,7 +269,7 @@ export interface GridStackWidget extends GridStackPosition {
 
 /** Drag&Drop resize options */
 export interface DDResizeOpt {
-  /** do resize handle hide by default until mouse over ? - default: true */
+  /** do resize handle hide by default until mouse over ? - default: true on desktop, false on mobile*/
   autoHide?: boolean;
   /**
    * sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east)


### PR DESCRIPTION
### Description
* `alwaysShowResizeHandle` now support `'mobile'` which is the default, making it much easier (see doc)

everything seems to be working now, just need to release next #1757
* tested on:
Win10: Chrome 104, Firefox 103, Edge 104
Android 10: Chrome

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
