### PR TITLE
fix(drag): always put element under the mouse when dragging an element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,7 @@
     <li><a href="responsive.html">Responsive</a></li>
     <li><a href="right-to-left(rtl).html">Right-To-Left (RTL)</a></li>
     <li><a href="serialization.html">Serialization</a></li>
+    <li><a href="scale.html">Scale</a></li>
     <li><a href="sizeToContent.html">Size To Content</a></li>
     <li><a href="static.html">Static</a></li>
     <li><a href="title_drag.html">Title drag</a></li>

--- a/demo/scale.html
+++ b/demo/scale.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Transform (Scale) Parent demo</title>
+
+  <link rel="stylesheet" href="demo.css"/>
+  <script src="../dist/gridstack-all.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Transform Parent demo</h1>
+    <p>example where the grid parent has a scale (0.5, 0.5)</p>
+    <div>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
+      <a class="btn btn-primary" onClick="zoomIn()" href="#">Zoom in</a>
+      <a class="btn btn-primary" onClick="zoomOut()" href="#">Zoom out</a>
+    </div>
+    <br><br>
+    <div style="transform: scale(var(--global-scale), var(--global-scale))">
+      <div class="grid-stack"></div>
+    </div>
+  </div>
+  <script src="events.js"></script>
+  <script type="text/javascript">
+    let scale = 0.5;
+
+    let grid = GridStack.init({float: true});
+    addEvents(grid);
+
+    let items = [
+      {x: 0, y: 0, w: 2, h: 2},
+      {x: 2, y: 0, w: 1},
+      {x: 3, y: 0, h: 1},
+      {x: 0, y: 2, w: 2},
+    ];
+    let count = 0;
+
+    getNode = function() {
+      let n = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
+      };
+      n.content = n.content || String(count);
+      count++;
+      return n;
+    };
+
+    addNewWidget = function() {
+      let w = grid.addWidget(getNode());
+    };
+
+    const updateScaleCssVariable = () => {
+      document.body.style.setProperty('--global-scale', `${scale}`);
+    }
+
+    zoomIn = function() {
+      const scaleStep = scale < 1 ? 0.05 : 0.1;
+      scale += scaleStep;
+      updateScaleCssVariable();
+    }
+
+    zoomOut = function() {
+      const scaleStep = scale < 1 ? 0.05 : 0.1;
+      scale -= scaleStep;
+      updateScaleCssVariable();
+    }
+
+    updateScaleCssVariable();
+
+
+    addNewWidget();
+    addNewWidget();
+    addNewWidget();
+  </script>
+</body>
+</html>

--- a/demo/scale.html
+++ b/demo/scale.html
@@ -20,7 +20,7 @@
       <a class="btn btn-primary" onClick="zoomOut()" href="#">Zoom out</a>
     </div>
     <br><br>
-    <div style="transform: scale(var(--global-scale), var(--global-scale))">
+    <div style="transform: scale(var(--global-scale), var(--global-scale)); transform-origin: 0 0;">
       <div class="grid-stack"></div>
     </div>
   </div>

--- a/demo/web2.html
+++ b/demo/web2.html
@@ -15,7 +15,7 @@
 
   <!-- support for IE -->
   <script src="../dist/es5/gridstack-poly.js"></script>
-  <script src="../dist/es5/gridstack.js"></script>
+  <script src="../dist/es5/gridstack-all.js"></script>
 
   <style type="text/css">
     .grid-stack-item-removing {

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -323,10 +323,11 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _dragFollow(e: DragEvent): void {
     const style = this.helper.style;
     const { scaleX, scaleY } = Utils.getScaleForElement(this.helper);
-    // when an element is scaled, the helper is positioned relative to it's parent, so we need to remove the extra offset
-    const containementRect = this.helperContainment.getBoundingClientRect();
-    const offsetX = scaleX === 1 ? 0 : containementRect.left;
-    const offsetY = scaleY === 1 ? 0 : containementRect.top;
+    const transformParent = Utils.getContainerForPositionFixedElement(this.helper);
+    const transformParentRect = transformParent.getBoundingClientRect();
+    // when an element is scaled, the helper is positioned relative to the first transformed parent, so we need to remove the extra offset
+    const offsetX = transformParentRect.left;
+    const offsetY = transformParentRect.top;
 
     // Position the element under the mouse
     const x = (e.clientX - offsetX - (this._originalMousePositionInsideElement?.x || 0)) / scaleX;
@@ -350,14 +351,20 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal TODO: set to public as called by DDDroppable! */
   public ui(): DDUIData {
     const containmentEl = this.el.parentElement;
+    const scrollElement = Utils.getScrollElement(this.el.parentElement);
     const containmentRect = containmentEl.getBoundingClientRect();
     const offset = this.helper.getBoundingClientRect();
     const { scaleX, scaleY } = Utils.getScaleForElement(this.helper);
 
+    // When an element is inside a scrolled element, the boundingClientRect will return the position of the element minus the scroll.
+    const parentPositionIncludingScroll = containmentEl === scrollElement
+      ? { top: containmentRect.top + scrollElement.scrollTop, left: containmentRect.left + scrollElement.scrollLeft }
+      : { top: containmentRect.top, left: containmentRect.left };
+
     return {
       position: { // Current CSS position of the helper as { top, left } object
-        top: (offset.top - containmentRect.top) / scaleY,
-        left: (offset.left - containmentRect.left) / scaleX,
+        top: (offset.top - parentPositionIncludingScroll.top) / scaleY,
+        left: (offset.left - parentPositionIncludingScroll.left) / scaleX,
       }
       /* not used by GridStack for now...
       helper: [this.helper], //The object arr representing the helper that's being dragged.

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -202,7 +202,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       }
       if (node) {
         const rect = this.el.getBoundingClientRect();
-        this._originalMousePositionInsideElement = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+        this._originalMousePositionInsideElement = { x: s.clientX - rect.left, y: s.clientY - rect.top };
       }
       this.helper = this._createHelper(e);
       this._setupHelperContainmentStyle();
@@ -323,11 +323,14 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _dragFollow(e: DragEvent): void {
     const style = this.helper.style;
     const { scaleX, scaleY } = Utils.getScaleForElement(this.helper);
+    // when an element is scaled, the helper is positioned relative to it's parent, so we need to remove the extra offset
+    const containementRect = this.helperContainment.getBoundingClientRect();
+    const offsetX = scaleX === 1 ? 0 : containementRect.left;
+    const offsetY = scaleY === 1 ? 0 : containementRect.top;
 
-
-    // Position the element behind the mouse
-    const x = (e.clientX  - (this._originalMousePositionInsideElement?.x || 0)) / scaleX;
-    const y = (e.clientY  - (this._originalMousePositionInsideElement?.y || 0)) / scaleY;
+    // Position the element under the mouse
+    const x = (e.clientX - offsetX - (this._originalMousePositionInsideElement?.x || 0)) / scaleX;
+    const y = (e.clientY - offsetY - (this._originalMousePositionInsideElement?.y || 0)) / scaleY;
     style.left = `${x}px`;
     style.top = `${y}px`;
   }

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -183,7 +183,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
         this._callDrag(e);
       }
     } else if (Math.abs(e.x - s.x) + Math.abs(e.y - s.y) > 3) {
-      let node = (this.el as GridItemHTMLElement)?.gridstackNode;
       /**
        * don't start unless we've moved at least 3 pixels
        */

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -52,7 +52,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   protected static originStyleProp = ['transition', 'pointerEvents', 'position', 'left', 'top', 'minWidth', 'willChange'];
   /** @internal pause before we call the actual drag hit collision code */
   protected dragTimeout: number;
-  protected _originalMousePositionInsideElement: { x: number; y: number; };
+  protected origRelativeMouse: { x: number; y: number; };
 
   constructor(el: HTMLElement, option: DDDraggableOpt = {}) {
     super();
@@ -184,10 +184,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       }
     } else if (Math.abs(e.x - s.x) + Math.abs(e.y - s.y) > 3) {
       let node = (this.el as GridItemHTMLElement)?.gridstackNode;
-      if (node) {
-        const rect = this.el.getBoundingClientRect();
-        node._originalMousePositionInsideElement = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-      }
       /**
        * don't start unless we've moved at least 3 pixels
        */
@@ -200,10 +196,8 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       } else {
         delete DDManager.dropElement;
       }
-      if (node) {
-        const rect = this.el.getBoundingClientRect();
-        this._originalMousePositionInsideElement = { x: s.clientX - rect.left, y: s.clientY - rect.top };
-      }
+      const rect = this.el.getBoundingClientRect();
+      this.origRelativeMouse = { x: s.clientX - rect.left, y: s.clientY - rect.top };
       this.helper = this._createHelper(e);
       this._setupHelperContainmentStyle();
       const ev = Utils.initEvent<DragEvent>(e, { target: this.el, type: 'dragstart' });
@@ -330,8 +324,8 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     const offsetY = transformParentRect.top;
 
     // Position the element under the mouse
-    const x = (e.clientX - offsetX - (this._originalMousePositionInsideElement?.x || 0)) / scaleX;
-    const y = (e.clientY - offsetY - (this._originalMousePositionInsideElement?.y || 0)) / scaleY;
+    const x = (e.clientX - offsetX - (this.origRelativeMouse?.x || 0)) / scaleX;
+    const y = (e.clientY - offsetY - (this.origRelativeMouse?.y || 0)) / scaleY;
     style.left = `${x}px`;
     style.top = `${y}px`;
   }

--- a/src/dd-resizable.ts
+++ b/src/dd-resizable.ts
@@ -281,10 +281,11 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal constrain the size to the set min/max values */
   protected _constrainSize(oWidth: number, oHeight: number): Size {
     const { scaleX, scaleY } = Utils.getScaleForElement(this.el);
-    const maxWidth = this.option.maxWidth ? this.option.maxWidth * scaleX : Number.MAX_SAFE_INTEGER;
-    const minWidth = this.option.minWidth ? this.option.minWidth * scaleX : oWidth;
-    const maxHeight = this.option.maxHeight ? this.option.maxHeight * scaleY : Number.MAX_SAFE_INTEGER;
-    const minHeight = this.option.minHeight ? this.option.minHeight * scaleY : oHeight;
+    const o = this.option;
+    const maxWidth = o.maxWidth ? o.maxWidth * scaleX : Number.MAX_SAFE_INTEGER;
+    const minWidth = o.minWidth ? o.minWidth * scaleX : oWidth;
+    const maxHeight = o.maxHeight ? o.maxHeight * scaleY : Number.MAX_SAFE_INTEGER;
+    const minHeight = o.minHeight ? o.minHeight * scaleY : oHeight;
     const width = Math.min(maxWidth, Math.max(minWidth, oWidth));
     const height = Math.min(maxHeight, Math.max(minHeight, oHeight));
     return { width, height };

--- a/src/dd-resizable.ts
+++ b/src/dd-resizable.ts
@@ -295,10 +295,10 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _applyChange(): DDResizable {
     if (!this.temporalRect) return this;
     const { scaleX, scaleY } = Utils.getScaleForElement(this.el);
-    this.el.style.width = `${Math.floor(this.temporalRect.width / scaleX)}px`;
-    this.el.style.height = `${Math.floor(this.temporalRect.height / scaleY)}px`;
-    this.el.style.top = `${Math.floor(this.temporalRect.top / scaleY)}px`;
-    this.el.style.left = `${Math.floor(this.temporalRect.left / scaleX)}px`;
+    this.el.style.width = `${Math.round(this.temporalRect.width / scaleX)}px`;
+    this.el.style.height = `${Math.round(this.temporalRect.height / scaleY)}px`;
+    this.el.style.top = `${Math.round(this.temporalRect.top / scaleY)}px`;
+    this.el.style.left = `${Math.round(this.temporalRect.left / scaleX)}px`;
     return this;
   }
 

--- a/src/dd-resizable.ts
+++ b/src/dd-resizable.ts
@@ -293,18 +293,12 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
 
   /** @internal */
   protected _applyChange(): DDResizable {
-    let containmentRect = { left: 0, top: 0, width: 0, height: 0 };
-    if (this.el.style.position === 'absolute') {
-      const containmentEl = this.el.parentElement;
-      const { left, top } = containmentEl.getBoundingClientRect();
-      containmentRect = { left, top, width: 0, height: 0 };
-    }
     if (!this.temporalRect) return this;
     const { scaleX, scaleY } = Utils.getScaleForElement(this.el);
-    this.el.style.width = `${this.temporalRect.width / scaleX}px`;
-    this.el.style.height = `${this.temporalRect.height / scaleY}px`;
-    this.el.style.top = `${this.temporalRect.top / scaleY}px`;
-    this.el.style.left = `${this.temporalRect.left / scaleX}px`;
+    this.el.style.width = `${Math.floor(this.temporalRect.width / scaleX)}px`;
+    this.el.style.height = `${Math.floor(this.temporalRect.height / scaleY)}px`;
+    this.el.style.top = `${Math.floor(this.temporalRect.top / scaleY)}px`;
+    this.el.style.left = `${Math.floor(this.temporalRect.left / scaleX)}px`;
     return this;
   }
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1917,9 +1917,10 @@ export class GridStack {
 
       helper = helper || el;
       let parent = this.el.getBoundingClientRect();
+      const { scaleX, scaleY } = Utils.getScaleForElement(helper);
       let {top, left} = helper.getBoundingClientRect();
-      left -= parent.left;
-      top -= parent.top;
+      left = (left - parent.left) / scaleX;
+      top = (top - parent.top) / scaleY;
       let ui: DDUIData = {position: {top, left}};
 
       if (node._temporaryRemoved) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,4 +436,6 @@ export interface GridStackNode extends GridStackWidget {
   _removeDOM?: boolean;
   /** @internal */
   _initDD?: boolean;
+  /** @internal original mouse position inside the element */
+  _originalMousePositionInsideElement?: GridStackPosition;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,6 +436,4 @@ export interface GridStackNode extends GridStackWidget {
   _removeDOM?: boolean;
   /** @internal */
   _initDD?: boolean;
-  /** @internal original mouse position inside the element */
-  _originalMousePositionInsideElement?: GridStackPosition;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,16 +377,14 @@ export class Utils {
     }
   }
 
-  static getContainerForPositionFixedElement(el: HTMLElement | HTMLHtmlElement): HTMLElement {
-    if (el === document.documentElement) return el;
-
+  static getContainerForPositionFixedElement(el: HTMLElement): HTMLElement {
     const style = getComputedStyle(el as HTMLElement);
 
-    if (style.transform && style.transform !== 'none') {
-      return el;
-    } else {
-      return Utils.getContainerForPositionFixedElement(el.parentElement);
+    while (el !== document.documentElement && el.parentElement && style.transform === 'none') {
+      el = el.parentElement;
     }
+
+    return el;
   }
 
   /** @internal */
@@ -570,20 +568,18 @@ export class Utils {
   }
 
   public static getScaleForElement(element: HTMLElement) {
-    let el = element;
-
     // Check if element is visible, otherwise the width/height will be of 0
-    while (el && !el.offsetParent) {
-      el = el.parentElement;
+    while (element && !element.offsetParent) {
+      element = element.parentElement;
     }
 
-    if (!el) {
+    if (!element) {
       return { scaleX: 1, scaleY: 1 };
     }
 
-    const boundingClientRect = el.getBoundingClientRect();
-    const scaleX = boundingClientRect.width / el.offsetWidth;
-    const scaleY = boundingClientRect.height / el.offsetHeight;
+    const boundingClientRect = element.getBoundingClientRect();
+    const scaleX = boundingClientRect.width / element.offsetWidth;
+    const scaleY = boundingClientRect.height / element.offsetHeight;
     return { scaleX, scaleY };
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Alain Dumesny - see GridStack root license
  */
 
-import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget, GridItemHTMLElement } from './types';
+import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
 
 export interface HeightData {
   h: number;
@@ -558,20 +558,20 @@ export class Utils {
   }
 
   public static getScaleForElement(element: HTMLElement) {
-    let elementToGetTheScaleFrom = element;
+    let el = element;
 
     // Check if element is visible, otherwise the width/height will be of 0
-    while (elementToGetTheScaleFrom && !elementToGetTheScaleFrom.offsetParent) {
-      elementToGetTheScaleFrom = elementToGetTheScaleFrom.parentElement;
+    while (el && !el.offsetParent) {
+      el = el.parentElement;
     }
 
-    if (!elementToGetTheScaleFrom) {
+    if (!el) {
       return { scaleX: 1, scaleY: 1 };
     }
 
-    const boundingClientRect = elementToGetTheScaleFrom.getBoundingClientRect();
-    const scaleX = boundingClientRect.width / elementToGetTheScaleFrom.offsetWidth;
-    const scaleY = boundingClientRect.height / elementToGetTheScaleFrom.offsetHeight;
+    const boundingClientRect = el.getBoundingClientRect();
+    const scaleX = boundingClientRect.width / el.offsetWidth;
+    const scaleY = boundingClientRect.height / el.offsetHeight;
     return { scaleX, scaleY };
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -378,9 +378,7 @@ export class Utils {
   }
 
   static getContainerForPositionFixedElement(el: HTMLElement): HTMLElement {
-    const style = getComputedStyle(el as HTMLElement);
-
-    while (el !== document.documentElement && el.parentElement && style.transform === 'none') {
+    while (el !== document.documentElement && el.parentElement && getComputedStyle(el as HTMLElement).transform === 'none') {
       el = el.parentElement;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -561,8 +561,12 @@ export class Utils {
     let elementToGetTheScaleFrom = element;
 
     // Check if element is visible, otherwise the width/height will be of 0
-    while (!elementToGetTheScaleFrom.offsetParent) {
+    while (elementToGetTheScaleFrom && !elementToGetTheScaleFrom.offsetParent) {
       elementToGetTheScaleFrom = elementToGetTheScaleFrom.parentElement;
+    }
+
+    if (!elementToGetTheScaleFrom) {
+      return { scaleX: 1, scaleY: 1 };
     }
 
     const boundingClientRect = elementToGetTheScaleFrom.getBoundingClientRect();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Alain Dumesny - see GridStack root license
  */
 
-import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget } from './types';
+import { GridStackElement, GridStackNode, GridStackOptions, numberOrString, GridStackPosition, GridStackWidget, GridItemHTMLElement } from './types';
 
 export interface HeightData {
   h: number;
@@ -365,6 +365,18 @@ export class Utils {
     }
   }
 
+  static getPositionContainerElement(el: HTMLElement): HTMLElement {
+    if (!el) return null;
+
+    const style = getComputedStyle(el);
+
+    if (style.position === 'relative' || style.position === 'absolute' || style.position === 'fixed') {
+      return el;
+    } else {
+      return this.getPositionContainerElement(el.parentElement);
+    }
+  }
+
   /** @internal */
   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
     // is widget in view?
@@ -543,6 +555,20 @@ export class Utils {
       e.target      // relatedTarget
     );
     (target || e.target).dispatchEvent(simulatedEvent);
+  }
+
+  public static getScaleForElement(element: HTMLElement) {
+    let elementToGetTheScaleFrom = element;
+
+    // Check if element is visible, otherwise the width/height will be of 0
+    while (!elementToGetTheScaleFrom.offsetParent) {
+      elementToGetTheScaleFrom = elementToGetTheScaleFrom.parentElement;
+    }
+
+    const boundingClientRect = elementToGetTheScaleFrom.getBoundingClientRect();
+    const scaleX = boundingClientRect.width / elementToGetTheScaleFrom.offsetWidth;
+    const scaleY = boundingClientRect.height / elementToGetTheScaleFrom.offsetHeight;
+    return { scaleX, scaleY };
   }
 
   /** returns true if event is inside the given element rectangle */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,6 +377,18 @@ export class Utils {
     }
   }
 
+  static getContainerForPositionFixedElement(el: HTMLElement | HTMLHtmlElement): HTMLElement {
+    if (el === document.documentElement) return el;
+
+    const style = getComputedStyle(el as HTMLElement);
+
+    if (style.transform && style.transform !== 'none') {
+      return el;
+    } else {
+      return this.getContainerForPositionFixedElement(el.parentElement);
+    }
+  }
+
   /** @internal */
   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
     // is widget in view?

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -373,7 +373,7 @@ export class Utils {
     if (style.position === 'relative' || style.position === 'absolute' || style.position === 'fixed') {
       return el;
     } else {
-      return this.getPositionContainerElement(el.parentElement);
+      return Utils.getPositionContainerElement(el.parentElement);
     }
   }
 
@@ -385,7 +385,7 @@ export class Utils {
     if (style.transform && style.transform !== 'none') {
       return el;
     } else {
-      return this.getContainerForPositionFixedElement(el.parentElement);
+      return Utils.getContainerForPositionFixedElement(el.parentElement);
     }
   }
 


### PR DESCRIPTION
### Description
The position of elements dragged was badly calculated and resulted in weird behaviour in a lot of cases like:
- Disable automatic scroll, scroll page while dragging 
- Zoom out/in using the `scale` css property and try to drag a component

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

### Issues fixed
https://github.com/gridstack/gridstack.js/issues/1275
