### PR TITLE
Bugfix: prevent throwing error when node.grid is undefined (drag item from outside the grid)

### DIFF
--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -280,7 +280,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal call when keys are being pressed - use Esc to cancel, R to rotate */
   protected _keyEvent(e: KeyboardEvent): void {
     const n = this.el.gridstackNode as GridStackNodeRotate;
-    if (!n) return;
+    if (!n?.grid) return;
     const grid = n.grid;
 
     if (e.key === 'Escape') {


### PR DESCRIPTION
### Description
I added an extra nullcheck before performing the key event callback. If `n` or `n.grid` aren't defined then just `return`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
