### PR TITLE
removed incorrect doc/code on individual item resizeHandles

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -80,6 +80,7 @@ Change log
 
 ## 7.1.2-dev (TBD)
 * fix [#1936](https://github.com/gridstack/gridstack.js/issues/1936) some styles left behind after a drag
+* fix [#1842](https://github.com/gridstack/gridstack.js/issues/1842) incorrect doc/partial code on widget resizeHandles
 
 ## 7.1.2 (2022-12-29)
 * fix [#939](https://github.com/gridstack/gridstack.js/issues/2039) 'prototype' undefined error for dd-gridstack.js

--- a/doc/README.md
+++ b/doc/README.md
@@ -148,7 +148,6 @@ The widget can still be dragged or resized by the user.
 You need to add `noResize` and `noMove` attributes to completely lock the widget.
 - `noResize` - disable element resizing
 - `noMove` - disable element moving
-- `resizeHandles` - widgets can have their own custom resize handles. For example 'e,w' will make that particular widget only resize east and west. See `resizable: {handles: string}` option
 - `id`- (number | string) good for quick identification (for example in change event)
 - `content` - (string) html content to be added when calling `grid.load()/addWidget()` as content inside the item
 - `subGrid`?: GridStackOptions - optional nested grid options and list of children

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1423,7 +1423,6 @@ export class GridStack {
       noMove: 'gs-no-move',
       locked: 'gs-locked',
       id: 'gs-id',
-      resizeHandles: 'gs-resize-handles'
     };
     for (const key in attrs) {
       if (node[key]) { // 0 is valid for x,y only but done above already and not in list anyway
@@ -1450,7 +1449,6 @@ export class GridStack {
     node.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
     node.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
     node.locked = Utils.toBool(el.getAttribute('gs-locked'));
-    node.resizeHandles = el.getAttribute('gs-resize-handles');
     node.id = el.getAttribute('gs-id');
 
     // remove any key not found (null or false which is default)

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,8 +303,6 @@ export interface GridStackWidget extends GridStackPosition {
   noMove?: boolean;
   /** prevents being moved by others during their (default?: undefined = un-constrained) */
   locked?: boolean;
-  /** widgets can have their own custom resize handles. For example 'e,w' will make that particular widget only resize east and west. See `resizable: {handles: string}` option */
-  resizeHandles?: string;
   /** value for `gs-id` stored on the widget (default?: undefined) */
   id?: numberOrString;
   /** html to append inside as content */


### PR DESCRIPTION
### Description
* fix #1842
* remove this never implemented feature out (per item resize handle support)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
