### PR TITLE
(feat) column() resizing now supports 'list' | 'compact' modes

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -17,6 +17,8 @@
     <div>
       <label>Choose re-layout:</label>
       <select onchange="setLayout(this.value)">
+        <option value="list">list</option>
+        <option value="compact">compact</option>
         <option value="moveScale">move + scale</option>
         <option value="move">move</option>
         <option value="scale">scale</option>
@@ -25,6 +27,8 @@
       </select>
     </div>
     <div>
+      <a onClick="grid.removeAll().load(layout1)" class="btn btn-primary" href="#">random</a>
+      <a onClick="grid.removeAll().load(layout2)" class="btn btn-primary" href="#">list</a>
       <a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a>
       <a onClick="setOneColumn(false)" class="btn btn-primary" href="#">1 Column</a>
       <a onClick="setOneColumn(true)" class="btn btn-primary" href="#">1 Column DOM</a>
@@ -41,21 +45,7 @@
   </div>
 
   <script type="text/javascript">
-    let grid = GridStack.init({
-      float: true,
-      disableOneColumnMode: true, // prevent auto column for this manual demo
-      cellHeight: 100 // fixed as default 'auto' (square) makes it hard to test 1-3 column in actual large windows tests
-    });
-    let text = document.querySelector('#column-text');
-    let layout = 'moveScale';
-
-    grid.on('added removed change', function(e, items) {
-      let str = '';
-      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
-      console.log(e.type + ' ' + items.length + ' items:' + str );
-    });
-
-    let items = [
+    let layout1 = [ // DOM order will be 0,1,2,3,4,5,6 vs column1 = 0,1,4,3,2,5,6
       /* match karma testing
       {x: 0, y: 0, w: 4, h: 2},
       {x: 4, y: 0, w: 4, h: 4},
@@ -71,11 +61,29 @@
       {x: 5, y: 3, w: 2},
       {x: 0, y: 4, w: 12}
     ];
-    let count = 0;
-    items.forEach(n => {
-      n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
-      grid.addWidget(n); // DOM order will be 0,1,2,3,4,5,6 vs column1 = 0,1,4,3,2,5,6
+    let layout2 = [{h:2},{},{},{},{},{},{},{},{},{w:2},{},{},{},{},{},{}];
+    layout2.forEach((n,i) => {
+      n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + ++i;
     });
+    let count = 0;
+    layout1.forEach(n => {
+      n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
+    });
+
+    let grid = GridStack.init({
+      float: true,
+      disableOneColumnMode: true, // prevent auto column for this manual demo
+      cellHeight: 100 // fixed as default 'auto' (square) makes it hard to test 1-3 column in actual large windows tests
+    }).load(layout2);
+    let text = document.querySelector('#column-text');
+    let layout = 'list';
+
+    grid.on('added removed change', function(e, items) {
+      let str = '';
+      items.forEach(function(item) { str += ' (x,y)=' + item.x + ',' + item.y; });
+      console.log(e.type + ' ' + items.length + ' items:' + str );
+    });
+
 
     function addWidget() {
       let n = items[count] || {

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [8.2.3-dev TBD](#823-dev-tbd)
 - [8.2.3 (2023-06-11)](#823-2023-06-11)
 - [8.2.1 (2023-05-26)](#821-2023-05-26)
 - [8.2.0 (2023-05-24)](#820-2023-05-24)
@@ -89,6 +90,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 8.2.3-dev TBD
+* feat [#2358](https://github.com/gridstack/gridstack.js/issues/2358) column() resizing now support reflowing content as list
 
 ## 8.2.3 (2023-06-11)
 * fix [#2349](https://github.com/gridstack/gridstack.js/issues/2349) grid NoMove vs item NoMove support

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,13 +49,19 @@ export const dragInDefaultOptions: DDDragInOpt = {
   // scroll: false,
 };
 
-/** different layout options when changing # of columns,
- * including a custom function that takes new/old column count, and array of new/old positions
+/** 
+ * different layout options when changing # of columns, including a custom function that takes new/old column count, and array of new/old positions
  * Note: new list may be partially already filled if we have a cache of the layout at that size and new items were added later.
+ * Options are:
+ * 'list' - treat items as sorted list, keeping items (unsized unless too big for column count) sequentially reflowing them
+ * 'compact' - similar to list, but using compact() method which will possibly re-order items if an empty slots are available due to a larger item needing to be pushed to next row
+ * 'moveScale' - will scale and move items by the ratio new newColumnCount / oldColumnCount
+ * 'move' | 'scale' - will only size or move items
+ * 'none' will leave items unchanged, unless they don't fit in column count
  */
-export type ColumnOptions = 'moveScale' | 'move' | 'scale' | 'none' |
+export type ColumnOptions = 'list' | 'compact' | 'moveScale' | 'move' | 'scale' | 'none' |
   ((column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void);
-
+export type CompactOptions = 'list' | 'compact';
 export type numberOrString = number | string;
 export interface GridItemHTMLElement extends HTMLElement {
   /** pointer to grid node instance */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,7 @@ export class Utils {
    * @param dir 1 for asc, -1 for desc (optional)
    * @param width width of the grid. If undefined the width will be calculated automatically (optional).
    **/
-  static sort(nodes: GridStackNode[], dir?: -1 | 1, column?: number): GridStackNode[] {
+  static sort(nodes: GridStackNode[], dir: 1 | -1 = 1, column?: number): GridStackNode[] {
     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
     if (dir === -1)
       return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));


### PR DESCRIPTION
### Description
* fix #2358 when your grid is display a sorted list of items, we now support reflowing that content during column resize and compact() methods.
* compact() now takes options which today can be CompactOptions = 'list' | 'compact';
* column(N) now has new options ColumnOptions = 'list' | 'compact' | 'moveScale', etc...
* also optimized some code while stepping in debugger.

API is backward compatible and defaults  to the same behavior.

TODO: remember bigger width and restore back when going up in columns...

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
