### PR TITLE
addWidget() addRemoveCB checks if already initialize widget

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -91,6 +91,7 @@ Change log
 
 ## 8.2.0-dev (TBD)
 * fix: make sure `removeNode()` uses internal _id (unique) and not node itself (since we clone those often)
+* fix: after calling `addRemoveCB` make sure we don't makeWidget() (incorrectly) a second time
 
 ## 8.2.0 (2023-05-24)
 * feat: `makeWidget()` now take optional `GridStackWidget` for sizing


### PR DESCRIPTION
### Description
* addRemoveCB may have the user call makeWidget() so prevent multiple instances (which oddly created clone nodes) from happening.
* also makeWidget() (now call form addWidget()) checks for nested grid options. same optimization remains.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
