### PR TITLE
#2406 inf loop fix adding autoPosition in 1->2 column

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -95,6 +95,7 @@ Change log
 
 ## 8.4.0-dev (TBD)
 - feat [#404](https://github.com/gridstack/gridstack.js/issues/404) added `GridStackOptions.fitToContent` and `GridStackWidget.fitToContent` to make gridItems size themselves to their content (no scroll bar), calling `GridStack.resizeToContent(el)` whenever the grid or item is resized.
+- fix [#2406](https://github.com/gridstack/gridstack.js/issues/2406) inf loop when autoPosition after loading into 1 column, then 2.
 
 ## 8.4.0 (2023-07-20)
 * feat [#2378](https://github.com/gridstack/gridstack.js/pull/2378) attribute `DDRemoveOpt.decline` to deny the removal of a specific class.

--- a/spec/e2e/html/2406_inf_loop_autoPosition_column1.html
+++ b/spec/e2e/html/2406_inf_loop_autoPosition_column1.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Float grid demo</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css" />
+  <link rel="stylesheet" href="../../../dist/gridstack-extra.css" />
+  <script src="../../../dist/gridstack-all.js"></script>
+
+</head>
+
+<body>
+  <h1>1 column, autoPosition bug</h1>
+  <p>add a widget, switch to 2 column, add another widget</p>
+  <div><a class="btn btn-default" onClick="addNewWidget()" href="#">Add Widget</a></div>
+  <div><a class="btn btn-default" onClick="resizeColumns()" href="#">Resize Columns</a></div>
+  <br />
+  <div class="grid-stack"></div>
+  <script src="events.js"></script>
+  <script type="text/javascript">
+    var options = {
+      float: false,
+      column: 1,
+      cellHeight: 100
+    };
+    var grid = GridStack.init(options);
+    var count = 0;
+
+    addNewWidget = function () {
+      var node = {
+        autoPosition: true,
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random()),
+        content: String(count++),
+      };
+      grid.addWidget(node);
+    };
+
+    resizeColumns = function () {
+      grid.column(2);
+    }
+  </script>
+</body>
+
+</html>

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -844,11 +844,12 @@ export class GridStackEngine {
           let n = nodes.find(n => n._id === cacheNode._id);
           if (n) {
             // still current, use cache info positions
-            if (!doCompact) {
-              n.x = cacheNode.x;
-              n.y = cacheNode.y;
+            if (!doCompact && !cacheNode.autoPosition) {
+              n.x = cacheNode.x ?? n.x;
+              n.y = cacheNode.y ?? n.y;
             }
-            n.w = cacheNode.w;
+            n.w = cacheNode.w ?? n.w;
+            if (cacheNode.x == undefined || cacheNode.y === undefined) n.autoPosition = true;
           }
         });
       }
@@ -857,19 +858,20 @@ export class GridStackEngine {
       cacheNodes.forEach(cacheNode => {
         let j = nodes.findIndex(n => n._id === cacheNode._id);
         if (j !== -1) {
+          const n = nodes[j];
           // still current, use cache info positions
           if (doCompact) {
-            nodes[j].w = cacheNode.w; // only w is used, and don't trim the list
+            n.w = cacheNode.w; // only w is used, and don't trim the list
             return;
           }
           if (cacheNode.autoPosition || isNaN(cacheNode.x) || isNaN(cacheNode.y)) {
             this.findEmptyPosition(cacheNode, newNodes);
           }
           if (!cacheNode.autoPosition) {
-            nodes[j].x = cacheNode.x;
-            nodes[j].y = cacheNode.y;
-            nodes[j].w = cacheNode.w;
-            newNodes.push(nodes[j]);
+            n.x = cacheNode.x ?? n.x;
+            n.y = cacheNode.y ?? n.y;
+            n.w = cacheNode.w ?? n.w;
+            newNodes.push(n);
           }
           nodes.splice(j, 1);
         }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -833,7 +833,7 @@ export class GridStack {
    * Note: items will never be outside of the current column boundaries. default ('moveScale'). Ignored for 1 column
    */
   public column(column: number, layout: ColumnOptions = 'moveScale'): GridStack {
-    if (column < 1 || this.opts.column === column) return this;
+    if (!column || column < 1 || this.opts.column === column) return this;
     let oldColumn = this.getColumn();
 
     // if we go into 1 column mode (which happens if we're sized less than minW unless disableOneColumnMode is on)
@@ -1592,7 +1592,8 @@ export class GridStack {
       }
     } else {
       // else check for 1 column in/out behavior
-      let oneColumn = !this.opts.disableOneColumnMode && this.el.clientWidth <= this.opts.oneColumnSize;
+      let oneColumn = !this.opts.disableOneColumnMode && this.el.clientWidth <= this.opts.oneColumnSize ||
+      (this.opts.column === 1 && !this._prevColumn);
       if ((this.opts.column === 1) !== oneColumn) {
         // if (this.opts.animate) this.setAnimation(false); // 1 <-> 12 is too radical, turn off animation and we need it for fitToContent
         this.column(oneColumn ? 1 : this._prevColumn);


### PR DESCRIPTION
### Description
* this was a very particular flow where autoPosition were loading into 1 column (so we save the higher grid count layout) then switch to 2 column, then loaded new items.
* also fixed new v9 issue with sizing called with column 1 already.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
