### PR TITLE
`load()` support re-order loading with autoPosition

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -95,6 +95,7 @@ Change log
 ## 8.3.0-dev (TBD)
 * feat [#2378](https://github.com/gridstack/gridstack.js/pull/2378) attribute `DDRemoveOpt.decline` to deny the removal of a specific class.
 * fix: dragging onto trash now calls removeWidget() and therefore `GridStack.addRemoveCB` (for component cleanup)
+* feat: make `load()` support re-order loading without explicit coordinates (`autoPosition` or missing `x,y`) uses passed order.
 
 ## 8.3.0 (2023-06-13)
 * feat [#2358](https://github.com/gridstack/gridstack.js/issues/2358) column(N, 'list'|'compact'|...) resizing now support reflowing content as list

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,9 +137,9 @@ export class Utils {
   static sort(nodes: GridStackNode[], dir: 1 | -1 = 1, column?: number): GridStackNode[] {
     column = column || nodes.reduce((col, n) => Math.max(n.x + n.w, col), 0) || 12;
     if (dir === -1)
-      return nodes.sort((a, b) => (b.x + b.y * column)-(a.x + a.y * column));
+      return nodes.sort((a, b) => ((b.x ?? 1000) + (b.y ?? 1000) * column)-((a.x ?? 1000) + (a.y ?? 1000) * column));
     else
-      return nodes.sort((b, a) => (b.x + b.y * column)-(a.x + a.y * column));
+      return nodes.sort((b, a) => ((b.x ?? 1000) + (b.y ?? 1000) * column)-((a.x ?? 1000) + (a.y ?? 1000) * column));
   }
 
   /**


### PR DESCRIPTION
### Description
* you can now re-order widgets during load() using autoPosition:true

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
