### PR TITLE
Feat: add original event to drag and mouse events

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export type GridStackNodesHandler = (event: Event, nodes: GridStackNode[]) => vo
 export type GridStackDroppedHandler = (event: Event, previousNode: GridStackNode, newNode: GridStackNode) => void;
 export type GridStackEventHandlerCallback = GridStackEventHandler | GridStackElementHandler | GridStackNodesHandler | GridStackDroppedHandler;
 
+interface GridStakDMEvent<T> {
+    originalEvent: T
+}
+export type GridStackDragMouseEvent<T extends DragEvent | MouseEvent> = T extends DragEvent ? T & GridStakDMEvent<T> : T & GridStakDMEvent<T>;
+
 /** optional function called during load() to callback the user on new added/remove items */
 export type AddRemoveFcn = (g: GridStack, w: GridStackWidget, add: boolean) => HTMLElement | undefined;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -476,24 +476,31 @@ export class Utils {
     }
   }
 
-  public static initEvent<T>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }): T {
-    const evt = { type: info.type };
-    const obj = {
-      button: 0,
-      which: 0,
-      buttons: 1,
-      bubbles: true,
-      cancelable: true,
-      target: info.target ? info.target : e.target
-    };
-    // don't check for `instanceof DragEvent` as Safari use MouseEvent #1540
-    if ((e as DragEvent).dataTransfer) {
-      evt['dataTransfer'] = (e as DragEvent).dataTransfer; // workaround 'readonly' field.
+    public static initEvent<T extends DragEvent | MouseEvent>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }): T {
+        return {
+            type: info.type,
+            button: 0,
+            buttons: 1,
+            bubbles: true,
+            cancelable: true,
+            target: info?.target || e.target,
+            ...((e as DragEvent).dataTransfer && {
+                dataTransfer: (e as DragEvent).dataTransfer
+            } as any),
+            // keys
+            altKey: e.altKey,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+            shiftKey: e.shiftKey,
+            // point info
+            pageX: e.pageX,
+            pageY: e.pageY,
+            clientX: e.clientX,
+            clientY: e.clientY,
+            screenX: e.screenX,
+            screenY: e.screenY,
+        } as T;
     }
-    ['altKey','ctrlKey','metaKey','shiftKey'].forEach(p => evt[p] = e[p]); // keys
-    ['pageX','pageY','clientX','clientY','screenX','screenY'].forEach(p => evt[p] = e[p]); // point info
-    return {...evt, ...obj} as unknown as T;
-  }
 
   /** copies the MouseEvent properties and sends it as another event to the given target */
   public static simulateMouseEvent(e: MouseEvent, simulatedType: string, target?: EventTarget): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,15 @@
  * Copyright (c) 2021 Alain Dumesny - see GridStack root license
  */
 
-import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
+import {
+    GridStackElement,
+    GridStackNode,
+    GridStackOptions,
+    numberOrString,
+    GridStackPosition,
+    GridStackWidget,
+    GridStackDragMouseEvent
+} from './types';
 
 export interface HeightData {
   h: number;
@@ -476,7 +484,7 @@ export class Utils {
     }
   }
 
-    public static initEvent<T extends DragEvent | MouseEvent>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }): T {
+    public static initEvent<T extends DragEvent | MouseEvent>(e: DragEvent | MouseEvent, info: { type: string; target?: EventTarget }): GridStackDragMouseEvent<T> {
         return {
             type: info.type,
             button: 0,
@@ -499,7 +507,8 @@ export class Utils {
             clientY: e.clientY,
             screenX: e.screenX,
             screenY: e.screenY,
-        } as T;
+            originalEvent: e,
+        };
     }
 
   /** copies the MouseEvent properties and sends it as another event to the given target */


### PR DESCRIPTION
use case:

when I drop a card on a html element external to gridstack,
I want the event dragstop to tell me the html element I dropped it to 

problem:

Gridstack overrides the original target element, see #2185

usage example:

```js
    grid.on(
      'dragstop',
      (event: GridStackDragMouseEvent<DragEvent>, el: GridItemHTMLElement) => {
        const { originalEvent } = event;
        console.log('dragstop', originalEvent.target);
    });
```