### PR TITLE
Fix quickly drag elements between nested blocks

### DIFF
--- a/src/dd-droppable.ts
+++ b/src/dd-droppable.ts
@@ -94,7 +94,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
 
     // make sure when we enter this, that the last one gets a leave FIRST to correctly cleanup as we don't always do
     if (DDManager.dropElement && DDManager.dropElement !== this) {
-      DDManager.dropElement._mouseLeave(e as DragEvent);
+      DDManager.dropElement._mouseLeave(e as DragEvent, true);
     }
     DDManager.dropElement = this;
 
@@ -108,7 +108,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
   }
 
   /** @internal called when the item is leaving our area, stop tracking if we had moving item */
-  protected _mouseLeave(e: MouseEvent): void {
+  protected _mouseLeave(e: MouseEvent, external = false): void {
     // console.log(`${count++} Leave ${this.el.id || (this.el as GridHTMLElement).gridstack.opts.id}`); // TEST
     if (!DDManager.dragElement || DDManager.dropElement !== this) return;
     e.preventDefault();
@@ -120,7 +120,7 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
     }
     this.triggerEvent('dropout', ev);
 
-    if (DDManager.dropElement === this) {
+    if (!external && DDManager.dropElement === this) {
       delete DDManager.dropElement;
       // console.log('not tracking'); // TEST
 

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2111,14 +2111,18 @@ export class GridStack {
         if (!node) {
           node = this._readAttr(el, false); // don't wipe external (e.g. drag toolbar) attr #2354
         }
-
+        if (!node.grid) {
+          node._isExternal = true;
+          el.gridstackNode = node;
+        }
+        
         // calculate the grid size based on element outer size
         helper = helper || el;
         let w = node.w || Math.round(helper.offsetWidth / cellWidth) || 1;
         let h = node.h || Math.round(helper.offsetHeight / cellHeight) || 1;
 
         // if the item came from another grid, make a copy and save the original info in case we go back there
-        if (node.grid !== this) {
+        if (node.grid && node.grid !== this) {
         // copy the node original values (min/max/id/etc...) but override width/height/other flags which are this grid specific
         // console.log('dropover cloning node'); // TEST
           if (!el._gridstackNodeOrig) el._gridstackNodeOrig = node; // shouldn't have multiple nested!

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2526,6 +2526,7 @@ export class GridStack {
     } else if (node._isExternal) {
       // item came from outside (like a toolbar) so nuke any node info
       delete node.el;
+      delete el.gridstackNode;
       // and restore all nodes back to original
       this.engine.restoreInitial();
     }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2115,7 +2115,7 @@ export class GridStack {
           node._isExternal = true;
           el.gridstackNode = node;
         }
-        
+
         // calculate the grid size based on element outer size
         helper = helper || el;
         let w = node.w || Math.round(helper.offsetWidth / cellWidth) || 1;

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2111,10 +2111,6 @@ export class GridStack {
         if (!node) {
           node = this._readAttr(el, false); // don't wipe external (e.g. drag toolbar) attr #2354
         }
-        if (!node.grid) {
-          node._isExternal = true;
-          el.gridstackNode = node;
-        }
 
         // calculate the grid size based on element outer size
         helper = helper || el;
@@ -2122,7 +2118,7 @@ export class GridStack {
         let h = node.h || Math.round(helper.offsetHeight / cellHeight) || 1;
 
         // if the item came from another grid, make a copy and save the original info in case we go back there
-        if (node.grid && node.grid !== this) {
+        if (node.grid !== this) {
         // copy the node original values (min/max/id/etc...) but override width/height/other flags which are this grid specific
         // console.log('dropover cloning node'); // TEST
           if (!el._gridstackNodeOrig) el._gridstackNodeOrig = node; // shouldn't have multiple nested!
@@ -2530,7 +2526,6 @@ export class GridStack {
     } else if (node._isExternal) {
       // item came from outside (like a toolbar) so nuke any node info
       delete node.el;
-      delete el.gridstackNode;
       // and restore all nodes back to original
       this.engine.restoreInitial();
     }


### PR DESCRIPTION
### Description
If you quickly drag elements between nested blocks, duplicates of the same element appear.
