### PR TITLE
removed `gs-w='1'` since min-width handles it

### DIFF
--- a/demo/events.js
+++ b/demo/events.js
@@ -42,9 +42,6 @@ function addEvents(grid, id) {
   })
   .on('resizestart', function(event, el) {
     let n = el.gridstackNode;
-    let w = parseInt(el.getAttribute('gs-w')); // verify node (easiest) and attr are the same
-    let h = parseInt(el.getAttribute('gs-h'));
-    if (w !== n.w || h !== n.h) alert('resizestart missmatch');
     let rec = el.getBoundingClientRect();
     console.log(`${g} resizestart ${el.textContent} size: (${n.w}x${n.h}) = (${Math.round(rec.width)}x${Math.round(rec.height)})px`);
 
@@ -56,9 +53,6 @@ function addEvents(grid, id) {
   })
   .on('resizestop', function(event, el) {
     let n = el.gridstackNode;
-    let w = parseInt(el.getAttribute('gs-w')); // verify node (easiest) and attr are the same
-    let h = parseInt(el.getAttribute('gs-h'));
-    if (w !== n.w || h !== n.h) alert('resizestop missmatch');
     let rec = el.getBoundingClientRect();
     console.log(`${g} resizestop ${el.textContent} size: (${n.w}x${n.h}) = (${Math.round(rec.width)}x${Math.round(rec.height)})px`);
   });

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -84,7 +84,8 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 7.3.0-dev (TBD)
-* feat [#2243](https://github.com/gridstack/gridstack.js/issues/2243) removed `gs-min|max_w|h` attribute generated in CSS or written out as they are never used for rendering, only for initial load. This reduce our column/row styles in half!
+* feat [#2243](https://github.com/gridstack/gridstack.js/issues/2243) removed `gs-min|max_w|h` attribute generated in CSS or written out as they are never used for rendering, only for initial load. This reduce our column/row CSS in half!
+* feat: also removed `gs-w='1'` and `gs-h='1'` dom attribute writing since we already have min-width/min-height set, no need to set more attributes.
 
 ## 7.3.0 (2023-04-01)
 * feat [#2229](https://github.com/gridstack/gridstack.js/pull/2229) support nonce for CSP. Thank you [@jedwards1211](https://github.com/jedwards1211)

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -30,14 +30,8 @@
     };
     let grid = GridStack.init(options);
 
-    addNewWidget = function() {
-      grid.addWidget({content: String(count++)});
-    };
-
     grid.batchUpdate();
-    for (; count <= COLUMNS;) {
-      this.addNewWidget(); 
-    }
+    for (; count <= COLUMNS;) grid.addWidget({content: String(count++)});
     grid.batchUpdate(false);
   </script>
 </body>

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -321,12 +321,12 @@ describe('gridstack', function() {
       expect(grid.getColumn()).toBe(1);
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       // add default 1x1 item to the end (1 column)
@@ -334,8 +334,8 @@ describe('gridstack', function() {
       expect(el3).not.toBe(null);
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(6);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       // back to 12 column and initial layout (other than new item3)
       grid.column(12);
@@ -353,42 +353,42 @@ describe('gridstack', function() {
       // remembers autoPlacement so finds next slot on 12 layout after 4x2 + 4x4
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(8);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       // back to 1 column
       grid.column(1);
       expect(grid.getColumn()).toBe(1);
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(6);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       // move item2 to beginning to [3][1][2] vertically
       grid.update(el3, {x:0, y:0});
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
 
       // back to 12 column, el3 to be beginning still, but [1][2] to be in 1 columns still but wide 4x2 and 4x still
@@ -396,8 +396,8 @@ describe('gridstack', function() {
       expect(grid.getColumn()).toBe(12);
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0); // 8 TEST WHY
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
@@ -416,17 +416,17 @@ describe('gridstack', function() {
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0); // 1 TEST WHY
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1); // 1 as we scaled from 12 columns
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null); // 1 as we scaled from 12 columns
+      expect(el3.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el1.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(1);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el2.getAttribute('gs-h'))).toBe(4);
     });
   });
@@ -455,35 +455,35 @@ describe('gridstack', function() {
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
+      expect(el2.getAttribute('gs-h')).toBe(null);
 
       // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
       grid.column(1);
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
+      expect(el2.getAttribute('gs-h')).toBe(null);
     });
     it('should support oneColumnModeDomSort ON going to 1 column', function() {
       let options = {
@@ -499,34 +499,34 @@ describe('gridstack', function() {
       // items are item1[1x1], item3[1x1], item2[2x1]
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
+      expect(el2.getAttribute('gs-h')).toBe(null);
 
       // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
       grid.column(1);
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-w')).toBe(null);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(1);
-      expect(parseInt(el2.getAttribute('gs-h'))).toBe(1);
+      expect(el2.getAttribute('gs-w')).toBe(null);
+      expect(el2.getAttribute('gs-h')).toBe(null);
 
       expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el3.getAttribute('gs-y'))).toBe(2);
-      expect(parseInt(el3.getAttribute('gs-w'))).toBe(1);
+      expect(el3.getAttribute('gs-w')).toBe(null);
       expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
     });
   });
@@ -863,7 +863,7 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
       expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
       // expect(widget.getAttribute('gs-auto-position')).toBe('true');
       expect(widget.getAttribute('gs-id')).toBe('optionWidget');
@@ -874,7 +874,7 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
       expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
       // expect(widget.getAttribute('gs-auto-position')).toBe('true');
       expect(widget.getAttribute('gs-id')).toBe('optionWidget');
@@ -885,7 +885,7 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
       expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
       // expect(widget.getAttribute('gs-auto-position')).toBe('true');
       expect(widget.getAttribute('gs-id')).toBe('optionWidget');
@@ -896,7 +896,7 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
       expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(2);
       // expect(widget.getAttribute('gs-auto-position')).toBe('true');
       expect(widget.getAttribute('gs-id')).toBe('optionWidget');
@@ -907,8 +907,8 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
+      expect(widget.getAttribute('gs-h')).toBe(null);
       // expect(widget.getAttribute('gs-auto-position')).toBe('true');
     });
 
@@ -927,8 +927,8 @@ describe('gridstack', function() {
       
       expect(parseInt(widget.getAttribute('gs-x'), 10)).toBe(8);
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(0);
-      expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(1);
-      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-w')).toBe(null);
+      expect(widget.getAttribute('gs-h')).toBe(null);
     });
     it('null options should clear x position', function() {
       let grid = GridStack.init({float: true});
@@ -946,7 +946,7 @@ describe('gridstack', function() {
       expect(parseInt(widget.getAttribute('gs-y'), 10)).toBe(5);
       expect(parseInt(widget.getAttribute('gs-w'), 10)).toBe(3);
       expect(widget.gridstackNode.maxW).toBe(4);
-      expect(parseInt(widget.getAttribute('gs-h'), 10)).toBe(1);
+      expect(widget.getAttribute('gs-h')).toBe(null);
       expect(widget.getAttribute('gs-id')).toBe('foo');
     });
   });
@@ -1800,7 +1800,7 @@ describe('gridstack', function() {
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-w'))).toBe(5);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       let el2 = document.getElementById('item2')
       expect(parseInt(el2.getAttribute('gs-x'))).toBe(6);
@@ -1822,7 +1822,7 @@ describe('gridstack', function() {
       expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
       expect(parseInt(el1.getAttribute('gs-w'))).toBe(5);
-      expect(parseInt(el1.getAttribute('gs-h'))).toBe(1);
+      expect(el1.getAttribute('gs-h')).toBe(null);
 
       expect(document.getElementById('item2')).toBe(null);
       let el2 = grid.engine.nodes.find(n => n.id === 'new2').el;

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -97,7 +97,7 @@ $animation_speed: .3s !default;
   &.grid-stack-1>.grid-stack-item {
     min-width: 100%;
     &[gs-w='1'] { width: 100%; }
-    &[gs-x='1'] { left: 100%; }
+    &[gs-x='0'] { left: 0; }
   }
 
   &.grid-stack-animate,

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1415,8 +1415,8 @@ export class GridStack {
   protected _writePosAttr(el: HTMLElement, n: GridStackPosition): GridStack {
     if (n.x !== undefined && n.x !== null) { el.setAttribute('gs-x', String(n.x)); }
     if (n.y !== undefined && n.y !== null) { el.setAttribute('gs-y', String(n.y)); }
-    if (n.w) { el.setAttribute('gs-w', String(n.w)); }
-    if (n.h) { el.setAttribute('gs-h', String(n.h)); }
+    n.w > 1 ? el.setAttribute('gs-w', String(n.w)) : el.removeAttribute('gs-w');
+    n.h > 1 ? el.setAttribute('gs-h', String(n.h)) : el.removeAttribute('gs-h');
     return this;
   }
 
@@ -1444,36 +1444,38 @@ export class GridStack {
 
   /** @internal call to read any default attributes from element */
   protected _readAttr(el: HTMLElement): GridStackWidget {
-    let node: GridStackNode = {};
-    node.x = Utils.toNumber(el.getAttribute('gs-x'));
-    node.y = Utils.toNumber(el.getAttribute('gs-y'));
-    node.w = Utils.toNumber(el.getAttribute('gs-w'));
-    node.h = Utils.toNumber(el.getAttribute('gs-h'));
-    node.autoPosition = Utils.toBool(el.getAttribute('gs-auto-position'));
-    node.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
-    node.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
-    node.locked = Utils.toBool(el.getAttribute('gs-locked'));
-    node.id = el.getAttribute('gs-id');
+    let n: GridStackNode = {};
+    n.x = Utils.toNumber(el.getAttribute('gs-x'));
+    n.y = Utils.toNumber(el.getAttribute('gs-y'));
+    n.w = Utils.toNumber(el.getAttribute('gs-w'));
+    n.h = Utils.toNumber(el.getAttribute('gs-h'));
+    if (!(n.w > 1)) el.removeAttribute('gs-w');
+    if (!(n.h > 1)) el.removeAttribute('gs-h');
+    n.autoPosition = Utils.toBool(el.getAttribute('gs-auto-position'));
+    n.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
+    n.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
+    n.locked = Utils.toBool(el.getAttribute('gs-locked'));
+    n.id = el.getAttribute('gs-id');
 
     // read but never written out
-    node.maxW = Utils.toNumber(el.getAttribute('gs-max-w'));
-    if (node.maxW) el.removeAttribute('gs-max-w');
-    node.minW = Utils.toNumber(el.getAttribute('gs-min-w'));
-    if (node.minW) el.removeAttribute('gs-min-w');
-    node.maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
-    if (node.maxH) el.removeAttribute('gs-max-h');
-    node.minH = Utils.toNumber(el.getAttribute('gs-min-h'));
-    if (node.minH) el.removeAttribute('gs-min-h');
+    n.maxW = Utils.toNumber(el.getAttribute('gs-max-w'));
+    if (n.maxW) el.removeAttribute('gs-max-w');
+    n.minW = Utils.toNumber(el.getAttribute('gs-min-w'));
+    if (n.minW) el.removeAttribute('gs-min-w');
+    n.maxH = Utils.toNumber(el.getAttribute('gs-max-h'));
+    if (n.maxH) el.removeAttribute('gs-max-h');
+    n.minH = Utils.toNumber(el.getAttribute('gs-min-h'));
+    if (n.minH) el.removeAttribute('gs-min-h');
 
     // remove any key not found (null or false which is default)
-    for (const key in node) {
-      if (!node.hasOwnProperty(key)) return;
-      if (!node[key] && node[key] !== 0) { // 0 can be valid value (x,y only really)
-        delete node[key];
+    for (const key in n) {
+      if (!n.hasOwnProperty(key)) return;
+      if (!n[key] && n[key] !== 0) { // 0 can be valid value (x,y only really)
+        delete n[key];
       }
     }
 
-    return node;
+    return n;
   }
 
   /** @internal */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -240,10 +240,10 @@ export class Utils {
 
   /** copies over b size & position (GridStackPosition), and optionally min/max as well */
   static copyPos(a: GridStackWidget, b: GridStackWidget, doMinMax = false): GridStackWidget {
-    a.x = b.x;
-    a.y = b.y;
-    a.w = b.w;
-    a.h = b.h;
+    if (b.x !== undefined) a.x = b.x;
+    if (b.y !== undefined) a.y = b.y;
+    if (b.w !== undefined) a.w = b.w;
+    if (b.h !== undefined) a.h = b.h;
     if (doMinMax) {
       if (b.minW) a.minW = b.minW;
       if (b.minH) a.minH = b.minH;


### PR DESCRIPTION
### Description
* more fix #2243
* also removed `gs-w='1'` and `gs-h='1'` dom attribute writing since we already have min-width/min-height set, no need to set more attributes than needed. this will make girds with 1x1 items more compact/faster.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
