### PR TITLE
Revert "fix(drag): always put element under the mouse when dragging a…

### DIFF
--- a/demo/transform.html
+++ b/demo/transform.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Transform (Scale) Parent demo</title>
+  <title>Transform Parent demo</title>
 
   <link rel="stylesheet" href="demo.css"/>
   <script src="../dist/gridstack-all.js"></script>
@@ -13,15 +13,16 @@
 <body>
   <div class="container-fluid">
     <h1>Transform Parent demo</h1>
-    <p>example where the grid parent has a translate(50px, 100px) scale(0.5, 0.5) </p>
+    <p>example where the grid parent has a translate(50px, 100px) <s>scale(0.5, 0.5)</s> (scale not working yet see #1275)</p>
     <div>
       <a class="btn btn-primary" onClick="addNewWidget()" href="#">Add Widget</a>
-      <a class="btn btn-primary" onClick="zoomIn()" href="#">Zoom in</a>
-      <a class="btn btn-primary" onClick="zoomOut()" href="#">Zoom out</a>
+      <!-- <a class="btn btn-primary" onClick="zoomIn()" href="#">Zoom in</a>
+      <a class="btn btn-primary" onClick="zoomOut()" href="#">Zoom out</a> -->
     </div>
     <br><br>
-    <div style="transform: translate(50px, 100px) scale(var(--global-scale), var(--global-scale)); transform-origin: 0 0;">
-      <div class="grid-stack"></div>
+    <!-- <div style="transform: translate(50px, 100px) scale(var(--global-scale), var(--global-scale)); transform-origin: 0 0;"> -->
+    <div style="transform: translate(50px, 100px)">
+        <div class="grid-stack"></div>
     </div>
   </div>
   <script src="events.js"></script>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -103,6 +103,7 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 9.3.0-dev (TBD)
+* revert [#1275](https://github.com/gridstack/gridstack.js/issues/1275) div scale support - causing too many issues for now (#2498 #2497 #2491)
 * fix [#2492](https://github.com/gridstack/gridstack.js/issues/2492) calling load() allows overlapping widgets
 
 ## 9.3.0 (2023-09-30)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1947,10 +1947,9 @@ export class GridStack {
 
       helper = helper || el;
       let parent = this.el.getBoundingClientRect();
-      const { scaleX, scaleY } = Utils.getScaleForElement(helper);
       let {top, left} = helper.getBoundingClientRect();
-      left = (left - parent.left) / scaleX;
-      top = (top - parent.top) / scaleY;
+      left -= parent.left;
+      top -= parent.top;
       let ui: DDUIData = {position: {top, left}};
 
       if (node._temporaryRemoved) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -373,26 +373,6 @@ export class Utils {
     }
   }
 
-  static getPositionContainerElement(el: HTMLElement): HTMLElement {
-    if (!el) return null;
-
-    const style = getComputedStyle(el);
-
-    if (style.position === 'relative' || style.position === 'absolute' || style.position === 'fixed') {
-      return el;
-    } else {
-      return Utils.getPositionContainerElement(el.parentElement);
-    }
-  }
-
-  static getContainerForPositionFixedElement(el: HTMLElement): HTMLElement {
-    while (el !== document.documentElement && el.parentElement && getComputedStyle(el as HTMLElement).transform === 'none') {
-      el = el.parentElement;
-    }
-
-    return el;
-  }
-
   /** @internal */
   static updateScrollPosition(el: HTMLElement, position: {top: number}, distance: number): void {
     // is widget in view?
@@ -571,22 +551,6 @@ export class Utils {
       e.target      // relatedTarget
     );
     (target || e.target).dispatchEvent(simulatedEvent);
-  }
-
-  public static getScaleForElement(element: HTMLElement) {
-    // Check if element is visible, otherwise the width/height will be of 0
-    while (element && !element.offsetParent) {
-      element = element.parentElement;
-    }
-
-    if (!element) {
-      return { scaleX: 1, scaleY: 1 };
-    }
-
-    const boundingClientRect = element.getBoundingClientRect();
-    const scaleX = boundingClientRect.width / element.offsetWidth;
-    const scaleY = boundingClientRect.height / element.offsetHeight;
-    return { scaleX, scaleY };
   }
 
   /** returns true if event is inside the given element rectangle */


### PR DESCRIPTION
### Description
Revert "fix(drag): always put element under the mouse when dragging an element (#2263)"

re-opens #1275, and fix #2498 #2497 #2491

This reverts commit b559a6f33c985475f6a9afe0f5d08bc28e64c814.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
