### PR TITLE
addWidget() & load() fix for existing element

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -80,7 +80,8 @@ Change log
 ## 7.1.1-dev (TBD)
 * fix [#939](https://github.com/gridstack/gridstack.js/issues/2039) 'prototype' undefined error for dd-gridstack.js
 * add [#939](https://github.com/gridstack/gridstack.js/issues/2105) disable/enable are methods now recursive by default
-* add better GridStackEventHandlerCallback spelled out types
+* add better `GridStackEventHandlerCallback` spelled out types
+* add We now have support for [Angular Component wrappers](https://github.com/gridstack/gridstack.js/tree/master/demo/angular/src/app) out of the box included in the build, with docs and demo! Need help to do that for React and Vue.
 
 ## 7.1.1 (2022-11-13)
 * fix [#939](https://github.com/gridstack/gridstack.js/issues/939) editable elements focus (regression in v6). Thank you [@Gezdy](https://github.com/Gezdy)

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type GridStackElement = string | HTMLElement | GridItemHTMLElement;
 /** specific and general event handlers for the .on() method */
 export type GridStackEventHandler = (event: Event) => void;
 export type GridStackElementHandler = (event: Event, el: GridItemHTMLElement) => void;
-export type GridStackNodesHandler = (event: Event, node: GridStackNode[]) => void;
+export type GridStackNodesHandler = (event: Event, nodes: GridStackNode[]) => void;
 export type GridStackDroppedHandler = (event: Event, previousNode: GridStackNode, newNode: GridStackNode) => void;
 export type GridStackEventHandlerCallback = GridStackEventHandler | GridStackElementHandler | GridStackNodesHandler | GridStackDroppedHandler;
 


### PR DESCRIPTION
### Description
* we now support calling addWidget() when there is an existing HTML element not yet initialized, but with creation options
* load() also now supports the same
* make sure grid and items have the correct GS styles (don't assume callee does when they init()/addWidget()

these are required by new Angular wrapper to optimizes updates. #2130

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
