### PR TITLE
prevent 'r' rotation to items that can't resize

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -112,6 +112,7 @@ Change log
 
 ## 10.2.0-dev (TBD)
 * fix: [#2683](https://github.com/gridstack/gridstack.js/issues/2683) check for fixed grid maxRow during resize
+* fix: [#2694](https://github.com/gridstack/gridstack.js/issues/2694) prevent 'r' rotation to items that can't resize (locked, noResize, fixed sizes)
 
 ## 10.2.0 (2024-06-02)
 * feat: [#2682](https://github.com/gridstack/gridstack.js/pull/2682) You can now press 'Esc' to cancel a move|resize, 'r' to rotate during a drag. added `GridStack.rotate()` as well - Thank you John B. for this feature sponsor.

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1450,7 +1450,7 @@ export class GridStack {
   public rotate(els: GridStackElement, relative?: Position): GridStack {
     GridStack.getElements(els).forEach(el => {
       let n = el.gridstackNode;
-      if (!n || n.w === n.h) return;
+      if (!n || n.w === n.h || n.locked || n.noResize || n.grid?.opts.disableResize || (n.minW && n.minW === n.maxW) || (n.minH && n.minH === n.maxH)) return;
       const rot: GridStackWidget = { w: n.h, h: n.w, minH: n.minW, minW: n.minH, maxH: n.maxW, maxW: n.maxH };
       // if given an offset, adjust x/y by column/row bounds when user presses 'r' during dragging
       if (relative) {


### PR DESCRIPTION
### Description
* fix #2694
* not tested as I don't have my dev machine right now

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
