### PR TITLE
restrict vertical resize with sizeToContent

### DIFF
--- a/src/dd-gridstack.ts
+++ b/src/dd-gridstack.ts
@@ -40,9 +40,18 @@ export class DDGridStack {
       } else if (opts === 'option') {
         dEl.setupResizable({ [key]: value });
       } else {
-        const grid = dEl.el.gridstackNode.grid;
-        let handles = dEl.el.getAttribute('gs-resize-handles') ? dEl.el.getAttribute('gs-resize-handles') : grid.opts.resizable.handles;
-        let autoHide = !grid.opts.alwaysShowResizeHandle;
+        const n = dEl.el.gridstackNode;
+        const grid = n.grid;
+        let handles = dEl.el.getAttribute('gs-resize-handles') || grid.opts.resizable.handles || 'e,s,se';
+        if (handles === 'all') handles = 'n,e,s,w,se,sw,ne,nw';
+        // NOTE: keep the resize handles as e,w don't have enough space (10px) to show resize corners anyway. limit during drag instead
+        // restrict vertical resize if height is done to match content anyway... odd to have it spring back
+        // if (Utils.shouldSizeToContent(n)) {
+        //   const doE = handles.indexOf('e') !== -1;
+        //   const doW = handles.indexOf('w') !== -1;
+        //   handles = doE ? (doW ? 'e,w' : 'e') : (doW ? 'w' : '');
+        // }
+        const autoHide = !grid.opts.alwaysShowResizeHandle;
         dEl.setupResizable({
           ...grid.opts.resizable,
           ...{ handles, autoHide },


### PR DESCRIPTION
### Description
* since sizeToContent:true will automatically size the content vertically, don't let the user change the height to start with

Note: tried to change the feedback to have e,w arrows but we only have 10px area which is too narrow to show feedback (we have 20x20 for corners that may overlap content which is ok). Showing normal handles for now.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
