### PR TITLE
column(n, 'list') handles restore back to 12 size

### DIFF
--- a/demo/column.html
+++ b/demo/column.html
@@ -27,25 +27,28 @@
       </select>
     </div>
     <div>
-      <a onClick="grid.removeAll().load(layout1)" class="btn btn-primary" href="#">random</a>
-      <a onClick="grid.removeAll().load(layout2)" class="btn btn-primary" href="#">list</a>
+      load:
+      <a onClick="grid.removeAll().load(list)" class="btn btn-primary" href="#">list</a>
+      <a onClick="grid.removeAll().load(test1)" class="btn btn-primary" href="#">case 1</a>
+      <a onClick="random()" class="btn btn-primary" href="#">random</a>
       <a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a>
-      <a onClick="setOneColumn(false)" class="btn btn-primary" href="#">1 Column</a>
-      <a onClick="setOneColumn(true)" class="btn btn-primary" href="#">1 Column DOM</a>
-      <a onClick="column(2)" class="btn btn-primary" href="#">2 Column</a>
-      <a onClick="column(3)" class="btn btn-primary" href="#">3 Column</a>
-      <a onClick="column(4)" class="btn btn-primary" href="#">4 Column</a>
-      <a onClick="column(6)" class="btn btn-primary" href="#">6 Column</a>
-      <a onClick="column(8)" class="btn btn-primary" href="#">8 Column</a>
-      <a onClick="column(10)" class="btn btn-primary" href="#">10 Column</a>
-      <a onClick="column(12)" class="btn btn-primary" href="#">12 Column</a>
+      column:
+      <a onClick="setOneColumn(false)" class="btn btn-primary" href="#">1</a>
+      <a onClick="setOneColumn(true)" class="btn btn-primary" href="#">1 DOM</a>
+      <a onClick="column(2)" class="btn btn-primary" href="#">2</a>
+      <a onClick="column(3)" class="btn btn-primary" href="#">3</a>
+      <a onClick="column(4)" class="btn btn-primary" href="#">4</a>
+      <a onClick="column(6)" class="btn btn-primary" href="#">6</a>
+      <a onClick="column(8)" class="btn btn-primary" href="#">8</a>
+      <a onClick="column(10)" class="btn btn-primary" href="#">10</a>
+      <a onClick="column(12)" class="btn btn-primary" href="#">12</a>
     </div>
     <br>
     <div class="grid-stack"></div>
   </div>
 
   <script type="text/javascript">
-    let layout1 = [ // DOM order will be 0,1,2,3,4,5,6 vs column1 = 0,1,4,3,2,5,6
+    let test1 = [ // DOM order will be 0,1,2,3,4,5,6 vs column1 = 0,1,4,3,2,5,6
       /* match karma testing
       {x: 0, y: 0, w: 4, h: 2},
       {x: 4, y: 0, w: 4, h: 4},
@@ -61,12 +64,12 @@
       {x: 5, y: 3, w: 2},
       {x: 0, y: 4, w: 12}
     ];
-    let layout2 = [{h:2},{},{},{},{},{},{},{},{},{w:2},{},{},{},{},{},{}];
-    layout2.forEach((n,i) => {
+    let list = [{h:2},{},{},{},{},{},{},{},{},{w:2},{},{},{},{},{},{}];
+    list.forEach((n,i) => {
       n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + ++i;
     });
     let count = 0;
-    layout1.forEach(n => {
+    test1.forEach(n => {
       n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
     });
 
@@ -74,7 +77,7 @@
       float: true,
       disableOneColumnMode: true, // prevent auto column for this manual demo
       cellHeight: 100 // fixed as default 'auto' (square) makes it hard to test 1-3 column in actual large windows tests
-    }).load(layout2);
+    }).load(list);
     let text = document.querySelector('#column-text');
     let layout = 'list';
 
@@ -85,14 +88,18 @@
     });
 
 
+    function random() {
+      grid.removeAll();
+      count = 0;
+      for (i=0; i<8; i++) addWidget(true);
+    }
+
     function addWidget() {
-      let n = items[count] || {
-        x: Math.round(12 * Math.random()),
-        y: Math.round(5 * Math.random()),
+      let n = {
         w: Math.round(1 + 3 * Math.random()),
-        h: Math.round(1 + 3 * Math.random())
+        h: Math.round(1 + 3 * Math.random()),
+        content: '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++,
       };
-      n.content = '<button onClick="grid.removeWidget(this.parentNode.parentNode)">X</button><br>' + count++ + (n.text ? n.text : '');
       grid.addWidget(n);
     };
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -33,7 +33,7 @@ gridstack.js API
 - [API](#api)
   - [`addWidget(el?: GridStackWidget | GridStackElement, options?: GridStackWidget)`](#addwidgetel-gridstackwidget--gridstackelement-options-gridstackwidget)
   - [`batchUpdate(flag = true)`](#batchupdateflag--true)
-  - [`compact()`](#compact)
+  - [`compact(layout: CompactOptions = 'compact', doSort = true)`](#compactlayout-compactoptions--compact-dosort--true)
   - [`cellHeight(val: number, update = true)`](#cellheightval-number-update--true)
   - [`cellWidth()`](#cellwidth)
   - [`column(column: number, layout: ColumnOptions = 'moveScale')`](#columncolumn-number-layout-columnoptions--movescale)
@@ -361,9 +361,14 @@ grid.addWidget('<div class="grid-stack-item"><div class="grid-stack-item-content
 
 use before calling a bunch of `addWidget()` to prevent un-necessary relayouts in between (more efficient) and get a single event callback. You will see no changes until `batchUpdate(false)` is called.
 
-### `compact()`
+### `compact(layout: CompactOptions = 'compact', doSort = true)`
 
-re-layout grid items to reclaim any empty space.
+re-layout grid items to reclaim any empty space. Options are:
+- `'list'` keep the widget left->right order the same, even if that means leaving an empty slot if things don't fit
+- `'compact'` might re-order items to fill any empty space
+
+- `doSort` - `false` to let you do your own sorting ahead in case you need to control a different order. (default to sort)
+ 
 
 ### `cellHeight(val: number, update = true)`
 
@@ -385,10 +390,14 @@ Requires `gridstack-extra.css` (or minimized version) for [2-11],
 else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
 
 - `column` - Integer > 0 (default 12)
-- `layout` - specify the type of re-layout that will happen (position, size, etc...).
-Note: items will never be outside of the current column boundaries. default ('moveScale'). Ignored for 1 column.
-Possible values: 'moveScale' | 'move' | 'scale' | 'none' | (column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void.
-A custom function option takes new/old column count, and array of new/old positions.
+- `layout` - specify the type of re-layout that will happen (position, size, etc...). Values are: `'list' | 'compact' | 'moveScale' | 'move' | 'scale' | 'none' | ((column: number, oldColumn: number, nodes: GridStackNode[], oldNodes: GridStackNode[]) => void);`
+
+* `'list'` - treat items as sorted list, keeping items (un-sized unless too big for column count) sequentially reflowing them
+* `'compact'` - similar to list, but using compact() method which will possibly re-order items if an empty slots are available due to a larger item needing to be pushed to next row
+* `'moveScale'` - will scale and move items by the ratio new newColumnCount / oldColumnCount
+* `'move'` | `'scale'` - will only size or move items
+* `'none'` will leave items unchanged, unless they don't fit in column count
+* custom function that takes new/old column count, and array of new/old positions
 Note: new list may be partially already filled if we have a partial cache of the layout at that size (items were added later). If complete cache is present this won't get called at all.
 
 ### `destroy([removeDOM])`

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -9,7 +9,7 @@ import { GridStackEngine } from './gridstack-engine';
 import { Utils, HeightData, obsolete } from './utils';
 import { gridDefaults, ColumnOptions, GridItemHTMLElement, GridStackElement, GridStackEventHandlerCallback,
   GridStackNode, GridStackWidget, numberOrString, DDUIData, DDDragInOpt, GridStackPosition, GridStackOptions,
-  dragInDefaultOptions, GridStackEventHandler, GridStackNodesHandler, AddRemoveFcn, SaveFcn } from './types';
+  dragInDefaultOptions, GridStackEventHandler, GridStackNodesHandler, AddRemoveFcn, SaveFcn, CompactOptions } from './types';
 
 /*
  * and include D&D by default
@@ -796,9 +796,15 @@ export class GridStack {
     return (this.el.clientWidth || this.el.parentElement.clientWidth || window.innerWidth);
   }
 
-  /** re-layout grid items to reclaim any empty space */
-  public compact(): GridStack {
-    this.engine.compact();
+  /**
+   * re-layout grid items to reclaim any empty space. Options are:
+   * 'list' keep the widget left->right order the same, even if that means leaving an empty slot if things don't fit
+   * 'compact' might re-order items to fill any empty space
+   * 
+   * doSort - 'false' to let you do your own sorting ahead in case you need to control a different order. (default to sort)
+   **/
+  public compact(layout: CompactOptions = 'compact', doSort = true): GridStack {
+    this.engine.compact(layout, doSort);
     this._triggerChangeEvent();
     return this;
   }
@@ -810,7 +816,7 @@ export class GridStack {
    * else you will need to generate correct CSS (see https://github.com/gridstack/gridstack.js#change-grid-columns)
    * @param column - Integer > 0 (default 12).
    * @param layout specify the type of re-layout that will happen (position, size, etc...).
-   * Note: items will never be outside of the current column boundaries. default (moveScale). Ignored for 1 column
+   * Note: items will never be outside of the current column boundaries. default ('moveScale'). Ignored for 1 column
    */
   public column(column: number, layout: ColumnOptions = 'moveScale'): GridStack {
     if (column < 1 || this.opts.column === column) return this;
@@ -837,7 +843,7 @@ export class GridStack {
       });
       if (!domNodes.length) { domNodes = undefined; }
     }
-    this.engine.updateNodeWidths(oldColumn, column, domNodes, layout);
+    this.engine.columnChanged(oldColumn, column, domNodes, layout);
     if (this._isAutoCellHeight) this.cellHeight();
 
     // and trigger our event last...

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export const dragInDefaultOptions: DDDragInOpt = {
  * different layout options when changing # of columns, including a custom function that takes new/old column count, and array of new/old positions
  * Note: new list may be partially already filled if we have a cache of the layout at that size and new items were added later.
  * Options are:
- * 'list' - treat items as sorted list, keeping items (unsized unless too big for column count) sequentially reflowing them
+ * 'list' - treat items as sorted list, keeping items (un-sized unless too big for column count) sequentially reflowing them
  * 'compact' - similar to list, but using compact() method which will possibly re-order items if an empty slots are available due to a larger item needing to be pushed to next row
  * 'moveScale' - will scale and move items by the ratio new newColumnCount / oldColumnCount
  * 'move' | 'scale' - will only size or move items


### PR DESCRIPTION
### Description
* more fix #2358
* going 12 -> 1 -> 12 in 'list' mode now correctly restore original item width before doing compact()
* updated demo
* updated API docs

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
