### PR TITLE
(fix): moved the `dropped` event handler call to a safer place

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2134,7 +2134,6 @@ export class GridStack {
           this.engine.cleanupNode(node); // removes all internal _xyz values
           node.grid = this;
         }
-        delete node.grid._isTemp;
         dd.off(el, 'drag');
         // if we made a copy ('helper' which is temp) of the original node then insert a copy, else we move the original node (#1102)
         // as the helper will be nuked by jquery-ui otherwise. TODO: update old code path
@@ -2162,17 +2161,26 @@ export class GridStack {
           subGrid.parentGridItem = node;
           if (!subGrid.opts.styleInHead) subGrid._updateStyles(true); // re-create sub-grid styles now that we've moved
         }
-        this._prepareDragDropByNode(node);
         this._updateContainerHeight();
         this.engine.addedNodes.push(node);// @ts-ignore
         this._triggerAddEvent();// @ts-ignore
         this._triggerChangeEvent();
-
         this.engine.endUpdate();
-        if (this._gsEventHandler['dropped']) {
-          this._gsEventHandler['dropped']({...event, type: 'dropped'}, origNode && origNode.grid ? origNode : undefined, node);
-        }
-        
+
+        // wait till we return out of the drag callback to set the new drag&resize handler or they may get messed up
+        window.setTimeout(() => {
+          // IFF we are still there (some application will use as placeholder and insert their real widget instead and better call makeWidget())
+          if (node.el && node.el.parentElement) {
+            this._prepareDragDropByNode(node);
+          } else {
+            this.engine.removeNode(node);
+          }
+          delete node.grid._isTemp;
+          if (this._gsEventHandler['dropped']) {
+            this._gsEventHandler['dropped']({...event, type: 'dropped'}, origNode && origNode.grid ? origNode : undefined, node);
+          }
+        });
+
         return false; // prevent parent from receiving msg (which may be grid as well)
       });
     return this;


### PR DESCRIPTION
(fix): In rare cases the call to trigger the `dropped` handler could lead to errors.

### Description
The error occurred in the `window.setTimeout` code right after. An example is when one executes some logic on the (droppedCB) event in Angular. If you reset the grid the item was dragged from (by resetting the items in an *ngFor) the grid crashed.

By executing the event in the `setTimeout` this problem is solved. It also makes logically sense as the event noting the drop is done is now fired after `this._prepareDragDropByNode(node);` is executed.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

unfortunately i can't get the tests running (tried in the master branch )