### PR TITLE
Removed dynamic stylesheet and migrated to CSS vars

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -126,7 +126,6 @@ GridStack will add it to the `<style>` elements it creates.
 - `row` - fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain)
 - `rtl` - if `true` turns grid to RTL. Possible values are `true`, `false`, `'auto'` (default: `'auto'`) See [example](https://gridstackjs.com/demo/right-to-left(rtl).html)
 - `staticGrid` - removes drag|drop|resize (default `false`). If `true` widgets are not movable/resizable by the user, but code can still move and oneColumnMode will still work. You can use the smaller gridstack-static.js lib. A CSS class `grid-stack-static` is also added to the container.
-- `styleInHead` - if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`).
 
 ### Responsive
 v10.x supports a much richer responsive behavior, you can have breakpoints of width:column, or auto column sizing,  where no code is longer needed.

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1361,35 +1361,7 @@ describe('gridstack', function() {
       let grid = GridStack.init(options);
       expect(grid.el.classList.contains('grid-stack-rtl')).toBe(false);
     });
-  });
-  
-  describe('grid.opts.styleInHead', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should not add STYLE to parent node', function() {
-      const options = {
-        cellHeight: 80,
-        verticalMargin: 10,
-        float: false,
-      };
-      GridStack.init(options);
-      expect(document.querySelector("style")).toBe(null);
-    });
-    it('should not add STYLE to HEAD if styleInHead === true', function() {
-      const options = {
-        cellHeight: 80,
-        verticalMargin: 10,
-        float: false,
-        styleInHead: true
-      };
-      GridStack.init(options);
-      expect(document.querySelector("style")).toBe(null);
-    });
-  });
+  }); 
 
   describe('grid.enableMove', function() {
     beforeEach(function() {

--- a/spec/gridstack-spec.ts
+++ b/spec/gridstack-spec.ts
@@ -1370,41 +1370,24 @@ describe('gridstack', function() {
     afterEach(function() {
       document.body.removeChild(document.getElementById('gs-cont'));
     });
-    it('should add STYLE to parent node as a default', function() {
-      var options = {
+    it('should not add STYLE to parent node', function() {
+      const options = {
         cellHeight: 80,
         verticalMargin: 10,
         float: false,
       };
-      var grid = GridStack.init(options);
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('DIV'); // any to access private _styles
+      GridStack.init(options);
+      expect(document.querySelector("style")).toBe(null);
     });
-    it('should add STYLE to HEAD if styleInHead === true', function() {
-      var options = {
+    it('should not add STYLE to HEAD if styleInHead === true', function() {
+      const options = {
         cellHeight: 80,
         verticalMargin: 10,
         float: false,
         styleInHead: true
       };
-      var grid = GridStack.init(options);
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('HEAD'); // any to access private _styles
-    });
-  });
-
-  describe('grid.opts.styleInHead', function() {
-    beforeEach(function() {
-      document.body.insertAdjacentHTML('afterbegin', gridstackHTML);
-    });
-    afterEach(function() {
-      document.body.removeChild(document.getElementById('gs-cont'));
-    });
-    it('should add STYLE to parent node as a default', function() {
-      var grid = GridStack.init();
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('DIV');
-    });
-    it('should add STYLE to HEAD if styleInHead === true', function() {
-      var grid = GridStack.init({styleInHead: true});
-      expect((grid as any)._styles.ownerNode.parentNode.tagName).toBe('HEAD');
+      GridStack.init(options);
+      expect(document.querySelector("style")).toBe(null);
     });
   });
 

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -48,23 +48,6 @@ describe('gridstack utils', function() {
     });
   });
 
-  describe('test createStylesheet/removeStylesheet', function() {
-
-    it('should create/remove style DOM', function() {
-      let _id = 'test-123';
-      Utils.createStylesheet(_id);
-
-      let style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
-      expect(style).not.toBe(null);
-      // expect(style.prop('tagName')).toEqual('STYLE');
-
-      Utils.removeStylesheet(_id)
-      style = document.querySelector('STYLE[gs-style-id=' + _id + ']');
-      expect(style).toBe(null);
-    });
-
-  });
-
   describe('test parseHeight', function() {
 
     it('should parse height value', function() {

--- a/src/dd-resizable.ts
+++ b/src/dd-resizable.ts
@@ -201,12 +201,13 @@ export class DDResizable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal */
   protected _resizeStop(event: MouseEvent): DDResizable {
     const ev = Utils.initEvent<MouseEvent>(event, { type: 'resizestop', target: this.el });
+    // Remove style attr now, so the stop handler can rebuild style attrs
+    this._cleanHelper();
     if (this.option.stop) {
       this.option.stop(ev); // Note: ui() not used by gridstack so don't pass
     }
     this.el.classList.remove('ui-resizable-resizing');
     this.triggerEvent('resizestop', ev);
-    this._cleanHelper();
     delete this.startEvent;
     delete this.originalRect;
     delete this.temporalRect;

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -52,6 +52,8 @@ $animation_speed: .3s !default;
   &.size-to-content:not(.size-to-content-max) > .grid-stack-item-content {
     overflow-y: hidden;
   }
+
+  height: var(--gs-cell-height);
 }
 
 .grid-stack-item {
@@ -98,6 +100,19 @@ $animation_speed: .3s !default;
   > .ui-resizable-sw { cursor: sw-resize; width: 20px; height: 20px;}
   > .ui-resizable-w  { cursor: w-resize;  width: 10px; top: 15px; bottom: 15px; }
 
+  > .ui-resizable-n {
+    top: var(--gs-item-margin-top);
+  }
+  > .ui-resizable-s, > .ui-resizable-se, > .ui-resizable-sw {
+    bottom: var(--gs-item-margin-bottom);
+  }
+  > .ui-resizable-ne, > .ui-resizable-e, > .ui-resizable-se {
+    right: var(--gs-item-margin-right);
+  }
+  > .ui-resizable-nw, > .ui-resizable-w, > .ui-resizable-sw {
+    left: var(--gs-item-margin-left);
+  }
+  
   &.ui-draggable-dragging {
     &> .ui-resizable-handle {
       display: none !important;
@@ -156,47 +171,12 @@ $animation_speed: .3s !default;
   width: 100%;
 }
 
-.grid-stack > .grid-stack-item {
-  height: var(--gs-cell-height);
+.grid-stack {
+  > .grid-stack-item > .grid-stack-item-content, > .grid-stack-placeholder > .placeholder-content {
+    top: var(--gs-item-margin-top);
+    right: var(--gs-item-margin-right);
+    bottom: var(--gs-item-margin-bottom);
+    left: var(--gs-item-margin-left);
+  }
 }
 
-.grid-stack > .grid-stack-item > .grid-stack-item-content {
-  top: var(--gs-item-margin-top);
-  right: var(--gs-item-margin-right);
-  bottom: var(--gs-item-margin-bottom);
-  left: var(--gs-item-margin-left);
-}
-
-.grid-stack > .grid-stack-placeholder > .placeholder-content {
-  top: var(--gs-item-margin-top);
-  right: var(--gs-item-margin-right);
-  bottom: var(--gs-item-margin-bottom);
-  left: var(--gs-item-margin-left);
-}
-
-.grid-stack > .grid-stack-item > .ui-resizable-n {
-  top: var(--gs-item-margin-top);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-s {
-  bottom: var(--gs-item-margin-bottom);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-ne {
-  right: var(--gs-item-margin-right);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-e { 
-  right: var(--gs-item-margin-right);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-se {
-  right: var(--gs-item-margin-right);
-  bottom: var(--gs-item-margin-bottom);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-nw {
-  left: var(--gs-item-margin-left);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-w {
-  left: var(--gs-item-margin-left);
-}
-.grid-stack > .grid-stack-item > .ui-resizable-sw {
-  left: var(--gs-item-margin-left);
-  bottom: var(--gs-item-margin-bottom);
-}

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -155,3 +155,48 @@ $animation_speed: .3s !default;
 .gs-1 > .grid-stack-item {
   width: 100%;
 }
+
+.grid-stack > .grid-stack-item {
+  height: var(--gs-cell-height);
+}
+
+.grid-stack > .grid-stack-item > .grid-stack-item-content {
+  top: var(--gs-item-margin-top);
+  right: var(--gs-item-margin-right);
+  bottom: var(--gs-item-margin-bottom);
+  left: var(--gs-item-margin-left);
+}
+
+.grid-stack > .grid-stack-placeholder > .placeholder-content {
+  top: var(--gs-item-margin-top);
+  right: var(--gs-item-margin-right);
+  bottom: var(--gs-item-margin-bottom);
+  left: var(--gs-item-margin-left);
+}
+
+.grid-stack > .grid-stack-item > .ui-resizable-n {
+  top: var(--gs-item-margin-top);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-s {
+  bottom: var(--gs-item-margin-bottom);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-ne {
+  right: var(--gs-item-margin-right);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-e { 
+  right: var(--gs-item-margin-right);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-se {
+  right: var(--gs-item-margin-right);
+  bottom: var(--gs-item-margin-bottom);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-nw {
+  left: var(--gs-item-margin-left);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-w {
+  left: var(--gs-item-margin-left);
+}
+.grid-stack > .grid-stack-item > .ui-resizable-sw {
+  left: var(--gs-item-margin-left);
+  bottom: var(--gs-item-margin-bottom);
+}

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -41,6 +41,7 @@ $animation_speed: .3s !default;
 .grid-stack > .grid-stack-item {
   position: absolute;
   padding: 0;
+  height: var(--gs-cell-height);
 
   > .grid-stack-item-content {
     margin: 0;
@@ -52,8 +53,6 @@ $animation_speed: .3s !default;
   &.size-to-content:not(.size-to-content-max) > .grid-stack-item-content {
     overflow-y: hidden;
   }
-
-  height: var(--gs-cell-height);
 }
 
 .grid-stack-item {
@@ -103,13 +102,19 @@ $animation_speed: .3s !default;
   > .ui-resizable-n {
     top: var(--gs-item-margin-top);
   }
-  > .ui-resizable-s, > .ui-resizable-se, > .ui-resizable-sw {
+  > .ui-resizable-s
+  , > .ui-resizable-se
+  , > .ui-resizable-sw {
     bottom: var(--gs-item-margin-bottom);
   }
-  > .ui-resizable-ne, > .ui-resizable-e, > .ui-resizable-se {
+  > .ui-resizable-ne,
+  > .ui-resizable-e,
+  > .ui-resizable-se {
     right: var(--gs-item-margin-right);
   }
-  > .ui-resizable-nw, > .ui-resizable-w, > .ui-resizable-sw {
+  > .ui-resizable-nw,
+  > .ui-resizable-w,
+  > .ui-resizable-sw {
     left: var(--gs-item-margin-left);
   }
   
@@ -172,7 +177,8 @@ $animation_speed: .3s !default;
 }
 
 .grid-stack {
-  > .grid-stack-item > .grid-stack-item-content, > .grid-stack-placeholder > .placeholder-content {
+  > .grid-stack-item > .grid-stack-item-content, 
+  > .grid-stack-placeholder > .placeholder-content {
     top: var(--gs-item-margin-top);
     right: var(--gs-item-margin-right);
     bottom: var(--gs-item-margin-bottom);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1635,7 +1635,12 @@ export class GridStack {
     if ((!n._moving && !n._resizing) || this._placeholder === el) {
       // Set inline style, refer CSS variables
       el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
-      el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
+      if (n.h !== 1) {
+        el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
+      } else {
+        // height is set to --gs-cell-height by default
+        delete el.style.height;
+      }
     }
     return this;
   }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1556,12 +1556,12 @@ export class GridStack {
     }
 
     // Set CSS var of cell height
-    this.setVar(this.el.parentElement, "--gs-cell-height", `${this.opts.cellHeight}${this.opts.cellHeightUnit}`);
+    this.setVar(this.el, "--gs-cell-height", `${this.opts.cellHeight}${this.opts.cellHeightUnit}`);
     // content margins
-    this.setVar(this.el.parentElement, "--gs-item-margin-top", `${this.opts.marginTop}${this.opts.marginUnit}`);
-    this.setVar(this.el.parentElement, "--gs-item-margin-bottom", `${this.opts.marginBottom}${this.opts.marginUnit}`);
-    this.setVar(this.el.parentElement, "--gs-item-margin-right", `${this.opts.marginRight}${this.opts.marginUnit}`);
-    this.setVar(this.el.parentElement, "--gs-item-margin-left", `${this.opts.marginLeft}${this.opts.marginUnit}`);
+    this.setVar(this.el, "--gs-item-margin-top", `${this.opts.marginTop}${this.opts.marginUnit}`);
+    this.setVar(this.el, "--gs-item-margin-bottom", `${this.opts.marginBottom}${this.opts.marginUnit}`);
+    this.setVar(this.el, "--gs-item-margin-right", `${this.opts.marginRight}${this.opts.marginUnit}`);
+    this.setVar(this.el, "--gs-item-margin-left", `${this.opts.marginLeft}${this.opts.marginUnit}`);
 
     return this;
   }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1631,8 +1631,8 @@ export class GridStack {
     if (n.y !== undefined && n.y !== null) { el.setAttribute('gs-y', String(n.y)); }
     n.w > 1 ? el.setAttribute('gs-w', String(n.w)) : el.removeAttribute('gs-w');
     n.h > 1 ? el.setAttribute('gs-h', String(n.h)) : el.removeAttribute('gs-h');
-    // Avoid overwriting the inline style of the draggable element, but update the placeholder
-    if (!n._moving || this._placeholder === el) {
+    // Avoid overwriting the inline style of the element during drag/resize, but always update the placeholder
+    if ((!n._moving && !n._resizing) || this._placeholder === el) {
       // Set inline style, refer CSS variables
       el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
       el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
@@ -2349,6 +2349,7 @@ export class GridStack {
       const onEndMoving = (event: Event) => {
         this.placeholder.remove();
         delete node._moving;
+        delete node._resizing;
         delete node._event;
         delete node._lastTried;
         const widthChanged = node.w !== node._orig.w;
@@ -2447,7 +2448,8 @@ export class GridStack {
     node.el = this.placeholder;
     node._lastUiPosition = ui.position;
     node._prevYPix = ui.position.top;
-    node._moving = (event.type === 'dragstart' || event.type === 'resizestart'); // 'dropover' are not initially moving so they can go exactly where they enter (will push stuff out of the way)
+    node._moving = (event.type === 'dragstart'); // 'dropover' are not initially moving so they can go exactly where they enter (will push stuff out of the way)
+    node._resizing = (event.type === 'resizestart');
     delete node._lastTried;
 
     if (event.type === 'dropover' && node._temporaryRemoved) {

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -51,10 +51,6 @@ export interface CellPosition {
   y: number;
 }
 
-interface GridCSSStyleSheet extends CSSStyleSheet {
-  _max?: number; // internal tracker of the max # of rows we created
-}
-
 // extend with internal fields we need - TODO: move other items in here
 interface InternalGridStackOptions extends GridStackOptions {
   _alwaysShowResizeHandle?: true | false | 'mobile'; // so we can restore for save
@@ -247,8 +243,6 @@ export class GridStack {
   protected _ignoreLayoutsNodeChange: boolean;
   /** @internal */
   public _gsEventHandler = {};
-  /** @internal */
-  protected _styles: GridCSSStyleSheet;
   /** @internal flag to keep cells square during resize */
   protected _isAutoCellHeight: boolean;
   /** @internal limit auto cell resizing method */
@@ -395,8 +389,6 @@ export class GridStack {
       float: opts.float,
       maxRow: opts.maxRow,
       onChange: (cbNodes) => {
-        let maxH = 0;
-        this.engine.nodes.forEach(n => { maxH = Math.max(maxH, n.y + n.h) });
         cbNodes.forEach(n => {
           const el = n.el;
           if (!el) return;
@@ -407,12 +399,12 @@ export class GridStack {
             this._writePosAttr(el, n);
           }
         });
-        this._updateStyles(false, maxH); // false = don't recreate, just append if need be
+        this._updateStyles();
       }
     });
 
     // create initial global styles BEFORE loading children so resizeToContent margin can be calculated correctly
-    this._updateStyles(false, 0);
+    this._updateStyles();
 
     if (opts.auto) {
       this.batchUpdate(); // prevent in between re-layout #1535 TODO: this only set float=true, need to prevent collision check...
@@ -862,7 +854,7 @@ export class GridStack {
     this.resizeToContentCheck();
 
     if (update) {
-      this._updateStyles(true); // true = force re-create for current # of rows
+      this._updateStyles();
     }
     return this;
   }
@@ -979,7 +971,6 @@ export class GridStack {
     } else {
       this.el.parentNode.removeChild(this.el);
     }
-    this._removeStylesheet();
     if (this.parentGridNode) delete this.parentGridNode.subGrid;
     delete this.parentGridNode;
     delete this.opts;
@@ -1317,7 +1308,7 @@ export class GridStack {
           // restore any sub-grid back
           if (n.subGrid?.el) {
             itemContent.appendChild(n.subGrid.el);
-            if (!n.subGrid.opts.styleInHead) n.subGrid._updateStyles(true); // force create
+            n.subGrid._updateStyles();
           }
         }
         delete w.content;
@@ -1467,7 +1458,7 @@ export class GridStack {
     this.opts.marginTop = this.opts.marginBottom = this.opts.marginLeft = this.opts.marginRight = undefined;
     this._initMargin();
 
-    this._updateStyles(true); // true = force re-create
+    this._updateStyles();
 
     return this;
   }
@@ -1547,25 +1538,16 @@ export class GridStack {
     return this;
   }
 
-  /** @internal called to delete the current dynamic style sheet used for our layout */
-  protected _removeStylesheet(): GridStack {
-
-    if (this._styles) {
-      const styleLocation = this.opts.styleInHead ? undefined : this.el.parentNode as HTMLElement;
-      Utils.removeStylesheet(this._styleSheetClass, styleLocation);
-      delete this._styles;
-    }
-    return this;
+  private setVar(el: HTMLElement, varName: string, varValue: string) {
+    el.style.setProperty(varName, varValue);
   }
 
-  /** @internal updated/create the CSS styles for row based layout and initial margin setting */
-  protected _updateStyles(forceUpdate = false, maxH?: number): GridStack {
-    // call to delete existing one if we change cellHeight / margin
-    if (forceUpdate) {
-      this._removeStylesheet();
-    }
-
-    if (maxH === undefined) maxH = this.getRow();
+  /**
+   * Updates the CSS variables (used in CSS and inline style) for row based layout and initial margin setting,
+   * Variables are scoped in DOM so they works for nested grids as well
+   * @internal
+   */
+  protected _updateStyles(): GridStack {
     this._updateContainerHeight();
 
     // if user is telling us they will handle the CSS themselves by setting heights to 0. Do we need this opts really ??
@@ -1573,52 +1555,14 @@ export class GridStack {
       return this;
     }
 
-    const cellHeight = this.opts.cellHeight as number;
-    const cellHeightUnit = this.opts.cellHeightUnit;
-    const prefix = `.${this._styleSheetClass} > .${this.opts.itemClass}`;
+    // Set CSS var of cell height
+    this.setVar(this.el.parentElement, "--gs-cell-height", `${this.opts.cellHeight}${this.opts.cellHeightUnit}`);
+    // content margins
+    this.setVar(this.el.parentElement, "--gs-item-margin-top", `${this.opts.marginTop}${this.opts.marginUnit}`);
+    this.setVar(this.el.parentElement, "--gs-item-margin-bottom", `${this.opts.marginBottom}${this.opts.marginUnit}`);
+    this.setVar(this.el.parentElement, "--gs-item-margin-right", `${this.opts.marginRight}${this.opts.marginUnit}`);
+    this.setVar(this.el.parentElement, "--gs-item-margin-left", `${this.opts.marginLeft}${this.opts.marginUnit}`);
 
-    // create one as needed
-    if (!this._styles) {
-      // insert style to parent (instead of 'head' by default) to support WebComponent
-      const styleLocation = this.opts.styleInHead ? undefined : this.el.parentNode as HTMLElement;
-      this._styles = Utils.createStylesheet(this._styleSheetClass, styleLocation, {
-        nonce: this.opts.nonce,
-      });
-      if (!this._styles) return this;
-      this._styles._max = 0;
-
-      // these are done once only
-      Utils.addCSSRule(this._styles, prefix, `height: ${cellHeight}${cellHeightUnit}`);
-      // content margins
-      const top: string = this.opts.marginTop + this.opts.marginUnit;
-      const bottom: string = this.opts.marginBottom + this.opts.marginUnit;
-      const right: string = this.opts.marginRight + this.opts.marginUnit;
-      const left: string = this.opts.marginLeft + this.opts.marginUnit;
-      const content = `${prefix} > .grid-stack-item-content`;
-      const placeholder = `.${this._styleSheetClass} > .grid-stack-placeholder > .placeholder-content`;
-      Utils.addCSSRule(this._styles, content, `top: ${top}; right: ${right}; bottom: ${bottom}; left: ${left};`);
-      Utils.addCSSRule(this._styles, placeholder, `top: ${top}; right: ${right}; bottom: ${bottom}; left: ${left};`);
-      // resize handles offset (to match margin)
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-n`, `top: ${top};`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-s`, `bottom: ${bottom}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-ne`, `right: ${right}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-e`, `right: ${right}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-se`, `right: ${right}; bottom: ${bottom}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-nw`, `left: ${left}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-w`, `left: ${left}`);
-      Utils.addCSSRule(this._styles, `${prefix} > .ui-resizable-sw`, `left: ${left}; bottom: ${bottom}`);
-    }
-
-    // now update the height specific fields
-    maxH = maxH || this._styles._max;
-    if (maxH > this._styles._max) {
-      const getHeight = (rows: number): string => (cellHeight * rows) + cellHeightUnit;
-      for (let i = this._styles._max + 1; i <= maxH; i++) { // start at 1
-        Utils.addCSSRule(this._styles, `${prefix}[gs-y="${i}"]`, `top: ${getHeight(i)}`);
-        Utils.addCSSRule(this._styles, `${prefix}[gs-h="${i + 1}"]`, `height: ${getHeight(i + 1)}`); // start at 2
-      }
-      this._styles._max = maxH;
-    }
     return this;
   }
 
@@ -1677,17 +1621,27 @@ export class GridStack {
     return this;
   }
 
-  /** @internal call to write position x,y,w,h attributes back to element */
-  protected _writePosAttr(el: HTMLElement, n: GridStackPosition): GridStack {
+  /**
+   * Call to write position x,y,w,h attributes back to element
+   * In addition, updates the inline top/height inline style as well
+   * @internal
+   */
+  protected _writePosAttr(el: HTMLElement, n: GridStackNode): GridStack {
     if (n.x !== undefined && n.x !== null) { el.setAttribute('gs-x', String(n.x)); }
     if (n.y !== undefined && n.y !== null) { el.setAttribute('gs-y', String(n.y)); }
     n.w > 1 ? el.setAttribute('gs-w', String(n.w)) : el.removeAttribute('gs-w');
     n.h > 1 ? el.setAttribute('gs-h', String(n.h)) : el.removeAttribute('gs-h');
+    // Set inline style
+    if (!n._moving) {
+      // Refer CSS variables
+      el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
+      el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
+    }
     return this;
   }
 
   /** @internal call to write any default attributes back to element */
-  protected _writeAttr(el: HTMLElement, node: GridStackWidget): GridStack {
+  protected _writeAttr(el: HTMLElement, node: GridStackNode): GridStack {
     if (!node) return this;
     this._writePosAttr(el, node);
 
@@ -2306,7 +2260,7 @@ export class GridStack {
           this.resizeToContentCheck(false, node);
           if (subGrid) {
             subGrid.parentGridNode = node;
-            if (!subGrid.opts.styleInHead) subGrid._updateStyles(true); // re-create sub-grid styles now that we've moved
+            subGrid._updateStyles(); // re-create sub-grid styles now that we've moved
           }
           this._updateContainerHeight();
         }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1626,16 +1626,16 @@ export class GridStack {
    * In addition, updates the inline top/height inline style as well
    * @internal
    */
-  protected _writePosAttr(el: HTMLElement, node: GridStackNode): GridStack {
-    if (node.x !== undefined && node.x !== null) { el.setAttribute('gs-x', String(node.x)); }
-    if (node.y !== undefined && node.y !== null) { el.setAttribute('gs-y', String(node.y)); }
-    node.w > 1 ? el.setAttribute('gs-w', String(node.w)) : el.removeAttribute('gs-w');
-    node.h > 1 ? el.setAttribute('gs-h', String(node.h)) : el.removeAttribute('gs-h');
+  protected _writePosAttr(el: HTMLElement, n: GridStackNode): GridStack {
+    if (n.x !== undefined && n.x !== null) { el.setAttribute('gs-x', String(n.x)); }
+    if (n.y !== undefined && n.y !== null) { el.setAttribute('gs-y', String(n.y)); }
+    n.w > 1 ? el.setAttribute('gs-w', String(n.w)) : el.removeAttribute('gs-w');
+    n.h > 1 ? el.setAttribute('gs-h', String(n.h)) : el.removeAttribute('gs-h');
     // Avoid overwriting the inline style of the draggable element, but update the placeholder
-    if (!node._moving || this._placeholder === el) {
+    if (!n._moving || this._placeholder === el) {
       // Set inline style, refer CSS variables
-      el.style.top = `calc(${node.y} * var(--gs-cell-height))`;
-      el.style.height = `calc(${node.h} * var(--gs-cell-height))`;
+      el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
+      el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
     }
     return this;
   }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1631,9 +1631,9 @@ export class GridStack {
     if (node.y !== undefined && node.y !== null) { el.setAttribute('gs-y', String(node.y)); }
     node.w > 1 ? el.setAttribute('gs-w', String(node.w)) : el.removeAttribute('gs-w');
     node.h > 1 ? el.setAttribute('gs-h', String(node.h)) : el.removeAttribute('gs-h');
-    // Set inline style
-    if (!node._moving) {
-      // Refer CSS variables
+    // Avoid overwriting the inline style of the draggable element, but update the placeholder
+    if (!node._moving || this._placeholder === el) {
+      // Set inline style, refer CSS variables
       el.style.top = `calc(${node.y} * var(--gs-cell-height))`;
       el.style.height = `calc(${node.h} * var(--gs-cell-height))`;
     }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1635,12 +1635,8 @@ export class GridStack {
     if ((!n._moving && !n._resizing) || this._placeholder === el) {
       // Set inline style, refer CSS variables
       el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
-      if (n.h !== 1) {
-        el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
-      } else {
-        // height is set to --gs-cell-height by default
-        delete el.style.height;
-      }
+      // height is set to --gs-cell-height by default in the main CSS, so no need to set inline style when h = 1
+      el.style.height = n.h > 1 ? `calc(${n.h} * var(--gs-cell-height))` : undefined;
     }
     return this;
   }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1626,16 +1626,16 @@ export class GridStack {
    * In addition, updates the inline top/height inline style as well
    * @internal
    */
-  protected _writePosAttr(el: HTMLElement, n: GridStackNode): GridStack {
-    if (n.x !== undefined && n.x !== null) { el.setAttribute('gs-x', String(n.x)); }
-    if (n.y !== undefined && n.y !== null) { el.setAttribute('gs-y', String(n.y)); }
-    n.w > 1 ? el.setAttribute('gs-w', String(n.w)) : el.removeAttribute('gs-w');
-    n.h > 1 ? el.setAttribute('gs-h', String(n.h)) : el.removeAttribute('gs-h');
+  protected _writePosAttr(el: HTMLElement, node: GridStackNode): GridStack {
+    if (node.x !== undefined && node.x !== null) { el.setAttribute('gs-x', String(node.x)); }
+    if (node.y !== undefined && node.y !== null) { el.setAttribute('gs-y', String(node.y)); }
+    node.w > 1 ? el.setAttribute('gs-w', String(node.w)) : el.removeAttribute('gs-w');
+    node.h > 1 ? el.setAttribute('gs-h', String(node.h)) : el.removeAttribute('gs-h');
     // Set inline style
-    if (!n._moving) {
+    if (!node._moving) {
       // Refer CSS variables
-      el.style.top = `calc(${n.y} * var(--gs-cell-height))`;
-      el.style.height = `calc(${n.h} * var(--gs-cell-height))`;
+      el.style.top = `calc(${node.y} * var(--gs-cell-height))`;
+      el.style.height = `calc(${node.h} * var(--gs-cell-height))`;
     }
     return this;
   }
@@ -2447,7 +2447,7 @@ export class GridStack {
     node.el = this.placeholder;
     node._lastUiPosition = ui.position;
     node._prevYPix = ui.position.top;
-    node._moving = (event.type === 'dragstart'); // 'dropover' are not initially moving so they can go exactly where they enter (will push stuff out of the way)
+    node._moving = (event.type === 'dragstart' || event.type === 'resizestart'); // 'dropover' are not initially moving so they can go exactly where they enter (will push stuff out of the way)
     delete node._lastTried;
 
     if (event.type === 'dropover' && node._temporaryRemoved) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export const gridDefaults: GridStackOptions = {
   // handleClass: null,
   // removable: false,
   // staticGrid: false,
-  // styleInHead: false,
   //removable
 };
 
@@ -263,7 +262,9 @@ export interface GridStackOptions {
    */
   staticGrid?: boolean;
 
-  /** if `true` will add style element to `<head>` otherwise will add it to element's parent node (default `false`). */
+  /**
+   * @deprecated Not used anymore, styles are now implemented with local CSS variables
+   */
   styleInHead?: boolean;
 
   /** list of differences in options for automatically created sub-grids under us (inside our grid-items) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -435,6 +435,8 @@ export interface GridStackNode extends GridStackWidget {
   _event?: MouseEvent;
   /** @internal moving vs resizing */
   _moving?: boolean;
+  /** @internal is resizing? */
+  _resizing?: boolean;
   /** @internal true if we jumped down past item below (one time jump so we don't have to totally pass it) */
   _skipDown?: boolean;
   /** @internal original values before a drag/size */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -190,51 +190,6 @@ export class Utils {
     return id ? nodes.find(n => n.id === id) : undefined;
   }
 
-  /**
-   * creates a style sheet with style id under given parent
-   * @param id will set the 'gs-style-id' attribute to that id
-   * @param parent to insert the stylesheet as first child,
-   * if none supplied it will be appended to the document head instead.
-   */
-  static createStylesheet(id: string, parent?: HTMLElement, options?: { nonce?: string }): CSSStyleSheet {
-    const style: HTMLStyleElement = document.createElement('style');
-    const nonce = options?.nonce
-    if (nonce) style.nonce = nonce
-    style.setAttribute('type', 'text/css');
-    style.setAttribute('gs-style-id', id);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((style as any).styleSheet) { // TODO: only CSSImportRule have that and different beast ??
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (style as any).styleSheet.cssText = '';
-    } else {
-      style.appendChild(document.createTextNode('')); // WebKit hack
-    }
-    if (!parent) {
-      // default to head
-      parent = document.getElementsByTagName('head')[0];
-      parent.appendChild(style);
-    } else {
-      parent.insertBefore(style, parent.firstChild);
-    }
-    return style.sheet as CSSStyleSheet;
-  }
-
-  /** removed the given stylesheet id */
-  static removeStylesheet(id: string, parent?: HTMLElement): void {
-    const target = parent || document;
-    const el = target.querySelector('STYLE[gs-style-id=' + id + ']');
-    if (el && el.parentNode) el.remove();
-  }
-
-  /** inserts a CSS rule */
-  static addCSSRule(sheet: CSSStyleSheet, selector: string, rules: string): void {
-    if (typeof sheet.addRule === 'function') {
-      sheet.addRule(selector, rules);
-    } else if (typeof sheet.insertRule === 'function') {
-      sheet.insertRule(`${selector}{${rules}}`);
-    }
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static toBool(v: unknown): boolean {
     if (typeof v === 'boolean') {


### PR DESCRIPTION
### Description

The proposed change is to remove the dynamic CSS classes generation for rows and margins.
This has many benefits: it will speed up relayout operations, optimize performances for high row count and and fix the CSP style compatibility.

The requirement is CSS variables, that is now widely available: https://caniuse.com/css-variables

This deprecates the `styleInHead` properties as well.

It overrides #2852 as well.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`) (well, the failing test count is not increasing after the change, the main trunk has many failures)
- [X] Extended the README / documentation, if necessary
