### PR TITLE
prevent 'r' rotation to items that can't resize (2)

### DIFF
--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -291,7 +291,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
       grid.engine.restoreInitial();
       this._mouseUp(this.mouseDownEvent);
     } else if (e.key === 'r' || e.key === 'R') {
-      if (n.w === n.h) return;
+      if (!Utils.canBeRotated(n)) return;
       n._origRotate = n._origRotate || {...n._orig}; // store the real orig size in case we Esc after doing rotation
       delete n._moving; // force rotate to happen (move waits for >50% coverage otherwise)
       grid.setAnimation(false) // immediate rotate so _getDragOffset() gets the right dom size below

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1450,7 +1450,7 @@ export class GridStack {
   public rotate(els: GridStackElement, relative?: Position): GridStack {
     GridStack.getElements(els).forEach(el => {
       let n = el.gridstackNode;
-      if (!n || n.w === n.h || n.locked || n.noResize || n.grid?.opts.disableResize || (n.minW && n.minW === n.maxW) || (n.minH && n.minH === n.maxH)) return;
+      if (!Utils.canBeRotated(n)) return;
       const rot: GridStackWidget = { w: n.h, h: n.w, minH: n.minW, minW: n.minH, maxH: n.maxW, maxW: n.maxH };
       // if given an offset, adjust x/y by column/row bounds when user presses 'r' during dragging
       if (relative) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -604,4 +604,9 @@ export class Utils {
   //   }
   //   return el.contains(target);
   // }
+
+  /** true if the item can be rotated (checking for prop, not space available) */
+  public static canBeRotated(n: GridStackNode): boolean {
+    return !(!n || n.w === n.h || n.locked || n.noResize || n.grid?.opts.disableResize || (n.minW && n.minW === n.maxW) || (n.minH && n.minH === n.maxH));
+  }
 }


### PR DESCRIPTION
### Description
* fix #2694

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
