### PR TITLE
sizeToContent fixes (animation, DOM init, cleanup)

### DIFF
--- a/demo/sizeToContent.html
+++ b/demo/sizeToContent.html
@@ -13,13 +13,21 @@
     .grid-stack-item-content {
       text-align: unset;
     }
+    .sidebar.inline {
+      width: fit-content;
+      height: fit-content;
+      display: inline-block;
+      padding: 0;
+    }
   </style>  
 </head>
 <body>
   <div class="container">
-    <h1>Cell sizeToContent options demo</h1>
-    <p>new 9.x feature that size the items to fit their content height as to not have scroll bars
-      (unless `sizeToContent:false` in C: case). Defaulting to different initial size (see code) to show grow/shrink behavior.</p>
+    <h1>sizeToContent options demo</h1>
+    <p>New 9.x feature that size the items to fit their content height as to not have scroll bars
+    <br>case C: `sizeToContent:false` to turn off.
+    <br>case E: has soft maxsize `sizeToContent:3`, shrinking to smaller content as needed
+    <br>Defaulting to different initial size (see code) to show grow/shrink behavior</p>
     <div>
       <a onClick="clearGrid()" class="btn btn-primary" href="#">clear</a>
       <a onClick="load()" class="btn btn-primary" href="#">load</a>
@@ -32,31 +40,52 @@
       <a onClick="cellHeight(75)" class="btn btn-primary" href="#">75</a>
       Widget:
       <a onClick="addWidget()" class="btn btn-primary" href="#">Add</a>
-      <a onClick="makeWidget()" class="btn btn-primary" href="#">Make</a>
+      <a onClick="makeWidget()" class="btn btn-primary" href="#">Make w:2</a>
+      <div class="sidebar inline">
+        <div class="grid-stack-item" gs-w="2" gs-h="3">
+          <div class="grid-stack-item-content"><div>Insert me 2x3</div></div>
+        </div>
+      </div>
     </div>
     <br>
-    <div class="grid-stack"></div>
+    <div id="grid1"></div>
+    <p>from DOM test:</p>
+    <div id="grid2">
+      <div class="grid-stack-item" gs-x="11" gs-y="0" gs-h="4">
+        <div class="grid-stack-item-content">
+          <div>DOM: h:4 sized down</div>
+        </div>
+      </div>
+    </div>
+
   </div>
   <script type="text/javascript">
-    let opts = {
-      margin: 5,
-      cellHeight: 50,
-      sizeToContent: true, // default to make them all fit
-      resizable: { handles: 'all'} // do all sides for testing
-      // cellHeightThrottle: 100, // ms before sizeToContent happens
-    }
-    let grid = GridStack.init(opts);
     let text ='some very large content that will normally not fit in the window.'
     text = text + text;
     let count = 0;
     let items = [
+      // {x:0, y:0, w:2, h:3, sizeToContent: false, content: `<div>A no h: ${text}</div>`},
       {x:0, y:0, w:2, content: `<div>A no h: ${text}</div>`},
       {x:2, y:0, w:1, h:2, content: '<div>B: shrink h=2</div>'}, // make taller than needed upfront
       {x:3, y:0, w:2, sizeToContent: false, content: `<div>C: WILL SCROLL. ${text}</div>`}, // prevent this from fitting testing
       {x:0, y:1, w:3, content: `<div>D no h: ${text} ${text}</div>`},
-      {x:3, y:1, w:2, sizeToContent:3, content: `<div>E sizeToContent=3 <button onClick="more()">more</button><button onClick="less()">less</button><div id="dynContent">${text} ${text} ${text}</div></div>`}    ];
+      {x:3, y:1, w:2, sizeToContent:3, content: `<div>E sizeToContent=3 <button onClick="more()">more</button><button onClick="less()">less</button><div id="dynContent">${text} ${text} ${text}</div></div>`},
+    ];
     items.forEach(n => n.id = String(count++));
-    grid.load(items);
+    let opts = {
+      margin: 5,
+      cellHeight: 50,
+      sizeToContent: true, // default to make them all fit
+      resizable: { handles: 'all'}, // do all sides for testing
+      acceptWidgets: true,
+      // cellHeightThrottle: 100, // ms before sizeToContent happens
+      // children: items, // test loading first
+    }
+    let grid = GridStack.init(opts, '#grid1');
+    grid.load(items); // test loading after
+    GridStack.init({...opts, children:undefined}, '#grid2');
+
+    GridStack.setupDragIn('.sidebar .grid-stack-item', { appendTo: 'body', helper: 'clone' });
 
     function clearGrid() {
       grid.removeAll();
@@ -78,7 +107,7 @@
       doc.body.innerHTML = `<div class="item"><div class="grid-stack-item-content"><div>New Make: ${text}</div></div></div>`;
       let el = doc.body.children[0];
       grid.el.appendChild(el);
-      grid.makeWidget(el);
+      grid.makeWidget(el, {w:2});
     }
     function more() {
       let cont = document.getElementById('dynContent');

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [10.0.0-dev (TBD)](#1000-dev-tbd)
 - [10.0.0 (2023-11-20)](#1000-2023-11-20)
 - [9.5.1 (2023-11-11)](#951-2023-11-11)
 - [9.5.0 (2023-10-26)](#950-2023-10-26)
@@ -105,13 +106,20 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 10.0.0-dev (TBD)
+* fix: [#2552](https://github.com/gridstack/gridstack.js/issues/2552) DOM init doesn't sizeToContent
+* fix: issues with sizeToContent and animation, cleanup, etc...
+* fix: [#2558](https://github.com/gridstack/gridstack.js/pull/2558) remove style node in shadow root
+* fix: [#2556](https://github.com/gridstack/gridstack.js/pull/2556) make sure 'new GridStack(el)' set el.gridstack=this right away
+* cleanup: [#2550](https://github.com/gridstack/gridstack.js/pull/2550) Optimize resize arrow (~88% lighter from 1.82 KB to 225B)
+
 ## 10.0.0 (2023-11-20)
 * feat [#2542](https://github.com/gridstack/gridstack.js/pull/2542) we now support much richer responsive behavior with `GridStackOptions.columnOpts` including any breakpoint width:column pairs, or automatic column sizing. 
 * `disableOneColumnMode`, `oneColumnSize`, `oneColumnModeDomSort` have been removed (see v10 migration doc)
 
 ## 9.5.1 (2023-11-11)
 * fix [#2525](https://github.com/gridstack/gridstack.js/commit/2525) Fixed unhandled exception happening in _mouseMove handler
-* fix potential crash in doContentResize() if grid gets deleted by the time the delay happens
+* fix potential crash in resizeToContentCheck() if grid gets deleted by the time the delay happens
 * fix [#2527](https://github.com/gridstack/gridstack.js/issues/2527) Incorrect layout on grid load in one column mode
 * fix [#2496](https://github.com/gridstack/gridstack.js/issues/2496) animation on init, introduced in 8.1.1
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -53,7 +53,7 @@ gridstack.js API
   - [`isAreaEmpty(x, y, width, height)`](#isareaemptyx-y-width-height)
   - [`load(layout: GridStackWidget[], boolean | ((w: GridStackWidget, add: boolean) => void)  = true)`](#loadlayout-gridstackwidget-boolean--w-gridstackwidget-add-boolean--void---true)
   - [`makeWidget(el)`](#makewidgetel)
-  - [`makeSubgrid(el)`](#makesubgridel)
+  - [`makeSubGrid(el)`](#makesubgridel)
   - [`margin(value: numberOrString)`](#marginvalue-numberorstring)
   - [`movable(el, val)`](#movableel-val)
   - [`removeWidget(el, removeDOM = true, triggerEvent = true)`](#removewidgetel-removedom--true-triggerevent--true)

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type AddRemoveFcn = (parent: HTMLElement, w: GridStackWidget, add: boolea
 /** optional function called during save() to let the caller add additional custom data to the GridStackWidget structure that will get returned */
 export type SaveFcn = (node: GridStackNode, w: GridStackWidget) => void;
 
-export type ResizeToContentFcn = (el: GridItemHTMLElement, useAttr?: boolean) => void;
+export type ResizeToContentFcn = (el: GridItemHTMLElement) => void;
 
 /** describes the responsive nature of the grid */
 export interface Responsive {


### PR DESCRIPTION
### Description
* fix #2552 where dom init wasn't calling sizeToContent

Also:
* fixed drag&drop not calling size either
* prevent animation when loading (from empty) and when replacing placeholder with actual content (helps in sizeToContent)
* resizeToContent() no longer use dic sizing (only node.h) so we rarely have to delay for animation (only when column widget changes)
* bunch of renames (internal) to make cleaner.

*** POSSIBLE BREAK (unlikely)
* ResizeToContentFcn doesn't take optional useAttr arg anymore

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
