### PR TITLE
Support gridstack element node reparenting without losing the stylesheets

### DIFF
--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1934,4 +1934,24 @@ describe('gridstack', function() {
     });
     */
   });
+
+  describe('stylesheet', function() {
+    let grid: GridStack;
+    let root: HTMLElement;
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
+      grid = GridStack.init({ cellHeight: 30 });
+      root = document.getElementById('gs-cont')!;
+    });
+    afterEach(function() {
+      document.body.removeChild(root);
+    });
+    it('not getting lost in case of node detach/attach', function() {
+      expect(window.getComputedStyle(grid.el.querySelector("#item1")!).height).toBe("60px");
+      const oldParent = root.parentElement;
+      root.remove();
+      oldParent!.appendChild(root);
+      expect(window.getComputedStyle(grid.el.querySelector("#item1")!).height).toBe("60px");
+    });
+  });
 });

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -51,7 +51,7 @@ export interface CellPosition {
   y: number;
 }
 
-interface GridCSSStyleSheet extends CSSStyleSheet {
+interface GridHTMLStyleElement extends HTMLStyleElement {
   _max?: number; // internal tracker of the max # of rows we created
 }
 
@@ -248,7 +248,7 @@ export class GridStack {
   /** @internal */
   public _gsEventHandler = {};
   /** @internal */
-  protected _styles: GridCSSStyleSheet;
+  protected _styles: GridHTMLStyleElement;
   /** @internal flag to keep cells square during resize */
   protected _isAutoCellHeight: boolean;
   /** @internal limit auto cell resizing method */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,7 +196,7 @@ export class Utils {
    * @param parent to insert the stylesheet as first child,
    * if none supplied it will be appended to the document head instead.
    */
-  static createStylesheet(id: string, parent?: HTMLElement, options?: { nonce?: string }): CSSStyleSheet {
+  static createStylesheet(id: string, parent?: HTMLElement, options?: { nonce?: string }): HTMLStyleElement {
     const style: HTMLStyleElement = document.createElement('style');
     const nonce = options?.nonce
     if (nonce) style.nonce = nonce
@@ -216,7 +216,7 @@ export class Utils {
     } else {
       parent.insertBefore(style, parent.firstChild);
     }
-    return style.sheet as CSSStyleSheet;
+    return style;
   }
 
   /** removed the given stylesheet id */
@@ -227,12 +227,10 @@ export class Utils {
   }
 
   /** inserts a CSS rule */
-  static addCSSRule(sheet: CSSStyleSheet, selector: string, rules: string): void {
-    if (typeof sheet.addRule === 'function') {
-      sheet.addRule(selector, rules);
-    } else if (typeof sheet.insertRule === 'function') {
-      sheet.insertRule(`${selector}{${rules}}`);
-    }
+  static addCSSRule(sheet: HTMLStyleElement, selector: string, rules: string): void {
+    // Rather than using sheet.insertRule, use text since it supports 
+    // gridstack node reparenting around in the DOM
+    sheet.textContent += `${selector} { ${rules} } `;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### Description

The current implementation of gridstack styling is based on a <style> node appended in the parent `div`. However this element doesn't contain any CSS text content: his `style` content is rather manipulated as a `CSSStyleSheet` object.

This works fine unless the parent `div` is detached from the document, and then reattached. This operation can be common if gridstack containers are hosted in some type of high-level container (like tabs) that supports reorder.

It seems that the issue is somewhat related to the fact the `CSSStyleSheet` instance depends on the parent DOM context. So, when detached, the style content is reset.

Using CSS as text rather than opaque style object fixes the issue.

Probably the best approach to leverage `CSSStyleSheet` objects is to switch to HTML Custom Elements and Shadow DOM.

### Checklist
- [X] Created tests which fail without the change
- [ ] All tests passing (`yarn test`) (unfortunately the current code-base is in very bad shape).
- [ ] Extended the README / documentation, if necessary
