### PR TITLE
fix(save): don't remove w or h

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -326,8 +326,6 @@ export class Utils {
     if (!n.noResize) delete n.noResize;
     if (!n.noMove) delete n.noMove;
     if (!n.locked) delete n.locked;
-    if (n.w === 1 || n.w === n.minW) delete n.w;
-    if (n.h === 1 || n.h === n.minH) delete n.h;
   }
 
   /** return the closest parent (or itself) matching the given class */


### PR DESCRIPTION
### Description
GridStack freezes the browser when trying to call `.load()` with one of these values missing. This prevents instances where `.save()` drops a value ex `h`, and subsequently calling `.load()` freezes the browser.
