### PR TITLE
don't clear (default) attr when dragging outside item in

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -94,6 +94,7 @@ Change log
 * fix [#2349](https://github.com/gridstack/gridstack.js/issues/2349) grid NoMove vs item NoMove support
 * fix [#2352](https://github.com/gridstack/gridstack.js/issues/2352) .ui-draggable-dragging z-index for modal dialogs
 * fix [#2357](https://github.com/gridstack/gridstack.js/issues/2357) NaN inf loop when using cellHeight rem/em
+* fix [#2354](https://github.com/gridstack/gridstack.js/issues/2354) max-w cloning issue fix
 
 ## 8.2.1 (2023-05-26)
 * fix: make sure `removeNode()` uses internal _id (unique) and not node itself (since we clone those often)

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -285,7 +285,6 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     const style = this.helper.style;
     style.pointerEvents = 'none'; // needed for over items to get enter/leave
     // style.cursor = 'move'; //  TODO: can't set with pointerEvents=none ! (done in CSS as well)
-    style['min-width'] = 0; // since we no longer relative to our parent and we don't resize anyway (normally 100/#column %)
     style.width = this.dragOffset.width + 'px';
     style.height = this.dragOffset.height + 'px';
     style.willChange = 'left, top';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,8 +55,8 @@ export class Utils {
 
   /** convert a potential selector into actual list of html elements. optional root which defaults to document (for shadow dom) */
   static getElements(els: GridStackElement, root: HTMLElement | Document = document): HTMLElement[] {
-    const doc = ('getElementById' in root) ? root as Document : undefined;
     if (typeof els === 'string') {
+      const doc = ('getElementById' in root) ? root as Document : undefined;
 
       // Note: very common for people use to id='1,2,3' which is only legal as HTML5 id, but not CSS selectors
       // so if we start with a number, assume it's an id and just return that one item...
@@ -78,8 +78,8 @@ export class Utils {
 
   /** convert a potential selector into actual single element. optional root which defaults to document (for shadow dom) */
   static getElement(els: GridStackElement, root: HTMLElement | Document = document): HTMLElement {
-    const doc = ('getElementById' in root) ? root as Document : undefined;
     if (typeof els === 'string') {
+      const doc = ('getElementById' in root) ? root as Document : undefined;
       if (!els.length) return null;
       if (doc && els[0] === '#') {
         return doc.getElementById(els.substring(1));


### PR DESCRIPTION
### Description
* fix #2354
* external items (like toolbar) might have grid-item attr we want to clone, so don't clear them

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
