### PR TITLE
1 column mode loading, saving 12 column layout

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [7.0.2 (TBD)](#702-tbd)
+- [7.0.1-dev (TBD)](#701-dev-tbd)
 - [7.0.1 (2022-10-14)](#701-2022-10-14)
 - [7.0.0 (2022-10-09)](#700-2022-10-09)
 - [6.0.3 (2022-10-08)](#603-2022-10-08)
@@ -75,9 +75,12 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## 7.0.2 (TBD)
+## 7.0.1-dev (TBD)
+* add `GridStackEngine.findEmptyPosition()`
 * fixed [#2081](https://github.com/gridstack/gridstack.js/issues/2081) removeWidget() after it's gone from DOM
-* add GridStackEngine.findEmptyPosition()
+* fixed [#1985](https://github.com/gridstack/gridstack.js/issues/1985) addWidget() or DOM read in single column mode will not adjust to multi column mode
+* fixed [#1975](https://github.com/gridstack/gridstack.js/issues/1975) oneColumnModeDomSort not respected when loading in 1 column
+
 ## 7.0.1 (2022-10-14)
 * fixed [#2073](https://github.com/gridstack/gridstack.js/issues/2073) SSR (server side rendering) isTouch issue (introduced in v6)
 * fixed - removing last item delete sub-grid that are not auto-generated (nested.html vs nested_advanced.html)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gridstack",
   "version": "7.0.1-dev",
-  "description": "TypeScript/JS lib for dashboard layout and creation, mobile support, no external dependencies, with many wrappers (React, Angular, Vue, Ember, knockout...)",
+  "description": "TypeScript/JS lib for dashboard layout and creation, responsive, mobile support, no external dependencies, with many wrappers (React, Angular, Vue, Ember, knockout...)",
   "main": "./dist/gridstack.js",
   "types": "./dist/gridstack.d.ts",
   "repository": {

--- a/spec/e2e/html/1985_read_1_column_wrong_12.html
+++ b/spec/e2e/html/1985_read_1_column_wrong_12.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>read 1 column</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-all.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>read from dom into 1 column has wrong order and 12 column layout</h1>
+    <div class="grid-stack">
+      <div class="grid-stack-item" gs-x="4" gs-y="0"><div class="grid-stack-item-content">1</div></div>
+      <div class="grid-stack-item" gs-x="0" gs-y="0"><div class="grid-stack-item-content">0</div></div>
+      <div class="grid-stack-item" gs-x="1" gs-y="1"><div class="grid-stack-item-content">2</div></div>
+    </div>
+  </div>
+  <script type="text/javascript">
+    let grid = GridStack.init({
+      cellHeight: 70,
+      float: true, 
+    });
+
+    var items = [
+      {x: 0, y: 0, content: '0'},
+      {x: 2, y: 0, content: '1'},
+    ];
+    // grid.addWidget(items[1]); // need to be reverse sort-order to be correct (otherwise DOM above is wrong)
+    // grid.addWidget(items[0]);
+    // grid.load(items); // or this work (code reverse sort)
+
+  </script>
+</body>
+</html>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,7 +236,7 @@ export class Utils {
     return true;
   }
 
-  /** copies over b size & position (GridStackPosition), and possibly min/max as well */
+  /** copies over b size & position (GridStackPosition), and optionally min/max as well */
   static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
     a.x = b.x;
     a.y = b.y;


### PR DESCRIPTION
### Description
fix #1985
fix #1975 (oneColumnModeDomSort case)

* we now handle DOM and addWidget() when temporally into 1 column mode better to save the full 12 column mode
* also DOM reading will reverse-sort entries to lay them in 1 column mode correctly (like if you had started with 12 and scaled down)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
