### PR TITLE
Set dimensions on resize arrow SVG

### DIFF
--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -70,7 +70,7 @@ $animation_speed: .3s !default;
   > .ui-resizable-nw,
   > .ui-resizable-se,
   > .ui-resizable-sw {
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%23666" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m8 1 2 2H6l2-2v14l-2-2h4l-2 2"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%23666" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" width="16" height="16" viewBox="0 0 16 16"><path d="m8 1 2 2H6l2-2v14l-2-2h4l-2 2"/></svg>');
     background-repeat: no-repeat;
     background-position: center;
   }


### PR DESCRIPTION
### Description
Improves scaling in browser. Proposed in https://github.com/gridstack/gridstack.js/pull/2550#issuecomment-1875794188. Fixes minor regression in #2550.

Before #2550:
![Screenshot 2024-01-03 at 13 20 41](https://github.com/gridstack/gridstack.js/assets/117094633/1e9c4641-3984-40c2-947f-cd52860ecf93)
After #2550 and before this change:
![Screenshot 2024-01-03 at 13 20 54](https://github.com/gridstack/gridstack.js/assets/117094633/84378d0c-9293-474a-8bd1-8d384f56102c)
After this change:
![Screenshot 2024-01-03 at 13 26 53](https://github.com/gridstack/gridstack.js/assets/117094633/5eef33e9-dd8f-4df0-b585-77f3584cb700)

### Checklist
- [n/a] Created tests which fail without the change (if possible)
- [n/a] All tests passing (`yarn test`)
- [n/a] Extended the README / documentation, if necessary
