### PR TITLE
Update README.md - GridStackNod to GridStackNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ grid.printCount();
 You can now (5.1+) easily create your own layout engine to further customize your usage. Here is a typescript example
 
 ```ts
-import { GridStack, GridStackEngine, GridStackNod, GridStackMoveOpts } from 'gridstack';
+import { GridStack, GridStackEngine, GridStackNode, GridStackMoveOpts } from 'gridstack';
 
 class CustomEngine extends GridStackEngine {
 


### PR DESCRIPTION
Typo on example

### Description
Fixed typo on example
GridStackNod -> GridStackNode

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
