### PR TITLE
Resolved: Grid engine.nodes count is incorrect after removing item.

### DIFF
--- a/demo/vue3js_v-for.html
+++ b/demo/vue3js_v-for.html
@@ -37,7 +37,7 @@
 
     <div class="grid-stack">
       <div v-for="(w, indexs) in items" class="grid-stack-item" :gs-x="w.x" :gs-y="w.y" :gs-w="w.w" :gs-h="w.h"
-        :gs-id="w.id" :id="w.id">
+        :gs-id="w.id" :id="w.id" :key="w.id">
         <div class="grid-stack-item-content">
           <button @click="remove(w)">remove</button>
           {{w}}


### PR DESCRIPTION
### Description
Vue will reset items in order if no 'key' property is set. So, the element and id won't be matched between vue and GridStack.
So, the solution is to add key property.