### PR TITLE
update Grid's options when setting float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 dist
 node_modules
 .vscode
+.idea/

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -790,8 +790,10 @@ export class GridStack {
    * enable/disable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
    */
   public float(val: boolean): GridStack {
-    this.engine.float = val;
-    this._triggerChangeEvent();
+    if (this.opts.float !== val) {
+      this.opts.float = this.engine.float = val;
+      this._triggerChangeEvent();
+    }
     return this;
   }
 


### PR DESCRIPTION
Sync the Grid's options with the float value.

I also set to check if the value actually changed before calling `triggerChangeEvent`, but maybe this is not desired?