### PR TITLE
nested grid save() incorrectly re-list children

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -10,5 +10,5 @@ If unsure if lib bug, use slack channel instead: https://join.slack.com/t/gridst
 You **MUST** provide a working demo - keep it simple and avoid frameworks as that could have issues - you can use 
 https://jsfiddle.net/adumesny/jqhkry7g
 
-## Actual behavior
-Tell us what happens instead of what's expected. If hard to describe, attach a video as well.
+## Expected behavior
+Tell us what should happen. If hard to describe, attach a video as well.

--- a/demo/nested_advanced.html
+++ b/demo/nested_advanced.html
@@ -20,19 +20,20 @@
     <a class="btn btn-primary" onClick="addNewWidget(0)" href="#">Add W Grid0</a>
     <a class="btn btn-primary" onClick="addNewWidget(1)" href="#">Add W Grid1</a>
     <a class="btn btn-primary" onClick="addNewWidget(2)" href="#">Add W Grid2</a>
-    <span>entire save/re-create:</span>
-    <a class="btn btn-primary" onClick="save()" href="#">Save</a>
+    <span>entire option+layout:</span>
+    <a class="btn btn-primary" onClick="save()" href="#">Save Full</a>
     <a class="btn btn-primary" onClick="destroy()" href="#">Destroy</a>
-    <a class="btn btn-primary" onClick="load()" href="#">Load</a>
-    <span>partial save/load:</span>
-    <a class="btn btn-primary" onClick="save(true, false)" href="#">Save list</a>
-    <a class="btn btn-primary" onClick="save(false, false)" href="#">Save no content</a>
+    <a class="btn btn-primary" onClick="load()" href="#">Re-create</a>
+    <span>layout list:</span>
+    <a class="btn btn-primary" onClick="save(true, false)" href="#">Save layout</a>
+    <a class="btn btn-primary" onClick="save(false, false)" href="#">Save layout no content</a>
     <a class="btn btn-primary" onClick="destroy(false)" href="#">Clear</a>
     <a class="btn btn-primary" onClick="load(false)" href="#">Load</a>
     <br><br>
     <!-- grid will be added here -->
   </div>
-
+  <p>Output</p>
+  <textarea id="saved" style="width:100%; height:200px;"></textarea>
   <script type="text/javascript">
     let subOptions = {
       cellHeight: 50, // should be 50 - top/bottom
@@ -54,15 +55,17 @@
       subGridDynamic: true, // v7 api to create sub-grids on the fly
       children: [
         ...main,
-        {x:2, y:0, w:2, h:3, subGrid: {children: sub0, ...subOptions}},
-        {x:4, y:0, h:2, subGrid: {children: sub1, ...subOptions}},
+        {x:2, y:0, w:2, h:3, id: 'sub0', subGrid: {children: sub0, ...subOptions}},
+        {x:4, y:0, h:2, id: 'sub1', subGrid: {children: sub1, ...subOptions}},
         // {x:2, y:0, w:2, h:3, subGrid: {children: [...sub1, {x:0, y:1, subGrid: subOptions}], ...subOptions}/*,content: "<div>nested grid here</div>"*/},
       ]
     };
     let count = 0;
-    [...main, ...sub0, ...sub1].forEach(d => {if (!d.subGrid) d.content = String(count++)});
+    // create unique ids+content so we can incrementally load() and not re-create anything (updates)
+    [...main, ...sub0, ...sub1].forEach(d => d.id = d.content = String(count++));
 
     // create and load it all from JSON above
+    document.querySelector('#saved').value = JSON.stringify(options);
     let grid = GridStack.addGrid(document.querySelector('.container-fluid'), options);
 
     function addMainWidget() {
@@ -84,11 +87,12 @@
     };
 
     function save(content = true, full = true) {
-      options = grid.save(content, full);
+      options = grid?.save(content, full);
       console.log(options);
-      // console.log(JSON.stringify(options));
+      document.querySelector('#saved').value = JSON.stringify(options);
     }
     function destroy(full = true) {
+      if (!grid) return;
       if (full) {
         grid.destroy();
         grid = undefined;
@@ -97,13 +101,15 @@
       }
     }
     function load(full = true) {
-      if (full) {
+      // destroy(full); // in case user didn't call
+      if (full || !grid) {
         grid = GridStack.addGrid(document.querySelector('.container-fluid'), options);
       } else {
         grid.load(options);
       }
     }
 
+    // save(true, false); load(false); // TESTing
   </script>
 </body>
 </html>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [7.2.1-dev (TBD)](#721-dev-tbd)
 - [7.2.1 (2023-01-14)](#721-2023-01-14)
 - [7.2.0 (2023-01-07)](#720-2023-01-07)
 - [7.1.2 (2022-12-29)](#712-2022-12-29)
@@ -78,6 +79,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 7.2.1-dev (TBD)
+* fix [#2171](https://github.com/gridstack/gridstack.js/issues/2171) `save()` nested grid has extra nested children & options
+
 ## 7.2.1 (2023-01-14)
 * fix [#2162](https://github.com/gridstack/gridstack.js/pull/2162) removing item from a grid (into another) will now call `change` if anything was also modified during the remove
 * fix [#2110](https://github.com/gridstack/gridstack.js/issues/2110) custom `GridStackOptions.itemClass` now works when dragging from outside


### PR DESCRIPTION
### Description
* fix #2171
* we no longer store ops.subGrid for each nested grid. instead we parse the top grid that has this info and re-use it during create
* save() now handles saving only layout of subGrid more efficiently (don't list options)
* updated demo to showcase the issues

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
