### PR TITLE
fix column(1) to not restore if disableOneColumnMode

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -104,9 +104,10 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 9.4.0-dev (TBD)
-* fix [#1275](https://github.com/gridstack/gridstack.js/issues/1275) div scale support - Thank you [elmehdiamlou](https://github.com/elmehdiamlou) for implementing this teh right way (add scale to current code)
+* feat [#1275](https://github.com/gridstack/gridstack.js/issues/1275) div scale support - Thank you [elmehdiamlou](https://github.com/elmehdiamlou) for implementing this teh right way (add scale to current code)
 * fix [#2489](https://github.com/gridstack/gridstack.js/commit/2489) moved the dropped event handler to after doing everything (no more setTimeout) - Thanks [arnoudb](https://github.com/arnoudb) for suggesting a fix.
 * fix [#2497](https://github.com/gridstack/gridstack.js/issues/2497) Utils.parseHeight() fix
+* fix column(1) to not restore if disableOneColumnMode on size change
 
 ## 9.4.0 (2023-10-15)
 * revert [#2263](https://github.com/gridstack/gridstack.js/issues/2263) div scale support - causing too many issues for now (#2498 #2491)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -863,9 +863,9 @@ export class GridStack {
     if (!column || column < 1 || this.opts.column === column) return this;
     let oldColumn = this.getColumn();
 
-    // if we go into 1 column mode (which happens if we're sized less than minW unless disableOneColumnMode is on)
+    // if we go into 1 column mode due to size change (disableOneColumnMode is off and we hit min width)
     // then remember the original columns so we can restore.
-    if (column === 1) {
+    if (column === 1 && !this.opts.disableOneColumnMode) {
       this._prevColumn = oldColumn;
     } else {
       delete this._prevColumn;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,8 +215,8 @@ export class Utils {
   static parseHeight(val: numberOrString): HeightData {
     let h: number;
     let unit = 'px';
-    if (val && typeof val === 'string') {
-      if (val === 'auto') h = 0;
+    if (typeof val === 'string') {
+      if (val === 'auto' || val === '') h = 0;
       else {
         let match = val.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw|%)?$/);
         if (!match) {


### PR DESCRIPTION
### Description
* regression where setting column(1) manually would revert back on next window resize.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
