### PR TITLE
`GridStackWidget.id` is now string only

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -92,6 +92,7 @@ Change log
 ## 8.2.0-dev (TBD)
 * fix: make sure `removeNode()` uses internal _id (unique) and not node itself (since we clone those often)
 * fix: after calling `addRemoveCB` make sure we don't makeWidget() (incorrectly) a second time
+* break: `GridStackWidget.id` is now string only (used to be numberOrString) as it causes usage to have to check and cast
 
 ## 8.2.0 (2023-05-24)
 * feat: `makeWidget()` now take optional `GridStackWidget` for sizing

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -682,7 +682,7 @@ export class GridStack {
 
     // now add/update the widgets
     items.forEach(w => {
-      let item = (w.id || w.id === 0) ? this.engine.nodes.find(n => n.id === w.id) : undefined;
+      let item = (w.id !== undefined) ? this.engine.nodes.find(n => n.id === w.id) : undefined;
       if (item) {
         this.update(item.el, w);
         if (w.subGridOpts?.children) { // update any sub grid as well

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,9 +163,6 @@ export interface GridStackOptions {
   /** draggable handle class (e.g. 'grid-stack-item-content'). If set 'handle' is ignored (default?: null) */
   handleClass?: string;
 
-  /** id used to debug grid instance, not currently stored in DOM attributes */
-  id?: numberOrString;
-
   /** additional widget class (default?: 'grid-stack-item') */
   itemClass?: string;
 
@@ -309,7 +306,7 @@ export interface GridStackWidget extends GridStackPosition {
   /** prevents being moved by others during their (default?: undefined = un-constrained) */
   locked?: boolean;
   /** value for `gs-id` stored on the widget (default?: undefined) */
-  id?: numberOrString;
+  id?: string;
   /** html to append inside as content */
   content?: string;
   /** optional nested grid options and list of children, which then turns into actual instance at runtime to get options from */


### PR DESCRIPTION
### Description
* `GridStackWidget.id` is now string only (used to be numberOrString) as it causes usage to have to check and cast

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
