### PR TITLE
fitToContent fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ grid.printCount();
 
 ## Extend Engine
 
-You can now (5.1+) easily create your own layout engine to further customize you usage. Here is a typescript example
+You can now (5.1+) easily create your own layout engine to further customize your usage. Here is a typescript example
 
 ```ts
 import { GridStack, GridStackEngine, GridStackNod, GridStackMoveOpts } from 'gridstack';
@@ -183,7 +183,7 @@ import { GridStack, GridStackEngine, GridStackNod, GridStackMoveOpts } from 'gri
 class CustomEngine extends GridStackEngine {
 
   /** refined this to move the node to the given new location */
-  public moveNode(node: GridStackNode, o: GridStackMoveOpts): boolean {
+  public override moveNode(node: GridStackNode, o: GridStackMoveOpts): boolean {
     // keep the same original X and Width and let base do it all...
     o.x = node.x;
     o.w = node.w;

--- a/demo/fitToContent.html
+++ b/demo/fitToContent.html
@@ -7,6 +7,7 @@
   <title>FitToContent demo</title>
 
   <link rel="stylesheet" href="demo.css"/>
+  <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
   <script src="../dist/gridstack-all.js"></script>
   <style type="text/css">
     .grid-stack-item-content {
@@ -18,6 +19,11 @@
   <div class="container">
     <h1>Cell FitToContent options demo</h1>
     <p>new 9.x feature that size the items to fit their content height as to not have scroll bars (unless `fitToContent:false` in C: case) </p>
+    <div>
+      column:
+      <a onClick="column(8)" class="btn btn-primary" href="#">8</a>
+      <a onClick="column(12)" class="btn btn-primary" href="#">12</a>
+    </div>
     <br>
     <div class="grid-stack"></div>
   </div>
@@ -38,6 +44,10 @@
       {x:0, y:1, w:3, content: `<div>D: ${text} ${text}</div>`},
     ];
     grid.load(items);
+
+    function column(n) {
+      grid.column(n, 'none');
+    }
   </script>
 </body>
 </html>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -95,6 +95,7 @@ Change log
 
 ## 8.4.0-dev (TBD)
 - feat [#404](https://github.com/gridstack/gridstack.js/issues/404) added `GridStackOptions.fitToContent` and `GridStackWidget.fitToContent` to make gridItems size themselves to their content (no scroll bar), calling `GridStack.resizeToContent(el)` whenever the grid or item is resized.
+- also added new `'resizecontent'` event, and `resizeToContentCB` and `resizeToContentParent` vars.
 - fix [#2406](https://github.com/gridstack/gridstack.js/issues/2406) inf loop when autoPosition after loading into 1 column, then 2.
 
 ## 8.4.0 (2023-07-20)

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -385,10 +385,10 @@ export class GridStackEngine {
     if (node.minW && node.minW <= this.column) { node.w = Math.max(node.w, node.minW); }
     if (node.minH) { node.h = Math.max(node.h, node.minH); }
 
-    // if user loaded a larger than allowed widget for current # of columns (or force 1 column mode),
+    // if user loaded a larger than allowed widget for current # of columns,
     // remember it's position & width so we can restore back (1 -> 12 column) #1655 #1985
     // IFF we're not in the middle of column resizing!
-    const saveOrig = this.column === 1 || node.x + node.w > this.column;
+    const saveOrig = (node.x || 0) + (node.w || 1) > this.column;
     if (saveOrig && this.column < 12 && !this._inColumnResize && node._id && this.findCacheLayout(node, 12) === -1) {
       let copy = {...node}; // need _id + positions
       if (copy.autoPosition) { delete copy.x; delete copy.y; }
@@ -771,7 +771,7 @@ export class GridStackEngine {
           if (!n) return; // no cache for new nodes. Will use those values.
           // Y changed, push down same amount
           // TODO: detect doing item 'swaps' will help instead of move (especially in 1 column mode)
-          if (node.y !== node._orig.y) {
+          if (n.y >= 0 && node.y !== node._orig.y) {
             n.y += (node.y - node._orig.y);
           }
           // X changed, scale from new position

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export type AddRemoveFcn = (parent: HTMLElement, w: GridStackWidget, add: boolea
 /** optional function called during save() to let the caller add additional custom data to the GridStackWidget structure that will get returned */
 export type SaveFcn = (node: GridStackNode, w: GridStackWidget) => void;
 
+export type ResizeToContentFcn = (els: GridItemHTMLElement) => void;
 
 /**
  * Defines the options for a Grid


### PR DESCRIPTION
### Description
more fix #404
* changing column size and manually resizing a widget will now call resizeToContent()
* added resizeToContentCB for app to override how to resize.
* Added `resizeToContentParent` to make generic code more robust.
* fixed some 1 column loading Nan issues

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
