### PR TITLE
Fixed unhandled exception happening in _mouseMove handler

### DIFF
--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -120,7 +120,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   public destroy(): void {
     if (this.dragTimeout) window.clearTimeout(this.dragTimeout);
     delete this.dragTimeout;
-    if (this.dragging) this._mouseUp(this.mouseDownEvent);
+    if (this.mouseDownEvent) this._mouseUp(this.mouseDownEvent);
     this.disable(true);
     delete this.el;
     delete this.helper;


### PR DESCRIPTION
### Description
Fixed unhandled exception happening in _mouseMove handler on line 209, 'this.el' is undefined. Happens if element is removed just before call of _mouseMove and just after _mouseDown.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

I am unable to run yarn test. Gets all kinds of strange errors.

I had a setup easily reproducing the issue. After the fix, I could not reproduce it anymore.