### PR TITLE
calling load() allows overlapping widgets

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [9.3.0-dev (TBD)](#930-dev-tbd)
 - [9.3.0 (2023-09-30)](#930-2023-09-30)
 - [9.2.2 (2023-09-27)](#922-2023-09-27)
 - [9.2.1 (2023-09-20)](#921-2023-09-20)
@@ -100,6 +101,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 9.3.0-dev (TBD)
+* fix [#2492](https://github.com/gridstack/gridstack.js/issues/2492) calling load() allows overlapping widgets
 
 ## 9.3.0 (2023-09-30)
 * fix [#1275](https://github.com/gridstack/gridstack.js/issues/1275) div scale support - Thank you [VincentMolinie](https://github.com/VincentMolinie) for implementing this

--- a/spec/e2e/html/2492_load_twice.html
+++ b/spec/e2e/html/2492_load_twice.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>load() twice bug</title>
+
+  <link rel="stylesheet" href="../../../demo/demo.css" />
+  <script src="../../../dist/gridstack-all.js"></script>
+
+</head>
+<body>
+  <div class="container-fluid">
+    <h1>load twice bug</h1>
+    <p>this load() twice in a row with overlapping content and floating item</p>
+    <div class="grid-stack"></div>
+  </div>
+  <script type="text/javascript">
+    let items = [
+      {x: 0, y: 0, w:2, content: '0 wide'},
+      {x: 1, y: 0, content: '1 over'},
+      {x: 2, y: 1, content: '2 float'},
+    ];
+    let count = 0;
+    items.forEach(n => n.id = String(count++)); // TEST loading with ids
+    let grid = GridStack.init({disableOneColumnMode: true, cellHeight: 70, margin: 5}).load(items)
+    items.forEach(n => n.content += '*')
+    grid.load(items);
+  </script>
+</body>
+</html>

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -655,7 +655,7 @@ export class GridStackEngine {
   public moveNode(node: GridStackNode, o: GridStackMoveOpts): boolean {
     if (!node || /*node.locked ||*/ !o) return false;
     let wasUndefinedPack: boolean;
-    if (o.pack === undefined) {
+    if (o.pack === undefined && !this.batchMode) {
       wasUndefinedPack = o.pack = true;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,6 +147,11 @@ export class Utils {
       return nodes.sort((b, a) => ((b.x ?? 1000) + (b.y ?? 1000) * column)-((a.x ?? 1000) + (a.y ?? 1000) * column));
   }
 
+  /** find an item by id */
+  static find(nodes: GridStackNode[], id: string): GridStackNode | undefined {
+    return id ? nodes.find(n => n.id === id) : undefined;
+  }
+
   /**
    * creates a style sheet with style id under given parent
    * @param id will set the 'gs-style-id' attribute to that id


### PR DESCRIPTION
### Description
* fix #2492
* make sure we use existing items and not reset to start from scratch so we do collision at each step.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
