### PR TITLE
mobile doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ This option is now the default:
 
 ```js
 let options = {
-  alwaysShowResizeHandle: 'mobile' // which defaults to /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  alwaysShowResizeHandle: 'mobile' // true if we're on mobile devices
 };
 GridStack.init(options);
 ```

--- a/demo/angular-ngFor.ts
+++ b/demo/angular-ngFor.ts
@@ -59,10 +59,6 @@ export class AngularNgForTestComponent implements AfterViewInit {
   // wait until after DOM is ready to init gridstack - can't be ngOnInit() as angular ngFor needs to run first!
   public ngAfterViewInit() {
     this.grid = GridStack.init({
-      alwaysShowResizeHandle:
-        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-          navigator.userAgent
-        ),
       margin: 5,
       float: true,
     });

--- a/doc/README.md
+++ b/doc/README.md
@@ -74,8 +74,6 @@ gridstack.js API
   * `false` the resizing handles are only shown while hovering over a widget
   * `true` the resizing handles are always shown
   * `'mobile'` if running on a mobile device, default to `true` (since there is no hovering per say), else `false`.
-  this uses this condition on browser agent check:
-  `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
   See [mobile](http://gridstack.github.io/gridstack.js/demo/mobile.html)
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,8 +84,6 @@ export interface GridStackOptions {
     * `false` the resizing handles are only shown while hovering over a widget
     * `true` the resizing handles are always shown
     * 'mobile' if running on a mobile device, default to `true` (since there is no hovering per say), else `false`.
-    * this uses this condition on browser agent check:
-    `alwaysShowResizeHandle: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test( navigator.userAgent )`
     See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html) */
   alwaysShowResizeHandle?: true | false | 'mobile';
 


### PR DESCRIPTION
removed this comment since code uses different heuristics now

alwaysShowResizeHandle: 'mobile' // which defaults to /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)