### PR TITLE
more nested grid reflow

### DIFF
--- a/spec/e2e/html/2864_nested_resize_reflow.html
+++ b/spec/e2e/html/2864_nested_resize_reflow.html
@@ -4,15 +4,15 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Grid Spec test</title>
-  <link rel="stylesheet" href="../demo/demo.css"/>
-  <link rel="stylesheet" href="../dist/gridstack-extra.css"/>
-  <script src="../dist/gridstack-all.js"></script>
+  <title>2864 nest grid resize</title>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <link rel="stylesheet" href="../../../dist/gridstack-extra.css"/>
+  <script src="../../../dist/gridstack-all.js"></script>
 </head>
 <body>
-  <h1>Grid Spec test</h1>
-  <a class="btn btn-primary" onClick="step1()" href="#">step1</a>
-  <a class="btn btn-primary" onClick="step2()" href="#">step2</a>
+  <h1>2864 nest grid resize</h1>
+  <p>Test for nested grid resize reflowing content (manually and API)</p>
+  <a class="btn btn-primary" onClick="step1()" href="#">resize</a>
   <div class="grid-stack">
     <!-- <div class="grid-stack-item" gs-x="0" gs-y="0" gs-w="4" gs-h="2" gs-id="gsItem1" id="item1">
       <div class="grid-stack-item-content">item 1 text</div>
@@ -36,8 +36,6 @@
 
     step1 = function() {
       grid.update(grid.engine.nodes[0].el, {w:2});
-    }
-    step2 = function() {
     }
   </script>
 </body>

--- a/spec/regression-spec.ts
+++ b/spec/regression-spec.ts
@@ -7,6 +7,10 @@ describe('regression >', function() {
   let findEl = function(id: string): GridItemHTMLElement {
     return grid.engine.nodes.find(n => n.id === id)!.el!;
   };
+  let findSubEl = function(id: string, index = 0): GridItemHTMLElement {
+    return grid.engine.nodes[index].subGrid?.engine.nodes.find(n => n.id === id)!.el!;
+  };
+
 
   // empty grid
   let gridstackEmptyHTML =
@@ -53,6 +57,53 @@ describe('regression >', function() {
       expect(parseInt(el1.getAttribute('gs-y'), 10)).toBe(1);
       expect(parseInt(el2.getAttribute('gs-x'), 10)).toBe(2);
       expect(parseInt(el2.getAttribute('gs-y'), 10)).toBe(0);
+    });
+  });
+
+  describe('2865 nested grid resize >', function() {
+    beforeEach(function() {
+      document.body.insertAdjacentHTML('afterbegin', gridstackEmptyHTML);
+    });
+    afterEach(function() {
+      document.body.removeChild(document.getElementById('gs-cont'));
+    });
+    it('', function() {
+      let children: GridStackWidget[] = [{},{},{}];
+      let items: GridStackWidget[] = [
+        {x: 0, y: 0, w:3, h:3, sizeToContent: true, subGridOpts: {children, column: 'auto'}}
+      ];
+      let count = 0;
+      [...items, ...children].forEach(n => n.id = String(count++));
+      grid = GridStack.init({cellHeight: 70, margin: 5, children: items});
+
+      let nested = findEl('0');
+      let el1 = findSubEl('1');
+      let el2 = findSubEl('2');
+      let el3 = findSubEl('3');
+      expect(parseInt(nested.getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(nested.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(nested.getAttribute('gs-w'), 10)).toBe(3);
+      expect(nested.getAttribute('gs-h')).toBe(null); // sizeToContent 3 -> 1 which is null
+      expect(parseInt(el1.getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-x'), 10)).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-x'), 10)).toBe(2);
+      expect(parseInt(el3.getAttribute('gs-y'), 10)).toBe(0);
+
+      // now resize the nested grid to 2 -> should reflow el3
+      grid.update(nested, {w:2});
+      expect(parseInt(nested.getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(nested.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(nested.getAttribute('gs-w'), 10)).toBe(2);
+      expect(nested.getAttribute('gs-h')).toBe(null); // sizeToContent not called until some delay
+      expect(parseInt(el1.getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(el1.getAttribute('gs-y'), 10)).toBe(0);
+      expect(parseInt(el2.getAttribute('gs-x'), 10)).toBe(1);
+      expect(parseInt(el2.getAttribute('gs-y'), 10)).toBe(0);
+      // 3rd item pushed to next row
+      expect(parseInt(el3.getAttribute('gs-x'), 10)).toBe(0);
+      expect(parseInt(el3.getAttribute('gs-y'), 10)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
### Description
* more fix #2864
* make sure API resizing also reflows the content, deal with animation for force re-layout right away before animating items away.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
