### PR TITLE
🍱 fix blurry resize arrow

### DIFF
--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -70,7 +70,7 @@ $animation_speed: .3s !default;
   > .ui-resizable-nw,
   > .ui-resizable-se,
   > .ui-resizable-sw {
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%23666" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m8 1 2 2H6l2-2v14l-2-2h4l-2 2"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%23666" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 20 20"><path d="m10 3 2 2H8l2-2v14l-2-2h4l-2 2"/></svg>');
     background-repeat: no-repeat;
     background-position: center;
   }


### PR DESCRIPTION
### Description

Update SVG to take `2px` padding into consideration (20x20 container for a 16x16 SVG).