### PR TITLE
new `GridStackOptions.responsive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Join us on Slack: [https://gridstackjs.slack.com](https://gridstackjs.slack.com)
   - [Migrating to v7](#migrating-to-v7)
   - [Migrating to v8](#migrating-to-v8)
   - [Migrating to v9](#migrating-to-v9)
+  - [Migrating to v10](#migrating-to-v10)
 - [jQuery Application](#jquery-application)
 - [Changes](#changes)
 - [The Team](#the-team)
@@ -449,6 +450,15 @@ Possible breaking change if you use nested grid JSON format, or original Angular
 New addition - see release notes about `sizeToContent` feature.
 Possible break:
 * `GridStack.onParentResize()` is now called `onResize()` as grid now directly track size change, no longer involving parent per say to tell us anything. Note sure why it was public.
+
+## Migrating to v10
+
+we now support much richer responsive behavior with `GridStackOptions.responsive` including any breakpoint width:column pairs, or automatic column sizing.
+
+breaking change: 
+* `disableOneColumnMode`, `oneColumnSize` have been removed (thought we temporary convert if you have them). use `{ responsive: breakpoints: [{w:768, c:1}] }` for the same behavior.
+* 1 column mode switch is no longer by default (`responsive` is not defined) as too many new users had issues. Instead set it explicitly (see above).
+* `oneColumnModeDomSort` has been removed. Planning to support per column layouts at some future times. TBD
 
 # jQuery Application
 

--- a/angular/projects/demo/src/app/app.component.ts
+++ b/angular/projects/demo/src/app/app.component.ts
@@ -62,7 +62,6 @@ export class AppComponent implements OnInit {
     cellHeight: 50,
     margin: 5,
     minRow: 2, // don't collapse when empty
-    disableOneColumnMode: true,
     acceptWidgets: true,
     children: this.subChildren
   };
@@ -71,7 +70,6 @@ export class AppComponent implements OnInit {
     cellHeight: 50,
     margin: 5,
     minRow: 1, // don't collapse when empty
-    disableOneColumnMode: true,
     removable: '.trash',
     acceptWidgets: true,
     float: true,

--- a/demo/canvasJS.html
+++ b/demo/canvasJS.html
@@ -23,7 +23,6 @@
   let grid = GridStack.init({
     cellHeight: 'initial', // start square but will set to % of window width later
     animate: false, // show immediate (animate: true is nice for user dragging though)
-    disableOneColumnMode: true, // will manually do 1 column
     float: true
   });
 

--- a/demo/column.html
+++ b/demo/column.html
@@ -33,8 +33,7 @@
       <a onClick="random()" class="btn btn-primary" href="#">random</a>
       <a onClick="addWidget()" class="btn btn-primary" href="#">Add Widget</a>
       column:
-      <a onClick="setOneColumn(false)" class="btn btn-primary" href="#">1</a>
-      <a onClick="setOneColumn(true)" class="btn btn-primary" href="#">1 DOM</a>
+      <a onClick="column(1)" class="btn btn-primary" href="#">1</a>
       <a onClick="column(2)" class="btn btn-primary" href="#">2</a>
       <a onClick="column(3)" class="btn btn-primary" href="#">3</a>
       <a onClick="column(4)" class="btn btn-primary" href="#">4</a>
@@ -107,14 +106,6 @@
       grid.column(n, layout);
       text.innerHTML = n;
     }
-    function setOneColumn(dom) {
-      if (grid.opts.column === 1 && grid.opts.oneColumnModeDomSort !== dom) {
-        column(12); // go ack to 12 before going to new column1 version
-      }
-      grid.opts.oneColumnModeDomSort = dom;
-      grid.column(1, layout);
-      text.innerHTML = dom ? '1 DOM' : '1';
-    }
     // dummy test method that moves items to the right each new layout... grid engine will validate those values (can't be neg or out of bounds) anyway...
     function columnLayout(column, oldColumn, nodes, oldNodes) {
       oldNodes.forEach(n => {
@@ -126,7 +117,6 @@
     function setLayout(name) {
       layout = name === 'custom' ? this.columnLayout : name;
     }
-    // setOneColumn(true); // test dom order
   </script>
 </body>
 </html>

--- a/demo/custom-engine.html
+++ b/demo/custom-engine.html
@@ -50,7 +50,6 @@
 
     let grid = GridStack.init({
       float: true, 
-      disableOneColumnMode: true,
       cellHeight: 70
     }).load(items);
     addEvents(grid);

--- a/demo/drag-and-drop-dataTransfer.html
+++ b/demo/drag-and-drop-dataTransfer.html
@@ -34,7 +34,6 @@
     <script type="text/javascript">
         let options = {
             column: 12,
-            disableOneColumnMode: true,
             acceptWidgets: function (el) { return true; }
         };
         let items = [

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,8 @@
     <li><a href="react-hooks-controlled-multiple.html">ReactJS (Hooks), multiple grid, controlled (NOT Ideal)</a></li>
     <li><a href="react-hooks.html">ReactJS (Hooks)</a></li>
     <li><a href="react.html">ReactJS</a></li>
-    <li><a href="responsive.html">Responsive</a></li>
+    <li><a href="responsive.html">Responsive: by column size</a></li>
+    <li><a href="responsive_break.html">Responsive: using breakpoints</a></li>
     <li><a href="right-to-left(rtl).html">Right-To-Left (RTL)</a></li>
     <li><a href="serialization.html">Serialization</a></li>
     <li><a href="sizeToContent.html">Size To Content</a></li>

--- a/demo/mobile.html
+++ b/demo/mobile.html
@@ -18,7 +18,6 @@
   <script type="text/javascript">
     let grid = GridStack.init({
       column: 3,
-      disableOneColumnMode: true,
     });
     grid.load([{x:0, y:0, content: '1'}, {x:1, y:0, h:2, content: '2'}, {x:2, y:0, content: '3'}])
   </script>

--- a/demo/nested.html
+++ b/demo/nested.html
@@ -47,7 +47,6 @@
       cellHeight: 50,
       margin: 5,
       minRow: 2, // don't collapse when empty
-      disableOneColumnMode: true,
       acceptWidgets: true,
       id: 'main',
       children: [

--- a/demo/old_two-jq.html
+++ b/demo/old_two-jq.html
@@ -56,7 +56,6 @@
       column: 6,
       minRow: 1, // don't collapse when empty
       cellHeight: 70,
-      disableOneColumnMode: true,
       float: false,
       // dragIn: '.sidebar .grid-stack-item', // add draggable to class
       // dragInOptions: { revert: 'invalid', scroll: false, appendTo: 'body', helper: 'clone' }, // clone

--- a/demo/react-hooks-controlled-multiple.html
+++ b/demo/react-hooks-controlled-multiple.html
@@ -52,7 +52,6 @@
           {
             float: false,
             acceptWidgets: true,
-            disableOneColumnMode: true, // side-by-side and fever columns to fit smaller screens
             column: 6,
             minRow: 1,
           },

--- a/demo/responsive_break.html
+++ b/demo/responsive_break.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Responsive column</title>
+  <title>Responsive breakpoint</title>
 
   <link rel="stylesheet" href="demo.css"/>
   <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
@@ -9,9 +9,8 @@
 </head>
 <body>
   <div>
-    <h1>Responsive: by column size</h1>
-    <p>Using new v10 <code>GridStackOptions.responsive: { columnWidth: x }</code></p>
-
+    <h1>Responsive: using breakpoint</h1>
+    <p>Using new v10 <code>GridStackOptions.responsive: { breakpoints: [] }</code></p>
     <div>
       <span>Number of Columns:</span> <span id="column-text"></span>
     </div>
@@ -52,10 +51,11 @@
     items.forEach(n => {n.id = count; n.content = String(count++)});
 
     let grid = GridStack.init({
-      cellHeight: 80, // use 'auto' to make square
+      cellHeight: 80,
       animate: false, // show immediate (animate: true is nice for user dragging though)
       responsive: {
-        columnWidth: 100, // wanted width
+        breakpointForWindow: true,  // test window vs grid size
+        breakpoints: [{w:700, c:1},{w:850, c:3},{w:950, c:6},{w:1100, c:8}]
       },
       children: items,
       float: true })

--- a/demo/two.html
+++ b/demo/two.html
@@ -57,7 +57,6 @@
       column: 6,
       minRow: 1, // don't collapse when empty
       cellHeight: 70,
-      disableOneColumnMode: true,
       float: true,
       removable: '.trash', // true or drag-out delete class
       // itemClass: 'with-lines', // test a custom additional class #2110

--- a/demo/web1.html
+++ b/demo/web1.html
@@ -25,7 +25,6 @@
   <script type="text/javascript">
     let grid = GridStack.init({
       cellHeight: 70,
-      disableOneColumnMode: true,
     });
 
     let items = [

--- a/demo/web2.html
+++ b/demo/web2.html
@@ -62,7 +62,6 @@
       cellHeight: 70,
       acceptWidgets: true,
       removable: '#trash', // drag-out delete class
-      disableOneColumnMode: true,
     });
     GridStack.setupDragIn('.newWidget', { appendTo: 'body', helper: 'clone' });
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [10.0.0 (TBD)](#1000-tbd)
 - [9.5.1 (2023-11-11)](#951-2023-11-11)
 - [9.5.0 (2023-10-26)](#950-2023-10-26)
 - [9.4.0 (2023-10-15)](#940-2023-10-15)
@@ -103,6 +104,10 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 10.0.0 (TBD)
+* feat - we now support much richer responsive behavior with `GridStackOptions.responsive` including any breakpoint width:column pairs, or automatic column sizing. 
+* `disableOneColumnMode`, `oneColumnSize`, `oneColumnModeDomSort` have been removed (see v10 migration doc)
 
 ## 9.5.1 (2023-11-11)
 * fix [#2525](https://github.com/gridstack/gridstack.js/commit/2525) Fixed unhandled exception happening in _mouseMove handler

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,6 +6,8 @@ gridstack.js API
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
 - [Grid Options](#grid-options)
+  - [Responsive](#responsive)
+    - [ResponsiveBreakpoint](#responsivebreakpoint)
   - [DDDragOpt](#dddragopt)
   - [DDDragInOpt extends DDDragOpt](#dddraginopt-extends-dddragopt)
 - [Grid attributes](#grid-attributes)
@@ -95,7 +97,6 @@ gridstack.js API
 - `column` - Integer > 0 (default 12) which can change on the fly with `column(N)` API, or `'auto'` for nested grids to size themselves to the parent grid container (to make sub-items are the same size). See [column](http://gridstackjs.com/demo/column.html) and [nested](http://gridstackjs.com/demo/nested.html)
 - `class`?: string - additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance
 - `disableDrag` - disallows dragging of widgets (default: `false`).
-- `disableOneColumnMode` - Prevents the grid container from being displayed in "one column mode", even when the container's width is smaller than the value of oneColumnSize (default value of oneColumnSize is 768px). By default, this option is set to "false".
 - `disableResize` - disallows resizing of widgets (default: `false`).
 - `draggable` - allows to override draggable options - see `DDDragOpt`. (default: `{handle: '.grid-stack-item-content', appendTo: 'body', scroll: true}`)
 - `dragOut` to let user drag nested grid items out of a parent or not (default false) See [example](http://gridstackjs.com/demo/nested.html)
@@ -115,18 +116,30 @@ gridstack.js API
 - `maxRow` - maximum rows amount. Default is `0` which means no max.
 - `minRow` - minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`. You can also do this with `min-height` CSS attribute on the grid div in pixels, which will round to the closest row.
 - `nonce` - If you are using a nonce-based Content Security Policy, pass your nonce here and
-GridStack will add it to the <style> elements it creates.
-- `oneColumnSize` - When the width of the grid is equal to or less than the value set in oneColumnSize, the grid will be displayed in one-column mode. By default, the value of this option is set to "768".
-- `oneColumnModeDomSort` - set to `true` if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: `false`)
+GridStack will add it to the `<style>` elements it creates.
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)
 - `placeholderText` - placeholder default content (default: `''`)
 - `resizable` - allows to override resizable options. (default: `{handles: 'se'}`). `handles` can be any combo of `n,ne,e,se,s,sw,w,nw` or `all`.
 - `removable` - if `true` widgets could be removed by dragging outside of the grid. It could also be a selector string, in this case widgets will be removed by dropping them there (default: `false`) See [example](http://gridstackjs.com/demo/two.html)
 - `removeTimeout` - time in milliseconds before widget is being removed while dragging outside of the grid. (default: `2000`)
+- `responsive` - describes the responsive nature of the grid. see `Responsive` interface.
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)
 - `staticGrid` - removes drag|drop|resize (default `false`). If `true` widgets are not movable/resizable by the user, but code can still move and oneColumnMode will still work. You can use the smaller gridstack-static.js lib. A CSS class `grid-stack-static` is also added to the container.
 - `styleInHead` - if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`).
+
+### Responsive
+v10.x supports a much richer responsive behavior, you can have breakpoints of width:column, or auto column sizing,  where no code is longer needed.
+- `columnWidth`?: number - wanted width to maintain (+-50%) to dynamically pick a column count
+- `columnMax`?: number - maximum number of columns allowed (default: 12). Note: make sure to have correct CSS to support this.
+- `layout`?: ColumnOptions - global re-layout mode when changing columns
+- `breakpointForWindow`?: boolean - specify if breakpoints are for window size or grid size (default:false = grid)
+- `breakpoints`?: ResponsiveBreakpoint[] - explicit width:column breakpoints instead of automatic 'columnWidth'. Note: make sure to have correct CSS to support this.
+
+#### ResponsiveBreakpoint
+- `w`?: number - width
+- `c`: number - column
+- `layout`?: ColumnOptions - re-layout mode if different from global one
 
 ### DDDragOpt
 - `handle`?: string - class selector of items that can be dragged. default to '.grid-stack-item-content'

--- a/spec/e2e/html/1570_drag_bottom_max_row.html
+++ b/spec/e2e/html/1570_drag_bottom_max_row.html
@@ -86,7 +86,6 @@
   }
 
   let options2 = {
-    disableOneColumnMode: true,
     minRow: 3,
     maxRow: 3, // change this to show issue
     acceptWidgets: true,

--- a/spec/e2e/html/1571_drop_onto_full.html
+++ b/spec/e2e/html/1571_drop_onto_full.html
@@ -84,7 +84,6 @@
       column: 6,
       row: 1,
       cellHeight: 70,
-      disableOneColumnMode: true,
       float: false,
       removable: '.trash', // drag-out delete class
       acceptWidgets: function(el) { return true; } // function example, else can be simple: true | false | '.someClass' value

--- a/spec/e2e/html/1858_full_grid_overlap.html
+++ b/spec/e2e/html/1858_full_grid_overlap.html
@@ -17,7 +17,6 @@
   </div>
   <script type="text/javascript">
     options = {
-      disableOneColumnMode: true,
       row: 15,
       margin: 2,
       cellHeight: 20,

--- a/spec/e2e/html/2394_save_sub_item_moved.html
+++ b/spec/e2e/html/2394_save_sub_item_moved.html
@@ -25,13 +25,11 @@
         column: 3,
         padding: 5,
         minRow: 2, // don't collapse when empty
-        disableOneColumnMode: true,
         acceptWidgets: true,
         children: [ {id:0, x:0, y:0, w:3, content:'move to parent grid col=2'}]
       };
 
     var options = { // put in gridstack options here
-      disableOneColumnMode: true, // for jfiddle small window size
       cellHeight: 70,
       column: 2,
       minRow: 3,

--- a/spec/e2e/html/2469_min-height.html
+++ b/spec/e2e/html/2469_min-height.html
@@ -24,7 +24,6 @@
   <script src="events.js"></script>
   <script type="text/javascript">
     let grid = GridStack.init({
-      disableOneColumnMode: true,
       float: false,
       cellHeight: '120px',
       minRow: 1,

--- a/spec/e2e/html/2492_load_twice.html
+++ b/spec/e2e/html/2492_load_twice.html
@@ -24,7 +24,7 @@
     ];
     let count = 0;
     items.forEach(n => n.id = String(count++)); // TEST loading with ids
-    let grid = GridStack.init({disableOneColumnMode: true, cellHeight: 70, margin: 5}).load(items)
+    let grid = GridStack.init({cellHeight: 70, margin: 5}).load(items)
     items.forEach(n => n.content += '*')
     grid.load(items);
   </script>

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -431,130 +431,130 @@ describe('gridstack', function() {
     });
   });
 
-  describe('oneColumnModeDomSort', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackEmptyHTML);
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should support default going to 1 column', function() {
-      let options = {
-        column: 12,
-        float: true
-      };
-      let grid = GridStack.init(options);
-      grid.batchUpdate();
-      grid.batchUpdate();
-      let el1 = grid.addWidget({w:1, h:1});
-      let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
-      let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
-      grid.batchUpdate(false);
-      grid.batchUpdate(false);
+  // describe('oneColumnModeDomSort', function() {
+  //   beforeEach(function() {
+  //     document.body.insertAdjacentHTML('afterbegin', gridstackEmptyHTML);
+  //   });
+  //   afterEach(function() {
+  //     document.body.removeChild(document.getElementById('gs-cont'));
+  //   });
+  //   it('should support default going to 1 column', function() {
+  //     let options = {
+  //       column: 12,
+  //       float: true
+  //     };
+  //     let grid = GridStack.init(options);
+  //     grid.batchUpdate();
+  //     grid.batchUpdate();
+  //     let el1 = grid.addWidget({w:1, h:1});
+  //     let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
+  //     let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
+  //     grid.batchUpdate(false);
+  //     grid.batchUpdate(false);
       
-      // items are item1[1x1], item3[1x1], item2[2x1]
-      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(el1.getAttribute('gs-w')).toBe(null);
-      expect(el1.getAttribute('gs-h')).toBe(null);
+  //     // items are item1[1x1], item3[1x1], item2[2x1]
+  //     expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+  //     expect(el1.getAttribute('gs-w')).toBe(null);
+  //     expect(el1.getAttribute('gs-h')).toBe(null);
 
-      expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(el3.getAttribute('gs-w')).toBe(null);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
+  //     expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
+  //     expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+  //     expect(el3.getAttribute('gs-w')).toBe(null);
+  //     expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
-      expect(el2.getAttribute('gs-h')).toBe(null);
+  //     expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
+  //     expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+  //     expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
+  //     expect(el2.getAttribute('gs-h')).toBe(null);
 
-      // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
-      grid.column(1);
-      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(el1.getAttribute('gs-w')).toBe(null);
-      expect(el1.getAttribute('gs-h')).toBe(null);
+  //     // items are item1[1x1], item3[1x2], item2[1x1] in 1 column
+  //     grid.column(1);
+  //     expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+  //     expect(el1.getAttribute('gs-w')).toBe(null);
+  //     expect(el1.getAttribute('gs-h')).toBe(null);
 
-      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-y'))).toBe(1);
-      expect(el3.getAttribute('gs-w')).toBe(null);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
+  //     expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el3.getAttribute('gs-y'))).toBe(1);
+  //     expect(el3.getAttribute('gs-w')).toBe(null);
+  //     expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
-      expect(el2.getAttribute('gs-w')).toBe(null);
-      expect(el2.getAttribute('gs-h')).toBe(null);
-    });
-    it('should support oneColumnModeDomSort ON going to 1 column', function() {
-      let options = {
-        column: 12,
-        oneColumnModeDomSort: true,
-        float: true
-      };
-      let grid = GridStack.init(options);
-      let el1 = grid.addWidget({w:1, h:1});
-      let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
-      let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
+  //     expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el2.getAttribute('gs-y'))).toBe(3);
+  //     expect(el2.getAttribute('gs-w')).toBe(null);
+  //     expect(el2.getAttribute('gs-h')).toBe(null);
+  //   });
+  //   it('should support oneColumnModeDomSort ON going to 1 column', function() {
+  //     let options = {
+  //       column: 12,
+  //       oneColumnModeDomSort: true,
+  //       float: true
+  //     };
+  //     let grid = GridStack.init(options);
+  //     let el1 = grid.addWidget({w:1, h:1});
+  //     let el2 = grid.addWidget({x:2, y:0, w:2, h:1});
+  //     let el3 = grid.addWidget({x:1, y:0, w:1, h:2});
 
-      // items are item1[1x1], item3[1x1], item2[2x1]
-      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(el1.getAttribute('gs-w')).toBe(null);
-      expect(el1.getAttribute('gs-h')).toBe(null);
+  //     // items are item1[1x1], item3[1x1], item2[2x1]
+  //     expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+  //     expect(el1.getAttribute('gs-w')).toBe(null);
+  //     expect(el1.getAttribute('gs-h')).toBe(null);
 
-      expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
-      expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
-      expect(el3.getAttribute('gs-w')).toBe(null);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
+  //     expect(parseInt(el3.getAttribute('gs-x'))).toBe(1);
+  //     expect(parseInt(el3.getAttribute('gs-y'))).toBe(0);
+  //     expect(el3.getAttribute('gs-w')).toBe(null);
+  //     expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
 
-      expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
-      expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
-      expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
-      expect(el2.getAttribute('gs-h')).toBe(null);
+  //     expect(parseInt(el2.getAttribute('gs-x'))).toBe(2);
+  //     expect(parseInt(el2.getAttribute('gs-y'))).toBe(0);
+  //     expect(parseInt(el2.getAttribute('gs-w'))).toBe(2);
+  //     expect(el2.getAttribute('gs-h')).toBe(null);
 
-      // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
-      grid.column(1);
-      expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
-      expect(el1.getAttribute('gs-w')).toBe(null);
-      expect(el1.getAttribute('gs-h')).toBe(null);
+  //     // items are item1[1x1], item2[1x1], item3[1x2] in 1 column dom ordered
+  //     grid.column(1);
+  //     expect(parseInt(el1.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el1.getAttribute('gs-y'))).toBe(0);
+  //     expect(el1.getAttribute('gs-w')).toBe(null);
+  //     expect(el1.getAttribute('gs-h')).toBe(null);
 
-      expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
-      expect(el2.getAttribute('gs-w')).toBe(null);
-      expect(el2.getAttribute('gs-h')).toBe(null);
+  //     expect(parseInt(el2.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el2.getAttribute('gs-y'))).toBe(1);
+  //     expect(el2.getAttribute('gs-w')).toBe(null);
+  //     expect(el2.getAttribute('gs-h')).toBe(null);
 
-      expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
-      expect(parseInt(el3.getAttribute('gs-y'))).toBe(2);
-      expect(el3.getAttribute('gs-w')).toBe(null);
-      expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
-    });
-  });
+  //     expect(parseInt(el3.getAttribute('gs-x'))).toBe(0);
+  //     expect(parseInt(el3.getAttribute('gs-y'))).toBe(2);
+  //     expect(el3.getAttribute('gs-w')).toBe(null);
+  //     expect(parseInt(el3.getAttribute('gs-h'))).toBe(2);
+  //   });
+  // });
 
-  describe('disableOneColumnMode', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackSmallHTML); // smaller default to 1 column
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should go to 1 column', function() {
-      let grid = GridStack.init();
-      expect(grid.getColumn()).toBe(1);
-    });
-    it('should go to 1 column with large minW', function() {
-      let grid = GridStack.init({oneColumnSize: 1000});
-      expect(grid.getColumn()).toBe(1);
-    });
-    it('should stay at 12 with minW', function() {
-      let grid = GridStack.init({oneColumnSize: 300});
-      expect(grid.getColumn()).toBe(12);
-    });
-    it('should stay at 12 column', function() {
-      let grid = GridStack.init({disableOneColumnMode: true});
-      expect(grid.getColumn()).toBe(12);
-    });
-  });
+  // describe('disableOneColumnMode', function() {
+  //   beforeEach(function() {
+  //     document.body.insertAdjacentHTML('afterbegin', gridstackSmallHTML); // smaller default to 1 column
+  //   });
+  //   afterEach(function() {
+  //     document.body.removeChild(document.getElementById('gs-cont'));
+  //   });
+  //   it('should go to 1 column', function() {
+  //     let grid = GridStack.init();
+  //     expect(grid.getColumn()).toBe(1);
+  //   });
+  //   it('should go to 1 column with large minW', function() {
+  //     let grid = GridStack.init({oneColumnSize: 1000});
+  //     expect(grid.getColumn()).toBe(1);
+  //   });
+  //   it('should stay at 12 with minW', function() {
+  //     let grid = GridStack.init({oneColumnSize: 300});
+  //     expect(grid.getColumn()).toBe(12);
+  //   });
+  //   it('should stay at 12 column', function() {
+  //     let grid = GridStack.init({disableOneColumnMode: true});
+  //     expect(grid.getColumn()).toBe(12);
+  //   });
+  // });
 
   describe('grid.minRow', function() {
     beforeEach(function() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,6 @@ export const gridDefaults: GridStackOptions = {
   marginUnit: 'px',
   maxRow: 0,
   minRow: 0,
-  oneColumnSize: 768,
   placeholderClass: 'grid-stack-placeholder',
   placeholderText: '',
   removableOptions: { accept: 'grid-stack-item', decline: 'grid-stack-non-removable'},
@@ -31,11 +30,9 @@ export const gridDefaults: GridStackOptions = {
 
   // **** same as not being set ****
   // disableDrag: false,
-  // disableOneColumnMode: false,
   // disableResize: false,
   // float: false,
   // handleClass: null,
-  // oneColumnModeDomSort: false,
   // removable: false,
   // staticGrid: false,
   // styleInHead: false,
@@ -87,6 +84,31 @@ export type AddRemoveFcn = (parent: HTMLElement, w: GridStackWidget, add: boolea
 export type SaveFcn = (node: GridStackNode, w: GridStackWidget) => void;
 
 export type ResizeToContentFcn = (el: GridItemHTMLElement, useAttr?: boolean) => void;
+
+/** describes the responsive nature of the grid */
+export interface Responsive {
+  /** wanted width to maintain (+-50%) to dynamically pick a column count */
+  columnWidth?: number;
+  /** maximum number of columns allowed (default: 12). Note: make sure to have correct CSS to support this.*/
+  columnMax?: number;
+  /** global re-layout mode when changing columns */
+  layout?: ColumnOptions;
+  /** specify if breakpoints are for window size or grid size (default:false = grid) */
+  breakpointForWindow?: boolean;
+  /** explicit width:column breakpoints instead of automatic 'columnWidth'. Note: make sure to have correct CSS to support this.*/
+  breakpoints?: ResponsiveBreakpoint[];
+}
+
+export interface ResponsiveBreakpoint {
+  /** width */
+  w?: number;
+  /** column */
+  c: number;
+  /** re-layout mode if different from global one */
+  layout?: ColumnOptions;
+  /** TODO: children layout, which spells out exact locations and could omit/add some children */
+  // children?: GridStackWidget[];
+}
 
 /**
  * Defines the options for a Grid
@@ -147,9 +169,6 @@ export interface GridStackOptions {
   /** disallows dragging of widgets (default?: false) */
   disableDrag?: boolean;
 
-  /** disables the onColumnMode when the grid width is less than oneColumnSize (default?: false) */
-  disableOneColumnMode?: boolean;
-
   /** disallows resizing of widgets (default?: false). */
   disableResize?: boolean;
 
@@ -204,15 +223,6 @@ export interface GridStackOptions {
    * GridStack will add it to the <style> elements it creates. */
   nonce?: string;
 
-  /** minimal width before grid will be shown in one column mode (default?: 768) */
-  oneColumnSize?: number;
-
-  /**
-   * set to true if you want oneColumnMode to use the DOM order and ignore x,y from normal multi column
-   * layouts during sorting. This enables you to have custom 1 column layout that differ from the rest. (default?: false)
-   */
-  oneColumnModeDomSort?: boolean;
-
   /** class for placeholder (default?: 'grid-stack-placeholder') */
   placeholderClass?: string;
 
@@ -221,6 +231,9 @@ export interface GridStackOptions {
 
   /** allows to override UI resizable options. (default?: { handles: 'se' }) */
   resizable?: DDResizeOpt;
+
+  /** responsive layout for width->column behavior */
+  responsive?: Responsive;
 
   /**
    * if true widgets could be removed by dragging outside of the grid. It could also be a selector string (ex: ".trash"),
@@ -397,7 +410,7 @@ export interface DDUIData {
 }
 
 /**
- * internal descriptions describing the items in the grid
+ * internal runtime descriptions describing the widgets in the grid
  */
 export interface GridStackNode extends GridStackWidget {
   /** pointer back to HTML element */
@@ -408,7 +421,7 @@ export interface GridStackNode extends GridStackWidget {
   subGrid?: GridStack;
   /** @internal internal id used to match when cloning engines or saving column layouts */
   _id?: number;
-  /** @internal */
+  /** @internal does the node attr ned to be updated due to changed x,y,w,h values */
   _dirty?: boolean;
   /** @internal */
   _updating?: boolean;
@@ -438,6 +451,6 @@ export interface GridStackNode extends GridStackWidget {
   _temporaryRemoved?: boolean;
   /** @internal true if we should remove DOM element on _notify() rather than clearing _id (old way) */
   _removeDOM?: boolean;
-  /** @internal */
+  /** @internal had drag&drop been initialized */
   _initDD?: boolean;
 }


### PR DESCRIPTION
### Description
* we now support much richer responsive behavior with `GridStackOptions.responsive` including any breakpoint width:column pairs, or automatic column sizing
* `disableOneColumnMode`, `oneColumnSize`, `oneColumnModeDomSort` have been removed (see v10 migration doc)
* added new demo files.

* TODO: update test files, more testing...

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
