### PR TITLE
nested grid drag fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -115,7 +115,8 @@ Change log
 
 ## 10.3.0-dev (TBD)
 * fix: [#2734](https://github.com/gridstack/gridstack.js/bug/2734) rotate() JS error
-* fix: [#2739](https://github.com/gridstack/gridstack.js/pull/2739) resizeToContent JS error with nested grid
+* fix: [#2741](https://github.com/gridstack/gridstack.js/pull/2741) resizeToContent JS error with nested grid
+* fix: [#2740](https://github.com/gridstack/gridstack.js/bug/2740) nested grid drag fix
 
 ## 10.3.0 (2024-06-26)
 * fix: [#2720](https://github.com/gridstack/gridstack.js/pull/2720) load() now creates widgets in order (used to be reverse due to old collision code)

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -79,8 +79,9 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     super();
 
     // get the element that is actually supposed to be dragged by
-    let handleName = option.handle.substring(1);
-    this.dragEls = el.classList.contains(handleName) ? [el] : Array.from(el.querySelectorAll(option.handle));
+    const handleName = option.handle.substring(1);
+    const n = el.gridstackNode;
+    this.dragEls = el.classList.contains(handleName) ? [el] : (n?.subGrid ? [el.querySelector(option.handle) || el] : Array.from(el.querySelectorAll(option.handle)));
     if (this.dragEls.length === 0) {
       this.dragEls = [el];
     }


### PR DESCRIPTION
### Description
* fix #2740
* make sure we don't look for all draggable items when we're a nested grid, only first (grid-content)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
