### PR TITLE
mobile: nested grid drag out fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -121,6 +121,7 @@ Change log
 ## 11.1.1-dev (TBD)
 * fix: [#2877](https://github.com/gridstack/gridstack.js/pull/2877) angular wrapper uses standalone, while now being compatible down to ng14. thanks to [andre-steudel](https://github.com/andre-steudel)
 * fix: [#2886](https://github.com/gridstack/gridstack.js/issues/2886) added `gs-size-to-content` support
+* fix: [#2887](https://github.com/gridstack/gridstack.js/issues/2887) mobile nested grid TypeError: e.currentTarget is null
 
 ## 11.1.1 (2024-11-26)
 * fix: [#2878](https://github.com/gridstack/gridstack.js/pull/2878) make sure sub-grid inherit parent opts by default, with subgrid defaults.

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -224,7 +224,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _mouseUp(e: MouseEvent): void {
     document.removeEventListener('mousemove', this._mouseMove, true);
     document.removeEventListener('mouseup', this._mouseUp, true);
-    if (isTouch) {
+    if (isTouch && e.currentTarget) { // destroy() during nested grid call us again wit fake _mouseUp
       e.currentTarget.removeEventListener('touchmove', touchmove, true);
       e.currentTarget.removeEventListener('touchend', touchend, true);
     }


### PR DESCRIPTION
### Description
* fix #2887
* make sure we check for null since dragging a child out will destroy the old one, doing a double cleaning.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
