### PR TITLE
column('none') now ignores layouts

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -110,6 +110,7 @@ Change log
 ## 10.0.1-dev (TBD)
 * feat: [#2574](https://github.com/gridstack/gridstack.js/pull/2574) Allow cell height in cm and mm units
 * fix: [#2577](https://github.com/gridstack/gridstack.js/issues/2577) ui-resizable-s/-n style fix
+* fix: [#2578](https://github.com/gridstack/gridstack.js/issues/2578) column('none') now ignores layouts
 
 ## 10.0.1 (2023-12-10)
 * fix: [#2552](https://github.com/gridstack/gridstack.js/issues/2552) DOM init doesn't sizeToContent

--- a/spec/e2e/html/2576_insert_column_shift_content.html
+++ b/spec/e2e/html/2576_insert_column_shift_content.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Column insert bug #2578</title>
+  <link rel="stylesheet" href="../../../demo/demo.css" />
+  <script src="../../../dist/gridstack-all.js"></script>
+  <link rel="stylesheet" href="../../../dist/gridstack-extra.css"/>
+</head>
+
+<body>
+  <button onClick="addColAtIndex(0)">Add column 0</button>
+  <button onClick="removeColAtIndex(0)">Remove column 0</button>
+  <div class="grid-stack"></div>
+  </div>
+  <script type="text/javascript">
+    var items = [
+      { content: 'Item 1', x: 0, y: 0 },
+      { content: 'Item 2', x: 1, y: 0 },
+      { content: 'Item 3', x: 2, y: 2 },
+    ];
+    var options = { float: true, column: 3, row: 3, cellHeight: 50, children: items};
+
+    var grid = GridStack.init(options);
+
+    const addColAtIndex = (colIndex) => {
+      grid.column(grid.getColumn() + 1, 'none');
+      grid.engine.nodes.filter(n => n.x >= colIndex).sort((a, b) => b.x - a.x).forEach(n =>
+        grid.update(n.el, {x: n.x+1})
+      )
+    };
+
+    const removeColAtIndex = (colIndex) => {
+      grid.engine.nodes.filter(n => n.x >= colIndex).sort((a, b) => a.x - b.x).forEach(n => {
+        if (n.x) grid.update(n.el, {x: n.x-1})
+      })
+      grid.column(grid.getColumn() - 1, 'none')
+    };
+
+    addColAtIndex(0)
+    addColAtIndex(0)
+    removeColAtIndex(0)
+    removeColAtIndex(0)
+    addColAtIndex(0)
+    addColAtIndex(0)
+  </script>
+</body>
+
+</html>

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -954,7 +954,7 @@ export class GridStack {
     // update the items now, checking if we have a custom children layout
     /*const newChildren = this.opts.columnOpts?.breakpoints?.find(r => r.c === column)?.children;
     if (newChildren) this.load(newChildren);
-    else*/ this.engine.columnChanged(oldColumn, column, undefined, layout);
+    else*/ this.engine.columnChanged(oldColumn, column, layout);
     if (this._isAutoCellHeight) this.cellHeight();
 
     this.resizeToContentCheck(true); // wait for width resizing


### PR DESCRIPTION

### Description
* fix #2578 column('none') now ignores layouts

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
