### PR TITLE
`destroy()` now removes event handlers too

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -87,6 +87,7 @@ Change log
 ## 8.0.0-dev (TBD)
 * feat: [#2275](https://github.com/gridstack/gridstack.js/issues/2275) `setupDragIn()` now can take an array or elements (in addition to selector string) and optional parent root (for shadow DOM support)
 * fix: [#2234](https://github.com/gridstack/gridstack.js/issues/2234) `Utils.getElements('1')` (called by removeWidget() and others) now checks for digit 'selector' (becomes an id).
+* fix: [#2213](https://github.com/gridstack/gridstack.js/issues/2213) `destroy()` now removes event handlers too
 
 ## 8.0.0 (2023-04-29)
 * package is now ES2020 (TS exported files), webpack all.js still umd (better than commonjs for browsers), still have es5/ files unchanged (for now)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -894,6 +894,7 @@ export class GridStack {
    */
   public destroy(removeDOM = true): GridStack {
     if (!this.el) return; // prevent multiple calls
+    this.offAll();
     this._updateWindowResizeEvent(true);
     this.setStatic(true, false); // permanently removes DD but don't set CSS class (we're going away)
     this.setAnimation(false);
@@ -1061,6 +1062,12 @@ export class GridStack {
     }
     delete this._gsEventHandler[name];
 
+    return this;
+  }
+
+  /** remove all event handlers */
+  public offAll(): GridStack {
+    Object.keys(this._gsEventHandler).forEach(key => this.off(key));
     return this;
   }
 


### PR DESCRIPTION
### Description
* fix 2213

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
