### PR TITLE
v6 mouse events and React

### DIFF
--- a/demo/float.html
+++ b/demo/float.html
@@ -24,6 +24,7 @@
   <script type="text/javascript">
     let grid = GridStack.init({
       float: true, 
+      // disableResize: true, // TEST no resizing, but dragging
       resizable: { handles: 'all'} // do all sides for testing
     });
     addEvents(grid);

--- a/src/dd-gridstack.ts
+++ b/src/dd-gridstack.ts
@@ -444,9 +444,11 @@ GridStack.setupDragIn = function(this: GridStack, _dragIn?: string, _dragInOptio
 /** @internal prepares the element for drag&drop **/
 GridStack.prototype._prepareDragDropByNode = function(this: GridStack, node: GridStackNode): GridStack {
   let el = node.el;
+  const noMove = node.noMove || this.opts.disableDrag;
+  const noResize = node.noResize || this.opts.disableResize;
 
   // check for disabled grid first
-  if (this.opts.staticGrid || ((node.noMove || this.opts.disableDrag) && (node.noResize || this.opts.disableResize))) {
+  if (this.opts.staticGrid || (noMove && noResize)) {
     if (node._initDD) {
       this._removeDD(el); // nukes everything instead of just disable, will add some styles back next
       delete node._initDD;
@@ -537,20 +539,8 @@ GridStack.prototype._prepareDragDropByNode = function(this: GridStack, node: Gri
   }
 
   // finally fine tune move vs resize by disabling any part...
-  if (node.noMove || this.opts.disableDrag) {
-    dd.draggable(el, 'disable');
-    el.classList.add('ui-draggable-disabled');
-  } else {
-    dd.draggable(el, 'enable');
-    el.classList.remove('ui-draggable-disabled');
-  }
-  if (node.noResize || this.opts.disableResize) {
-    dd.resizable(el, 'disable');
-    el.classList.add('ui-resizable-disabled');
-  } else {
-    dd.resizable(el, 'enable');
-    el.classList.remove('ui-resizable-disabled');
-  }
+  dd.draggable(el, noMove ? 'disable' : 'enable')
+    .resizable(el, noResize ? 'disable' : 'enable');
 
   return this;
 }

--- a/src/dd-manager.ts
+++ b/src/dd-manager.ts
@@ -5,6 +5,7 @@
 
 import { DDDraggable } from './dd-draggable';
 import { DDDroppable } from './dd-droppable';
+import { DDResizable } from './dd-resizable';
 
 /**
  * globals that are shared across Drag & Drop instances
@@ -18,4 +19,8 @@ export class DDManager {
 
   /** item we are currently over as drop target */
   public static dropElement: DDDroppable;
+
+  /** current item we're over for resizing purpose (ignore nested grid resize handles) */
+  public static overResizeElement: DDResizable;
+
 }


### PR DESCRIPTION
### Description
* fix for #2018
* resizable _mouseOver() no longer calls event.stopPropagation() (which seems like the right thing to do) but relies instead on DDManager to track our active item

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
