### PR TITLE
Possible fix for React

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -122,6 +122,7 @@ GridStack will add it to the <style> elements it creates.
 - `placeholderText` - placeholder default content (default: `''`)
 - `resizable` - allows to override resizable options. (default: `{handles: 'se'}`). `handles` can be any combo of `n,ne,e,se,s,sw,w,nw` or `all`.
 - `removable` - if `true` widgets could be removed by dragging outside of the grid. It could also be a selector string, in this case widgets will be removed by dropping them there (default: `false`) See [example](http://gridstackjs.com/demo/two.html)
+- `removeOnDropOut` - if `remove` the widget will be removed from the dom when dropped to another grid. If `display-none` the widget will be hidden instead (default: `'remove'`).
 - `removeTimeout` - time in milliseconds before widget is being removed while dragging outside of the grid. (default: `2000`)
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)

--- a/doc/README.md
+++ b/doc/README.md
@@ -96,6 +96,7 @@ gridstack.js API
 - `class`?: string - additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance
 - `disableDrag` - disallows dragging of widgets (default: `false`).
 - `disableOneColumnMode` - Prevents the grid container from being displayed in "one column mode", even when the container's width is smaller than the value of oneColumnSize (default value of oneColumnSize is 768px). By default, this option is set to "false".
+- `disableRemoveNodeOnDrop` - if `false` the widget will be removed from the dom when dropped to another grid. If `true` the widget will be hidden instead (default: `false`).
 - `disableResize` - disallows resizing of widgets (default: `false`).
 - `draggable` - allows to override draggable options - see `DDDragOpt`. (default: `{handle: '.grid-stack-item-content', appendTo: 'body', scroll: true}`)
 - `dragOut` to let user drag nested grid items out of a parent or not (default false) See [example](http://gridstackjs.com/demo/nested.html)
@@ -122,7 +123,6 @@ GridStack will add it to the <style> elements it creates.
 - `placeholderText` - placeholder default content (default: `''`)
 - `resizable` - allows to override resizable options. (default: `{handles: 'se'}`). `handles` can be any combo of `n,ne,e,se,s,sw,w,nw` or `all`.
 - `removable` - if `true` widgets could be removed by dragging outside of the grid. It could also be a selector string, in this case widgets will be removed by dropping them there (default: `false`) See [example](http://gridstackjs.com/demo/two.html)
-- `removeOnDropOut` - if `remove` the widget will be removed from the dom when dropped to another grid. If `display-none` the widget will be hidden instead (default: `'remove'`).
 - `removeTimeout` - time in milliseconds before widget is being removed while dragging outside of the grid. (default: `2000`)
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1123,11 +1123,7 @@ export class GridStack {
       this.engine.removeNode(node, removeDOM, triggerEvent);
 
       if (removeDOM && el.parentElement) {
-        if (node._isEndMoving || this.opts.removeOnDropOut === 'display-none') {
-          el.style.display = 'none';
-        } else {
-          el.remove(); // in batch mode engine.removeNode doesn't call back to remove DOM
-        }
+        el.remove(); // in batch mode engine.removeNode doesn't call back to remove DOM
       }
     });
     if (triggerEvent) {
@@ -2129,7 +2125,11 @@ export class GridStack {
             el = el.cloneNode(true) as GridItemHTMLElement;
           }
         } else {
-          el.remove(); // reduce flicker as we change depth here, and size further down
+          if (this.opts.disableRemoveNodeOnDrop) {
+            el.style.display = 'none';
+          } else {
+            el.remove();  // reduce flicker as we change depth here, and size further down
+          }
           this._removeDD(el);
         }
         if (!wasAdded) return false;
@@ -2141,7 +2141,9 @@ export class GridStack {
         Utils.removePositioningStyles(el);// @ts-ignore
         this._writeAttr(el, node);
         el.classList.add(gridDefaults.itemClass, this.opts.itemClass);
-        this.el.appendChild(el);// @ts-ignore // TODO: now would be ideal time to _removeHelperStyle() overriding floating styles (native only)
+        if (!this.opts.disableRemoveNodeOnDrop) {
+          this.el.appendChild(el);// @ts-ignore // TODO: now would be ideal time to _removeHelperStyle() overriding floating styles (native only)
+        }
         if (subGrid) {
           subGrid.parentGridItem = node;
           if (!subGrid.opts.styleInHead) subGrid._updateStyles(true); // re-create sub-grid styles now that we've moved
@@ -2254,7 +2256,6 @@ export class GridStack {
             grid._gsEventHandler[event.type](event, target);
           }
           grid.engine.nodes.push(node); // temp add it back so we can proper remove it next
-          node._isEndMoving = true; // so we can ignore the remove event from the engine
           grid.removeWidget(el, true, true);
         } else {
           Utils.removePositioningStyles(target);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1123,7 +1123,11 @@ export class GridStack {
       this.engine.removeNode(node, removeDOM, triggerEvent);
 
       if (removeDOM && el.parentElement) {
-        el.remove(); // in batch mode engine.removeNode doesn't call back to remove DOM
+        if (node._isEndMoving || this.opts.removeOnDropOut === 'display-none') {
+          el.style.display = 'none';
+        } else {
+          el.remove(); // in batch mode engine.removeNode doesn't call back to remove DOM
+        }
       }
     });
     if (triggerEvent) {
@@ -2250,6 +2254,7 @@ export class GridStack {
             grid._gsEventHandler[event.type](event, target);
           }
           grid.engine.nodes.push(node); // temp add it back so we can proper remove it next
+          node._isEndMoving = true; // so we can ignore the remove event from the engine
           grid.removeWidget(el, true, true);
         } else {
           Utils.removePositioningStyles(target);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export const gridDefaults: GridStackOptions = {
   removableOptions: { accept: 'grid-stack-item', decline: 'grid-stack-non-removable'},
   resizable: { handles: 'se' },
   rtl: 'auto',
-  removeOnDropOut: 'remove',
+  disableRemoveNodeOnDrop: false,
 
   // **** same as not being set ****
   // disableDrag: false,
@@ -234,7 +234,7 @@ export interface GridStackOptions {
   removableOptions?: DDRemoveOpt;
 
   /** allows to override the removal from the dom when dropped to another grid with a display none */
-  removeOnDropOut?: 'remove' | 'display-none';
+  disableRemoveNodeOnDrop?: boolean;
 
   /** fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) */
   row?: number;
@@ -442,6 +442,4 @@ export interface GridStackNode extends GridStackWidget {
   _removeDOM?: boolean;
   /** @internal */
   _initDD?: boolean;
-  /** @internal is used to check if a remove event is send from the onEndMoving event */
-  _isEndMoving?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export const gridDefaults: GridStackOptions = {
   removableOptions: { accept: 'grid-stack-item', decline: 'grid-stack-non-removable'},
   resizable: { handles: 'se' },
   rtl: 'auto',
+  removeOnDropOut: 'remove',
 
   // **** same as not being set ****
   // disableDrag: false,
@@ -231,6 +232,9 @@ export interface GridStackOptions {
 
   /** allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) */
   removableOptions?: DDRemoveOpt;
+
+  /** allows to override the removal from the dom when dropped to another grid with a display none */
+  removeOnDropOut?: 'remove' | 'display-none';
 
   /** fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) */
   row?: number;
@@ -438,4 +442,6 @@ export interface GridStackNode extends GridStackWidget {
   _removeDOM?: boolean;
   /** @internal */
   _initDD?: boolean;
+  /** @internal is used to check if a remove event is send from the onEndMoving event */
+  _isEndMoving?: boolean;
 }


### PR DESCRIPTION
### Description
In this pull request I've added a new option to the GridStackOptions. This option is called `disableRemoveNodeOnDrop` and it allows to define if a widget which is moved from one to another grid should be removed from the dom or just hidden with `display: none`.

This changes make not a lot of sense for normal users. But for users with a virtual dom it makes a ton of sense to not remove the item from the dom, 
especially when using state. By only hiding the item, the state will be able to remove the item from the dom.

I tried to run the tests, but they are not working for me.

### Checklist
- [x] Extended the README / documentation, if necessary
