### PR TITLE
Remove added node from layout cache on drop event

### DIFF
--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -958,6 +958,17 @@ export class GridStackEngine {
     return this._layouts?.[column]?.findIndex(l => l._id === n._id) ?? -1;
   }
 
+  public removeNodeFromLayoutCache(n: GridStackNode) {
+    if (!this._layouts) {
+      return;
+    }
+    for (let i = 0; i < this._layouts.length; i++) {
+      let index = this.findCacheLayout(n, i);
+      if (index !== -1) {
+        this._layouts[i].splice(index, 1);
+      }
+    }
+  }
 
   /** called to remove all internal values but the _id */
   public cleanupNode(node: GridStackNode): GridStackEngine {

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2135,6 +2135,7 @@ export class GridStack {
         this._updateContainerHeight();
         this.engine.addedNodes.push(node);// @ts-ignore
         this._triggerAddEvent();// @ts-ignore
+        this.engine.removeNodeFromLayoutCache(node);
         this._triggerChangeEvent();
 
         this.engine.endUpdate();


### PR DESCRIPTION
### Description
Fix #2394 by removing dropped nodes from GridstackEngine's layout cache. 
I checked `1985_read_1_column_wrong_12.html` (the code relevant here has been added in that PR) and the behaviour is the same as before. Nodes are still positioned correctly after initialising in one column mode, and then enlarging the window (no matter how they are added)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
