### PR TITLE
z-index for modal dialogs

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -92,6 +92,7 @@ Change log
 
 ## 8.2.1-dev (TBD)
 * fix [#2349](https://github.com/gridstack/gridstack.js/issues/2349) grid NoMove vs item NoMove support
+* fix [#2352](https://github.com/gridstack/gridstack.js/issues/2352) .ui-draggable-dragging z-index for modal dialogs
 
 ## 8.2.1 (2023-05-26)
 * fix: make sure `removeNode()` uses internal _id (unique) and not node itself (since we clone those often)

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -103,16 +103,6 @@ $animation_speed: .3s !default;
     }
   }
 
-  &.ui-draggable-dragging,
-  &.ui-resizable-resizing {
-    z-index: 100;
-
-    > .grid-stack-item-content {
-      box-shadow: 1px 4px 6px rgba(0, 0, 0, 0.2);
-      opacity: 0.8;
-    }
-  }
-
   &.ui-draggable-dragging {
     will-change: left, top;
     cursor: move;
@@ -120,6 +110,17 @@ $animation_speed: .3s !default;
 
   &.ui-resizable-resizing {
     will-change: width, height;
+  }
+}
+
+// not .grid-stack-item specific to also affect dragIn regions
+.ui-draggable-dragging,
+.ui-resizable-resizing {
+  z-index: 10000; // bootstrap modal has a z-index of 1050
+
+  > .grid-stack-item-content {
+    box-shadow: 1px 4px 6px rgba(0, 0, 0, 0.2);
+    opacity: 0.8;
   }
 }
 


### PR DESCRIPTION
### Description
fix #2352
* make sure .ui-draggable-dragging is not just item (dragIn region) and high enough z-index to solve bootstrap modals too

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
