### PR TITLE
'Esc' to cancel drag/resize, 'r' to rotate drag

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -18,6 +18,8 @@
 <body>
   <div class="container-fluid">
     <h1>Two grids demo</h1>
+    <p>Two grids, one floating one not, showing drag&drop from sidebar and between grids.
+    <br>New v10.2: use 'Esc' to cancel any move/resize. Use 'r' to rotate as you drag.</p>
 
     <div class="row">
       <div class="col-md-3">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -110,6 +110,7 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## 10.1.2-dev (TBD)
+* feat: [#2682](https://github.com/gridstack/gridstack.js/pull/2682) You can now press 'Esc' to cancel a move|resize, 'r' to rotate during a drag. added `GridStack.rotate()` as well - Thank you John B. for this feature sponsor.
 * fix: [#2672](https://github.com/gridstack/gridstack.js/pull/2672) dropping into full grid JS error
 * fix: [#2676](https://github.com/gridstack/gridstack.js/issues/2676) handle minW resizing when column count is less
 * fix: [#2677](https://github.com/gridstack/gridstack.js/issues/2677) allow button as handle dragging

--- a/doc/README.md
+++ b/doc/README.md
@@ -60,6 +60,7 @@ gridstack.js API
   - [`removeAll(removeDOM = true)`](#removeallremovedom--true)
   - [`resizable(el, val)`](#resizableel-val)
   - [`resizeToContent(el: GridItemHTMLElement, useAttrSize = false)`](#resizetocontentel-griditemhtmlelement-useattrsize--false)
+  - [`rotate(els: GridStackElement, relative?: Position)`](#rotateels-gridstackelement-relative-position)
   - [`save(saveContent = true, saveGridOpt = false): GridStackWidget[] | GridStackOptions`](#savesavecontent--true-savegridopt--false-gridstackwidget--gridstackoptions)
   - [`setAnimation(doAnimate)`](#setanimationdoanimate)
   - [`setStatic(staticValue)`](#setstaticstaticvalue)
@@ -582,6 +583,12 @@ Enables/Disables user resizing of specific grid element. If you want all items, 
 Updates widget height to match the content height to avoid v-scrollbar or dead space.
 Note: this assumes only 1 child under `resizeToContentParent='.grid-stack-item-content'` (sized to gridItem minus padding) that is at the entire content size wanted.
 - `useAttrSize` set to `true` if GridStackNode.h should be used instead of actual container height when we don't need to wait for animation to finish to get actual DOM heights
+
+### `rotate(els: GridStackElement, relative?: Position)`
+rotate (by swapping w & h) the passed in node - called when user press 'r' during dragging
+
+- `els` - widget or selector of objects to modify
+- `relative` - optional pixel coord relative to upper/left corner to rotate around (will keep that cell under cursor)
 
 ### `save(saveContent = true, saveGridOpt = false): GridStackWidget[] | GridStackOptions`
 


### PR DESCRIPTION
### Description
* You can now press 'Esc' to cancel a move|resize
* 'r' to rotate during a drag
* added `GridStack.rotate()` as well Thank you John B. for this feature sponsor

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
