### PR TITLE
fix issue on failed drag makes the whole grid unresponsive

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2251,8 +2251,8 @@ export class GridStack {
         if (wasAdded) {
           this.engine.cleanupNode(node); // removes all internal _xyz values
           node.grid = this;
+          delete node.grid._isTemp;
         }
-        delete node.grid._isTemp;
         dd.off(el, 'drag');
         // if we made a copy ('helper' which is temp) of the original node then insert a copy, else we move the original node (#1102)
         // as the helper will be nuked by jquery-ui otherwise. TODO: update old code path

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,9 +111,9 @@ export class Utils {
 
   /** true if we should resize to content. strict=true when only 'sizeToContent:true' and not a number which lets user adjust */
   static shouldSizeToContent(n: GridStackNode | undefined, strict = false): boolean {
-    return n?.grid && (strict ? 
-    (n.sizeToContent === true || (n.grid.opts.sizeToContent === true && n.sizeToContent === undefined)) :
-    (!!n.sizeToContent || (n.grid.opts.sizeToContent && n.sizeToContent !== false)));
+    return n?.grid && (strict ?
+      (n.sizeToContent === true || (n.grid.opts.sizeToContent === true && n.sizeToContent === undefined)) :
+      (!!n.sizeToContent || (n.grid.opts.sizeToContent && n.sizeToContent !== false)));
   }
 
   /** returns true if a and b overlap */


### PR DESCRIPTION
### Description
![Screenshot 2024-05-02 at 09 16 45](https://github.com/gridstack/gridstack.js/assets/36124005/fe147c2c-b0fe-4083-a657-81d6f459a3ac)
when we drag a widget and fail, it will throw the above error and make all the whole grid unresponsive

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
