### PR TITLE
Break: GridStackWidget.subGridOpts rename

### DIFF
--- a/demo/angular/src/app/app.component.ts
+++ b/demo/angular/src/app/app.component.ts
@@ -51,8 +51,8 @@ export class AppComponent implements OnInit {
   private sub2: NgGridStackWidget[] = [ {x:0, y:0}, {x:0, y:1, w:2}];
   private subChildren: NgGridStackWidget[] = [
     {x:0, y:0, content: 'regular item'},
-    {x:1, y:0, w:4, h:4, subGrid: {children: this.sub1, id:'sub1_grid', class: 'sub1', ...this.subOptions}},
-    {x:5, y:0, w:3, h:4, subGrid: {children: this.sub2, id:'sub2_grid', class: 'sub2', ...this.subOptions}},
+    {x:1, y:0, w:4, h:4, subGridOpts: {children: this.sub1, id:'sub1_grid', class: 'sub1', ...this.subOptions}},
+    {x:5, y:0, w:3, h:4, subGridOpts: {children: this.sub2, id:'sub2_grid', class: 'sub2', ...this.subOptions}},
   ]
   public nestedGridOptions: GridStackOptions = { // main grid options
     cellHeight: 50,
@@ -68,7 +68,7 @@ export class AppComponent implements OnInit {
   constructor() {
     // give them content and unique id to make sure we track them during changes below...
     [...this.items, ...this.subChildren, ...this.sub1, ...this.sub2].forEach((w: NgGridStackWidget) => {
-      if (!w.type && !w.subGrid) w.content = `item ${ids}`;
+      if (!w.type && !w.subGridOpts) w.content = `item ${ids}`;
       w.id = String(ids++);
     });
   }
@@ -141,9 +141,10 @@ export class AppComponent implements OnInit {
     let grid = this.gridComp?.grid;
     if (!grid) return;
     let node = grid.engine.nodes[0];
-    if (node?.subGrid) {
-      grid = node.subGrid as GridStack;
-      node = grid?.engine.nodes[0];
+    // delete any children first before subGrid itself...
+    if (node?.subGrid && node.subGrid.engine.nodes.length) {
+      grid = node.subGrid;
+      node = grid.engine.nodes[0];
     }
     if (node) grid.removeWidget(node.el!);
   }

--- a/demo/angular/src/app/gridstack.component.ts
+++ b/demo/angular/src/app/gridstack.component.ts
@@ -216,7 +216,7 @@ export function gsCreateNgComponents(host: GridCompHTMLElement | HTMLElement, w:
 
       // IFF we're not a subGrid, define what type of component to create as child, OR you can do it GridstackItemComponent template, but this is more generic
       const type = (w as NgGridStackWidget).type;
-      if (!w.subGrid && type && GridstackComponent.selectorToType[type]) {
+      if (!w.subGridOpts && type && GridstackComponent.selectorToType[type]) {
         gridItem?.container?.createComponent(GridstackComponent.selectorToType[type]);
       }
 

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -51,8 +51,8 @@
       id: 'main',
       children: [
         {x:0, y:0, content: 'regular item'},
-        {x:1, y:0, w:4, h:4, subGrid: {children: sub1, id:'sub1_grid', class: 'sub1', ...subOptions}},
-        {x:5, y:0, w:3, h:4, subGrid: {children: sub2, id:'sub2_grid', class: 'sub2', ...subOptions}},
+        {x:1, y:0, w:4, h:4, subGridOpts: {children: sub1, id:'sub1_grid', class: 'sub1', ...subOptions}},
+        {x:5, y:0, w:3, h:4, subGridOpts: {children: sub2, id:'sub2_grid', class: 'sub2', ...subOptions}},
       ]
     };
 

--- a/demo/nested_advanced.html
+++ b/demo/nested_advanced.html
@@ -45,19 +45,19 @@
     let main = [{x:0, y:0}, {x:0, y:1}, {x:1, y:0}]
     let sub1 = [{x:0, y:0}];
     let sub0 = [{x:0, y:0}, {x:1, y:0}];
-    // let sub0 = [{x:0, y:0}, {x:1, y:0}, {x:1, y:1, h:2, subGrid: {children: sub1, ...subOptions}}];
+    // let sub0 = [{x:0, y:0}, {x:1, y:0}, {x:1, y:1, h:2, subGridOpts: {children: sub1, ...subOptions}}];
     let options = { // main grid options
       cellHeight: 50,
       margin: 5,
       minRow: 2, // don't collapse when empty
       acceptWidgets: true,
-      subGrid: subOptions,
+      subGridOpts: subOptions,
       subGridDynamic: true, // v7 api to create sub-grids on the fly
       children: [
         ...main,
-        {x:2, y:0, w:2, h:3, id: 'sub0', subGrid: {children: sub0, ...subOptions}},
-        {x:4, y:0, h:2, id: 'sub1', subGrid: {children: sub1, ...subOptions}},
-        // {x:2, y:0, w:2, h:3, subGrid: {children: [...sub1, {x:0, y:1, subGrid: subOptions}], ...subOptions}/*,content: "<div>nested grid here</div>"*/},
+        {x:2, y:0, w:2, h:3, id: 'sub0', subGridOpts: {children: sub0, ...subOptions}},
+        {x:4, y:0, h:2, id: 'sub1', subGridOpts: {children: sub1, ...subOptions}},
+        // {x:2, y:0, w:2, h:3, subGridOpts: {children: [...sub1, {x:0, y:1, subGridOpts: subOptions}], ...subOptions}/*,content: "<div>nested grid here</div>"*/},
       ]
     };
     let count = 0;

--- a/demo/nested_constraint.html
+++ b/demo/nested_constraint.html
@@ -55,8 +55,8 @@
       id: 'main',
       children: [
         {y:0, content: 'regular item'},
-        {x:1, w:4, h:4, subGrid: {children: sub1, class: 'sub1', ...subOptions}},
-        {x:5, w:4, h:4, subGrid: {children: sub2, class: 'sub2', ...subOptions}},
+        {x:1, w:4, h:4, subGridOpts: {children: sub1, class: 'sub1', ...subOptions}},
+        {x:5, w:4, h:4, subGridOpts: {children: sub2, class: 'sub2', ...subOptions}},
       ]
     };
 

--- a/demo/old_nested-jq.html
+++ b/demo/old_nested-jq.html
@@ -76,8 +76,8 @@
       id: 'main',
       children: [
         {x:0, y:0, content: 'regular item'},
-        {x:1, w:4, h:4, subGrid: {children: sub1, dragOut: true, class: 'sub1', ...subOptions}},
-        {x:5, w:3, h:4, subGrid: {children: sub2, dragOut: false, class: 'sub2', ...subOptions}},
+        {x:1, w:4, h:4, subGridOpts: {children: sub1, dragOut: true, class: 'sub1', ...subOptions}},
+        {x:5, w:3, h:4, subGridOpts: {children: sub2, dragOut: false, class: 'sub2', ...subOptions}},
       ]
     };
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -91,6 +91,7 @@ Change log
 * add: `GridStack.saveCB` global callback for each item during save so app can insert any custom data before serializing it. `save()` can now be passed optional callback
 * move: `GridStack.addRemoveCB` is now global instead of grid option. `load()` can still be passed different optional callback
 * fix: addGrid() to handle passing an existing initialized grid already
+* break: `GridStackOptions.subGrid` -> `GridStackOptions.subGridOpts`. We now have `GridStackWidget.subGridOpts` vs `GridStackNode.subGrid` (subclass) rather than try to merge the two at runtime since very different types...
 
 ## 7.3.0 (2023-04-01)
 * feat [#2229](https://github.com/gridstack/gridstack.js/pull/2229) support nonce for CSP. Thank you [@jedwards1211](https://github.com/jedwards1211)

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,8 +252,8 @@ export interface GridStackOptions {
   /** if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`). */
   styleInHead?: boolean;
 
-  /** list of differences in options for automatically created sub-grids under us */
-  subGrid?: GridStackOptions;
+  /** list of differences in options for automatically created sub-grids under us (inside our grid-items) */
+  subGridOpts?: GridStackOptions;
 
   /** enable/disable the creation of sub-grids on the fly by dragging items completely
    * over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that. */
@@ -318,8 +318,8 @@ export interface GridStackWidget extends GridStackPosition {
   id?: numberOrString;
   /** html to append inside as content */
   content?: string;
-  /** optional nested grid options and list of children, which then turns into actual instance at runtime */
-  subGrid?: GridStackOptions | GridStack;
+  /** optional nested grid options and list of children, which then turns into actual instance at runtime to get options from */
+  subGridOpts?: GridStackOptions;
 }
 
 /** Drag&Drop resize options */
@@ -390,8 +390,10 @@ export interface DDUIData {
 export interface GridStackNode extends GridStackWidget {
   /** pointer back to HTML element */
   el?: GridItemHTMLElement;
-  /** pointer back to Grid instance */
+  /** pointer back to parent Grid instance */
   grid?: GridStack;
+  /** actual sub-grid instance */
+  subGrid?: GridStack;
   /** @internal internal id used to match when cloning engines or saving column layouts */
   _id?: number;
   /** @internal */


### PR DESCRIPTION
### Description
* `GridStackOptions.subGrid` -> `GridStackOptions.subGridOpts`.
* We now have `GridStackWidget.subGridOpts` vs `GridStackNode.subGrid` (subclass) rather than try to merge the two at runtime since very different types...

always bugged me to have different runtime types, as it's error prone...

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
