### PR TITLE
auto-size height to fit content

### DIFF
--- a/demo/fitToContent.html
+++ b/demo/fitToContent.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FitToContent demo</title>
+
+  <link rel="stylesheet" href="demo.css"/>
+  <script src="../dist/gridstack-all.js"></script>
+  <style type="text/css">
+    .grid-stack-item-content {
+      text-align: unset;
+    }
+  </style>  
+</head>
+<body>
+  <div class="container">
+    <h1>Cell FitToContent options demo</h1>
+    <p>new 9.x feature that size the items to fit their content height as to not have scroll bars (unless `fitToContent:false` in C: case) </p>
+    <br>
+    <div class="grid-stack"></div>
+  </div>
+  <script type="text/javascript">
+    let opts = {
+      margin: 5,
+      cellHeight: 50,
+      fitToContent: true, // default to make them all fit
+      // cellHeightThrottle: 100, // ms before fitToContent happens
+    }
+    let grid = GridStack.init(opts);
+    let text ='some very large content that will normally not fit in the window.'
+    text = text + text;
+    let items = [
+      {x:0, y:0, w:2, content: `<div>A: ${text}</div>`},
+      {x:2, y:0, w:1, h:2, content: '<div>B: shrink</div>'}, // make taller than needed upfront
+      {x:3, y:0, w:2, fitToContent: false, content: `<div>C: WILL SCROLL. ${text}</div>`}, // prevent this from fitting testing
+      {x:0, y:1, w:3, content: `<div>D: ${text} ${text}</div>`},
+    ];
+    grid.load(items);
+  </script>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,6 +12,7 @@
     <li><a href="anijs.html">AniJS</a></li>
     <li><a href="cell-height.html">Cell Height</a></li>
     <li><a href="column.html">Column</a></li>
+    <li><a href="fitToContent.html">Fit To Content</a></li>
     <li><a href="float.html">Float grid</a></li>
     <li><a href="knockout.html">Knockout.js</a></li>
     <li><a href="mobile.html">Mobile touch</a></li>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,8 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [8.4.0-dev (2023-07-20)](#840-2023-07-20)
+- [8.4.0-dev (TBD)](#840-dev-tbd)
+- [8.4.0 (2023-07-20)](#840-2023-07-20)
 - [8.3.0 (2023-06-13)](#830-2023-06-13)
 - [8.2.3 (2023-06-11)](#823-2023-06-11)
 - [8.2.1 (2023-05-26)](#821-2023-05-26)
@@ -92,7 +93,10 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## 8.4.0-dev (2023-07-20)
+## 8.4.0-dev (TBD)
+- feat [#404](https://github.com/gridstack/gridstack.js/issues/404) added `GridStackOptions.fitToContent` and `GridStackWidget.fitToContent` to make gridItems size themselves to their content (no scroll bar), calling `GridStack.resizeToContent(el)` whenever the grid or item is resized.
+
+## 8.4.0 (2023-07-20)
 * feat [#2378](https://github.com/gridstack/gridstack.js/pull/2378) attribute `DDRemoveOpt.decline` to deny the removal of a specific class.
 * fix: dragging onto trash now calls removeWidget() and therefore `GridStack.addRemoveCB` (for component cleanup)
 * feat: `load()` support re-order loading without explicit coordinates (`autoPosition` or missing `x,y`) uses passed order.

--- a/doc/README.md
+++ b/doc/README.md
@@ -99,6 +99,7 @@ gridstack.js API
 - `draggable` - allows to override draggable options - see `DDDragOpt`. (default: `{handle: '.grid-stack-item-content', appendTo: 'body', scroll: true}`)
 - `dragOut` to let user drag nested grid items out of a parent or not (default false) See [example](http://gridstackjs.com/demo/nested.html)
 - `engineClass` - the type of engine to create (so you can subclass) default to GridStackEngine
+- `fitToContent` - make gridItems size themselves to their content, calling `resizeToContent(el)` whenever the grid or item is resized.
 - `float` - enable floating widgets (default: `false`) See [example](http://gridstackjs.com/demo/float.html)
 - `handle` - draggable handle selector (default: `'.grid-stack-item-content'`)
 - `handleClass` - draggable handle class (e.g. `'grid-stack-item-content'`). If set `handle` is ignored (default: `null`)
@@ -158,6 +159,7 @@ You need to add `noResize` and `noMove` attributes to completely lock the widget
 - `noMove` - disable element moving
 - `id`- (number | string) good for quick identification (for example in change event)
 - `content` - (string) html content to be added when calling `grid.load()/addWidget()` as content inside the item
+- `fitToContent` - make gridItem size itself to the content, calling `GridStack.resizeToContent(el)` whenever the grid or item is resized.
 - `subGrid`?: GridStackOptions - optional nested grid options and list of children
 - `subGridDynamic`?: boolean - enable/disable the creation of sub-grids on the fly by dragging items completely over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that.
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -51,6 +51,9 @@ $animation_speed: .3s !default;
     overflow-x: hidden;
     overflow-y: auto;
   }
+  &.fit-to-content > .grid-stack-item-content {
+    overflow-y: hidden;
+  }
 }
 
 .grid-stack-item {

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,10 @@ export interface GridStackOptions {
   /** the type of engine to create (so you can subclass) default to GridStackEngine */
   engineClass?: typeof GridStackEngine;
 
+  /** set to true if all grid items (by default, but item can also override) height should be based on content size instead of WidgetItem.h to avoid v-scrollbars.
+   Note: this is still row based, not pixels, so it will use ceil(getBoundingClientRect().height / getCellHeight()) */
+  fitToContent?: boolean;
+
   /** enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html) */
   float?: boolean;
 
@@ -316,6 +320,8 @@ export interface GridStackWidget extends GridStackPosition {
   id?: string;
   /** html to append inside as content */
   content?: string;
+  /** local (grid) override - see GridStackOptions */
+  fitToContent?: boolean;
   /** optional nested grid options and list of children, which then turns into actual instance at runtime to get options from */
   subGridOpts?: GridStackOptions;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,11 @@ export class Utils {
     return els;
   }
 
+  /** true if we should resize to content */
+  static shouldFitToContent(n: GridStackNode): boolean {
+    return n.fitToContent || (n.grid?.opts.fitToContent && n.fitToContent !== false);
+  }
+
   /** returns true if a and b overlap */
   static isIntercepted(a: GridStackPosition, b: GridStackPosition): boolean {
     return !(a.y >= b.y + b.h || a.y + a.h <= b.y || a.x + a.w <= b.x || a.x >= b.x + b.w);


### PR DESCRIPTION
### Description
* fix #404
* added `GridStackOptions.fitToContent` and `GridStackWidget.fitToContent` to make gridItems size themselves to their content (no scroll bar), calling `GridStack.resizeToContent(el)` whenever the grid or item is resized
* added demo showing behavior
* fixed sizing event to use much more accurate ResizeObserver on grid rather than generic window.addEventListener('resize')

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
