### PR TITLE
make sure 'new GridStack(el)' set el.gridstack=this

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -267,6 +267,7 @@ export class GridStack {
    * @param opts
    */
   public constructor(el: GridHTMLElement, opts: GridStackOptions = {}) {
+    el.gridstack = this;
     this.el = el; // exposed HTML element to the user
     opts = opts || {}; // handles null/undefined/0
 


### PR DESCRIPTION
### Description
make sure 'new GridStack(el)' set el.gridstack=this right away as code during loading might depend on those vars being set.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
