### PR TITLE
 set an id through setupDragIn

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -66,7 +66,7 @@
     let grids = GridStack.initAll(options);
     grids[1].float(false);
 
-    // new 4.x static method instead of setting up options on every grid (never been per grid really) but old options still works
+    // new 4.x static method instead of setting up options on every grid (never been per grid really)
     GridStack.setupDragIn('.sidebar .grid-stack-item', { appendTo: 'body', helper: myClone });
     // GridStack.setupDragIn(); // second call will now work (cache last values)
 
@@ -85,7 +85,9 @@
 
     // decide what the dropped item will be - for now just a clone but can be anything
     function myClone(event) {
-      return event.target.cloneNode(true);
+      const el = event.target.cloneNode(true);
+      el.setAttribute('gs-id', 'foo'); // TEST why clone element is not used directly on drop #2231
+      return el;
     }
 
     function toggleFloat(button, i) {


### PR DESCRIPTION
### Description
help debug #2231
* will need to figure out why clone element is not used directly on drop later.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
