### PR TITLE
add a class that defines a non removable grid item

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -286,6 +286,7 @@ export class GridStack {
       },
       removableOptions: {
         accept: opts.itemClass ? '.' + opts.itemClass : gridDefaults.removableOptions.accept,
+        decline: gridDefaults.removableOptions.decline
       },
     };
     if (el.getAttribute('gs-animate')) { // default to true, but if set to false use that instead
@@ -2038,7 +2039,7 @@ export class GridStack {
   /** @internal mark item for removal */
   private _itemRemoving(el: GridItemHTMLElement, remove: boolean) {
     let node = el ? el.gridstackNode : undefined;
-    if (!node || !node.grid) return;
+    if (!node || !node.grid || el.classList.contains(this.opts.removableOptions.decline)) return;
     remove ? node._isAboutToRemove = true : delete node._isAboutToRemove;
     remove ? el.classList.add('grid-stack-item-removing') : el.classList.remove('grid-stack-item-removing');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export const gridDefaults: GridStackOptions = {
   oneColumnSize: 768,
   placeholderClass: 'grid-stack-placeholder',
   placeholderText: '',
-  removableOptions: { accept: '.grid-stack-item' },
+  removableOptions: { accept: '.grid-stack-item' ,decline:'grid-stack-non-removable'},
   resizable: { handles: 'se' },
   rtl: 'auto',
 
@@ -39,6 +39,7 @@ export const gridDefaults: GridStackOptions = {
   // removable: false,
   // staticGrid: false,
   // styleInHead: false,
+  //removable
 };
 
 /** default dragIn options */
@@ -334,6 +335,7 @@ export interface DDResizeOpt {
 export interface DDRemoveOpt {
   /** class that can be removed (default?: '.' + opts.itemClass) */
   accept?: string;
+  decline?: string;
 }
 
 /** Drag&Drop dragging options */


### PR DESCRIPTION

### Description
An attribute 'decline' has been added to 'removableOptions' to deny the removal of a specific class. By default, it is set to 'grid-stack-non-removable'."

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
