### PR TITLE
load() now creates in order

### DIFF
--- a/demo/two.html
+++ b/demo/two.html
@@ -73,11 +73,13 @@
 
     let items = [
       {x: 0, y: 0, w: 2, h: 2},
-      {x: 3, y: 1, h: 2},
-      {x: 4, y: 1},
-      {x: 2, y: 3, w: 3, maxW: 3, id: 'special', content: 'has maxW=3'},
+      {x: 1, y: 1, h: 2}, // intentional overlap to test collision on load
+      {x: 1, y: 1}, // intentional overlap to test collision on load
+      {x: 3, y: 1},
+      {x: 2, y: 3, w: 3, maxW: 3, content: 'has maxW=3'},
       {x: 2, y: 5}
     ];
+    items.forEach((item, i) => item.content = item.content || String(i));
 
     grids.forEach(function (grid, i) {
       addEvents(grid, i);

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [10.2.1-dev (TBD)](#1021-dev-tbd)
 - [10.2.1 (2024-06-23)](#1021-2024-06-23)
 - [10.2.0 (2024-06-02)](#1020-2024-06-02)
 - [10.1.2 (2024-03-30)](#1012-2024-03-30)
@@ -110,6 +111,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 10.2.1-dev (TBD)
+* fix: [#2717](https://github.com/gridstack/gridstack.js/pull/2717) load() now creates in order
 
 ## 10.2.1 (2024-06-23)
 * fix: [#2683](https://github.com/gridstack/gridstack.js/issues/2683) check for fixed grid maxRow during resize


### PR DESCRIPTION
### Description
* changed code to create widgets in sorted order instead of reverse order (fixed collision code to handle that case to push down items during collision)
* updated two.html to force collision loading to test

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
