### PR TITLE
parseHeight() fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -106,6 +106,7 @@ Change log
 ## 9.4.0-dev (TBD)
 * fix [#1275](https://github.com/gridstack/gridstack.js/issues/1275) div scale support - Thank you [elmehdiamlou](https://github.com/elmehdiamlou) for implementing this teh right way (add scale to current code)
 * fix [#2489](https://github.com/gridstack/gridstack.js/commit/2489) moved the dropped event handler to after doing everything (no more setTimeout) - Thanks [arnoudb](https://github.com/arnoudb) for suggesting a fix.
+* fix [#2497](https://github.com/gridstack/gridstack.js/issues/2497) Utils.parseHeight() fix
 
 ## 9.4.0 (2023-10-15)
 * revert [#2263](https://github.com/gridstack/gridstack.js/issues/2263) div scale support - causing too many issues for now (#2498 #2491)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,12 +215,12 @@ export class Utils {
   static parseHeight(val: numberOrString): HeightData {
     let h: number;
     let unit = 'px';
-    if (typeof val === 'string') {
+    if (val && typeof val === 'string') {
       if (val === 'auto') h = 0;
       else {
         let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
         if (!match) {
-          throw new Error('Invalid height');
+          throw new Error(`Invalid height val = ${val}`);
         }
         unit = match[2] || 'px';
         h = parseFloat(match[1]);


### PR DESCRIPTION
### Description
* fix #2497
* make sure to check for height=''

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
