### PR TITLE
docs: slack invite link on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you find this lib useful, please donate [PayPal](https://www.paypal.me/alaind
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/alaind831)
 [![Donate](https://img.shields.io/badge/Donate-Venmo-g.svg)](https://www.venmo.com/adumesny)
 
-Join us on Slack: https://gridstackjs.slack.com
+Join us on Slack: [https://gridstackjs.slack.com](https://join.slack.com/t/gridstackjs/shared_invite/zt-1jobnclsy-FqGGeLX5dFPM_ZQzTunBsw)
 
 <!-- [![Slack Status](https://gridstackjs.com/badge.svg)](https://gridstackjs.slack.com) -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
Let users join slack from the link provided in the Readme

the link of the invite is already in the template when we create an issue, but users that have failed a first time to connect to slack won't always think that the invite link works

Most dev communities are on discord now, most ppl are not used to slack anymore. At least I'm not 🤷‍♂️