### PR TITLE
fix(scroll): prevent wrong offset when the scroll is on the html element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,7 @@
     <li><a href="responsive.html">Responsive</a></li>
     <li><a href="right-to-left(rtl).html">Right-To-Left (RTL)</a></li>
     <li><a href="serialization.html">Serialization</a></li>
+    <li><a href="scale.html">Scale</a></li>
     <li><a href="sizeToContent.html">Size To Content</a></li>
     <li><a href="static.html">Static</a></li>
     <li><a href="title_drag.html">Title drag</a></li>

--- a/demo/scale.html
+++ b/demo/scale.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Transform (Scale) Parent demo</title>
+
+  <link rel="stylesheet" href="demo.css"/>
+  <script src="../dist/gridstack-all.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>Transform Parent demo</h1>
+    <p>example where the grid parent has a scale (0.5, 0.5)</p>
+    <div>
+      <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
+      <a class="btn btn-primary" onClick="zoomIn()" href="#">Zoom in</a>
+      <a class="btn btn-primary" onClick="zoomOut()" href="#">Zoom out</a>
+    </div>
+    <br><br>
+    <div style="transform: scale(var(--global-scale), var(--global-scale)); transform-origin: 0 0;">
+      <div class="grid-stack"></div>
+    </div>
+  </div>
+  <script src="events.js"></script>
+  <script type="text/javascript">
+    let scale = 0.5;
+
+    let grid = GridStack.init({float: true});
+    addEvents(grid);
+
+    let items = [
+      {x: 0, y: 0, w: 2, h: 2},
+      {x: 2, y: 0, w: 1},
+      {x: 3, y: 0, h: 1},
+      {x: 0, y: 2, w: 2},
+    ];
+    let count = 0;
+
+    getNode = function() {
+      let n = items[count] || {
+        x: Math.round(12 * Math.random()),
+        y: Math.round(5 * Math.random()),
+        w: Math.round(1 + 3 * Math.random()),
+        h: Math.round(1 + 3 * Math.random())
+      };
+      n.content = n.content || String(count);
+      count++;
+      return n;
+    };
+
+    addNewWidget = function() {
+      let w = grid.addWidget(getNode());
+    };
+
+    const updateScaleCssVariable = () => {
+      document.body.style.setProperty('--global-scale', `${scale}`);
+    }
+
+    zoomIn = function() {
+      const scaleStep = scale < 1 ? 0.05 : 0.1;
+      scale += scaleStep;
+      updateScaleCssVariable();
+    }
+
+    zoomOut = function() {
+      const scaleStep = scale < 1 ? 0.05 : 0.1;
+      scale -= scaleStep;
+      updateScaleCssVariable();
+    }
+
+    updateScaleCssVariable();
+
+
+    addNewWidget();
+    addNewWidget();
+    addNewWidget();
+  </script>
+</body>
+</html>

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -328,9 +328,20 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     //   containmentRect = { left, top };
     // }
     const style = this.helper.style;
-    const offset = this.dragOffset;
-    style.left = e.clientX + offset.offsetLeft - containmentRect.left + 'px';
-    style.top = e.clientY + offset.offsetTop - containmentRect.top + 'px';
+    const { scaleX, scaleY } = Utils.getScaleForElement(this.helper);
+    const transformParent = Utils.getContainerForPositionFixedElement(this.helper);
+    // We need to be careful here as the html element actually also includes scroll
+    // so in this case we always need to ignore it
+    const transformParentRect = transformParent === document.documentElement ? { top: 0, left: 0 } : transformParent.getBoundingClientRect();
+    // when an element is scaled, the helper is positioned relative to the first transformed parent, so we need to remove the extra offset
+    const offsetX = transformParentRect.left;
+    const offsetY = transformParentRect.top;
+
+    // Position the element under the mouse
+    const x = (e.clientX - offsetX - (this.origRelativeMouse?.x || 0)) / scaleX;
+    const y = (e.clientY - offsetY - (this.origRelativeMouse?.y || 0)) / scaleY;
+    style.left = `${x}px`;
+    style.top = `${y}px`;
   }
 
   /** @internal */

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -316,7 +316,8 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _dragFollow(e: DragEvent): void {
     const style = this.helper.style;
     const { scaleX, scaleY } = Utils.getScaleForElement(this.helper);
-    const transformParent = Utils.getContainerForPositionFixedElement(this.helper);
+    const parentOfItem = Utils.getContainerOfGridStackItem(this.helper);
+    const transformParent = Utils.getContainerForPositionFixedElement(parentOfItem);
     const scrollParent = Utils.getScrollElement(this.helper);
     // We need to be careful here as the html element actually also includes scroll
     // so in this case we always need to ignore it

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1964,9 +1964,10 @@ export class GridStack {
 
       helper = helper || el;
       let parent = this.el.getBoundingClientRect();
+      const { scaleX, scaleY } = Utils.getScaleForElement(helper);
       let {top, left} = helper.getBoundingClientRect();
-      left -= parent.left;
-      top -= parent.top;
+      left = (left - parent.left) / scaleX;
+      top = (top - parent.top) / scaleY;
       let ui: DDUIData = {position: {top, left}};
 
       if (node._temporaryRemoved) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -373,6 +373,26 @@ export class Utils {
     }
   }
 
+  static getPositionContainerElement(el: HTMLElement): HTMLElement {
+    if (!el) return null;
+
+    const style = getComputedStyle(el);
+
+    if (style.position === 'relative' || style.position === 'absolute' || style.position === 'fixed') {
+      return el;
+    } else {
+      return Utils.getPositionContainerElement(el.parentElement);
+    }
+  }
+
+  static getContainerForPositionFixedElement(el: HTMLElement): HTMLElement {
+    while (el !== document.documentElement && el.parentElement && getComputedStyle(el as HTMLElement).transform === 'none') {
+      el = el.parentElement;
+    }
+
+    return el;
+  }
+
   /** @internal */
   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
     // is widget in view?
@@ -551,6 +571,22 @@ export class Utils {
       e.target      // relatedTarget
     );
     (target || e.target).dispatchEvent(simulatedEvent);
+  }
+
+  public static getScaleForElement(element: HTMLElement) {
+    // Check if element is visible, otherwise the width/height will be of 0
+    while (element && !element.offsetParent) {
+      element = element.parentElement;
+    }
+
+    if (!element) {
+      return { scaleX: 1, scaleY: 1 };
+    }
+
+    const boundingClientRect = element.getBoundingClientRect();
+    const scaleX = boundingClientRect.width / element.offsetWidth;
+    const scaleY = boundingClientRect.height / element.offsetHeight;
+    return { scaleX, scaleY };
   }
 
   /** returns true if event is inside the given element rectangle */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -385,6 +385,14 @@ export class Utils {
     }
   }
 
+  static getContainerOfGridStackItem(el: HTMLElement): HTMLElement {
+    if (!el) return null;
+
+    return el.classList.contains('grid-stack-item')
+      ? el.parentElement
+      : Utils.getContainerOfGridStackItem(el.parentElement);
+  }
+
   static getContainerForPositionFixedElement(el: HTMLElement): HTMLElement {
     while (el !== document.documentElement && el.parentElement && getComputedStyle(el as HTMLElement).transform === 'none') {
       el = el.parentElement;


### PR DESCRIPTION
### Description
Having scroll on the `html` element was increasing the offset because that element behave a bit differently, meaning that the scroll was included in the position of the html element.
So we had basically position like
```js
{ top: -150, left: 0 }
```
But if it's the `html` element in our case we were always expecting `0`


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

### Issues related
Fix https://github.com/gridstack/gridstack.js/issues/2491
