### PR TITLE
remove 'ui-draggable' 'ui-resizable'

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -84,8 +84,9 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 7.3.0-dev (TBD)
-* feat [#2243](https://github.com/gridstack/gridstack.js/issues/2243) removed `gs-min|max_w|h` attribute generated in CSS or written out as they are never used for rendering, only for initial load. This reduce our column/row CSS in half!
-* feat: also removed `gs-w='1'` and `gs-h='1'` dom attribute writing since we already have min-width/min-height set, no need to set more attributes.
+* optimize [#2243](https://github.com/gridstack/gridstack.js/issues/2243) removed `gs-min|max_w|h` attribute generated in CSS or written out as they are never used for rendering, only for initial load. This reduce our column/row CSS in half!
+* optimize: removed `gs-w='1'` and `gs-h='1'` dom attribute writing since we already have min-width/min-height set, no need to set more attributes.
+* optimize: remove `'ui-draggable'` and `'ui-resizable'` since wasn't used in CSS and we have the `-disabled` version when off (so we can use `not(xyz-disabled)`).
 
 ## 7.3.0 (2023-04-01)
 * feat [#2229](https://github.com/gridstack/gridstack.js/pull/2229) support nonce for CSP. Thank you [@jedwards1211](https://github.com/jedwards1211)

--- a/spec/e2e/html/810-many-columns.html
+++ b/spec/e2e/html/810-many-columns.html
@@ -26,7 +26,8 @@
     let options = {
       column: COLUMNS,
       cellHeight: 'auto',
-      margin: 1
+      margin: 1,
+      // staticGrid: true,
     };
     let grid = GridStack.init(options);
 

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -92,7 +92,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       // this.dragEl.style.touchAction = 'none'; // not needed unlike pointerdown doc comment
     }
     this.el.classList.remove('ui-draggable-disabled');
-    this.el.classList.add('ui-draggable');
   }
 
   public disable(forDestroy = false): void {
@@ -103,7 +102,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       this.dragEl.removeEventListener('touchstart', touchstart);
       this.dragEl.removeEventListener('pointerdown', pointerdown);
     }
-    this.el.classList.remove('ui-draggable');
     if (!forDestroy) this.el.classList.add('ui-draggable-disabled');
   }
 

--- a/src/dd-resizable.ts
+++ b/src/dd-resizable.ts
@@ -73,7 +73,6 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
 
   public enable(): void {
     super.enable();
-    this.el.classList.add('ui-resizable');
     this.el.classList.remove('ui-resizable-disabled');
     this._setupAutoHide(this.option.autoHide);
   }
@@ -81,14 +80,12 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
   public disable(): void {
     super.disable();
     this.el.classList.add('ui-resizable-disabled');
-    this.el.classList.remove('ui-resizable');
     this._setupAutoHide(false);
   }
 
   public destroy(): void {
     this._removeHandlers();
     this._setupAutoHide(false);
-    this.el.classList.remove('ui-resizable');
     delete this.el;
     super.destroy();
   }


### PR DESCRIPTION
### Description
* more fix #2243
* remove `'ui-draggable'` and `'ui-resizable'` since wasn't used in CSS and we have the `-disabled` version when off (so we can use `not(xyz-disabled)`).

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
