### PR TITLE
drag to trash calls removeWidget()

### DIFF
--- a/angular/projects/demo/src/environments/environment.prod.ts
+++ b/angular/projects/demo/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -94,6 +94,7 @@ Change log
 
 ## 8.3.0-dev (TBD)
 * feat [#2378](https://github.com/gridstack/gridstack.js/pull/2378) attribute `DDRemoveOpt.decline` to deny the removal of a specific class.
+* fix: dragging onto trash now calls removeWidget() and therefore `GridStack.addRemoveCB` (for component cleanup)
 
 ## 8.3.0 (2023-06-13)
 * feat [#2358](https://github.com/gridstack/gridstack.js/issues/2358) column(N, 'list'|'compact'|...) resizing now support reflowing content as list

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -547,8 +547,9 @@ export class GridStackEngine {
     if (removeDOM) node._removeDOM = true; // let CB remove actual HTML (used to set _id to null, but then we loose layout info)
     // don't use 'faster' .splice(findIndex(),1) in case node isn't in our list, or in multiple times.
     this.nodes = this.nodes.filter(n => n._id !== node._id);
-    return this._packNodes()
-      ._notify([node]);
+    if (!node._isAboutToRemove) this._packNodes(); // if dragged out, no need to relayout as already done...
+    this._notify([node]);
+    return this;
   }
 
   public removeAll(removeDOM = true): GridStackEngine {

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2113,17 +2113,12 @@ export class GridStack {
         node.el = target;
 
         if (node._isAboutToRemove) {
-          let gridToNotify = el.gridstackNode.grid;
-          if (gridToNotify._gsEventHandler[event.type]) {
-            gridToNotify._gsEventHandler[event.type](event, target);
+          let grid = el.gridstackNode.grid;
+          if (grid._gsEventHandler[event.type]) {
+            grid._gsEventHandler[event.type](event, target);
           }
-          this._removeDD(el);
-          gridToNotify.engine.removedNodes.push(node);
-          gridToNotify._triggerRemoveEvent();
-          // break circular links and remove DOM
-          delete el.gridstackNode;
-          delete node.el;
-          el.remove();
+          grid.engine.nodes.push(node); // temp add it back so we can proper remove it next
+          grid.removeWidget(el, true, true);
         } else {
           Utils.removePositioningStyles(target);
           if (node._temporaryRemoved) {


### PR DESCRIPTION
### Description
* dragging onto trash now calls removeWidget() and therefore `GridStack.addRemoveCB` (for component cleanup)
