### PR TITLE
tweaks to resizeToContent()

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -99,6 +99,7 @@ Change log
 
 ## 9.1.0-dev (TBD)
 * fix [#2435](https://github.com/gridstack/gridstack.js/issues/2435) directionCollideCoverage() tweaks
+* fix resizeToContent() to handle node.h (using when cellHeight changes or we resize) vs DOM sizing (rest of the time)
 
 ## 9.1.0 (2023-09-04)
 * renamed fitToContent to sizeToContent (API BREAK)

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -51,7 +51,7 @@ $animation_speed: .3s !default;
     overflow-x: hidden;
     overflow-y: auto;
   }
-  &.size-to-content > .grid-stack-item-content {
+  &.size-to-content:not(.size-to-content-max) > .grid-stack-item-content {
     overflow-y: hidden;
   }
 }


### PR DESCRIPTION
### Description
* fix resizeToContent() to handle node.h (using when cellHeight changes or we resize) vs DOM sizing (rest of the time) more #404

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
