### PR TITLE
resizeToContent JS error with nested grid

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -115,6 +115,7 @@ Change log
 
 ## 10.3.0-dev (TBD)
 * fix: [#2734](https://github.com/gridstack/gridstack.js/bug/2734) rotate() JS error
+* fix: [#2739](https://github.com/gridstack/gridstack.js/pull/2739) resizeToContent JS error with nested grid
 
 ## 10.3.0 (2024-06-26)
 * fix: [#2720](https://github.com/gridstack/gridstack.js/pull/2720) load() now creates widgets in order (used to be reverse due to old collision code)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1401,10 +1401,16 @@ export class GridStack {
     if (n.subGrid) {
       // sub-grid - use their actual row count * their cell height
       wantedH = n.subGrid.getRow() * n.subGrid.getCellHeight(true);
+    } else if (n.subGridOpts?.children?.length) {
+      // not sub-grid just yet (case above) wait until we do
+      return;
     } else {
       // NOTE: clientHeight & getBoundingClientRect() is undefined for text and other leaf nodes. use <div> container!
       const child = item.firstElementChild;
-      if (!child) { console.error(`Error: GridStack.resizeToContent() widget id:${n.id} '${GridStack.resizeToContentParent}'.firstElementChild is null, make sure to have a div like container. Skipping sizing.`); return; }
+      if (!child) {
+        console.error(`Error: GridStack.resizeToContent() widget id:${n.id} '${GridStack.resizeToContentParent}'.firstElementChild is null, make sure to have a div like container. Skipping sizing.`);
+        return;
+      }
       wantedH = child.getBoundingClientRect().height || itemH;
     }
     if (itemH === wantedH) return;


### PR DESCRIPTION
### Description
resizeToContent JS error with nested grid

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
