### PR TITLE
more sizeToContent fixes

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -108,7 +108,7 @@ Change log
 
 ## 10.0.0-dev (TBD)
 * fix: [#2552](https://github.com/gridstack/gridstack.js/issues/2552) DOM init doesn't sizeToContent
-* fix: issues with sizeToContent and animation, cleanup, etc...
+* fix: [#2561](https://github.com/gridstack/gridstack.js/pull/2561) issues with sizeToContent animation, cleanup, etc...
 * fix: [#2558](https://github.com/gridstack/gridstack.js/pull/2558) remove style node in shadow root
 * fix: [#2556](https://github.com/gridstack/gridstack.js/pull/2556) make sure 'new GridStack(el)' set el.gridstack=this right away
 * cleanup: [#2550](https://github.com/gridstack/gridstack.js/pull/2550) Optimize resize arrow (~88% lighter from 1.82 KB to 225B)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2224,6 +2224,7 @@ export class GridStack {
           if (!subGrid.opts.styleInHead) subGrid._updateStyles(true); // re-create sub-grid styles now that we've moved
         }
         this._updateContainerHeight();
+        this.engine.addedNodes.push(node);// @ts-ignore
         this._triggerAddEvent();// @ts-ignore
         this._triggerChangeEvent();
 


### PR DESCRIPTION
### Description
* tweak to #2561
* drap&drop not having added element)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
