### PR TITLE
disable/enable recursive by default

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -79,6 +79,7 @@ Change log
 
 ## 7.1.1-dev (TBD)
 * fix [#939](https://github.com/gridstack/gridstack.js/issues/2039) 'prototype' undefined error for dd-gridstack.js
+* add [#939](https://github.com/gridstack/gridstack.js/issues/2105) disable/enable are methods now recursive by default
 
 ## 7.1.1 (2022-11-13)
 * fix [#939](https://github.com/gridstack/gridstack.js/issues/939) editable elements focus (regression in v6). Thank you [@Gezdy](https://github.com/Gezdy)


### PR DESCRIPTION
### Description
* fix #2105
* disable/enable/setStatic/enableMove/enableResize now all take an optional recurse flag to update sub-grids

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
