### PR TITLE
'Esc' to cancel now works on sidebar

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -120,7 +120,8 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 11.1.2-dev (TBD)
-* fix: [#2852](https://github.com/gridstack/gridstack.js/pull/2852) better React example. Thank you [CNine](https://github.com/Aysnine)
+* feat: [#2695](https://github.com/gridstack/gridstack.js/issues/2695) 'Esc' to cancel now works on sidebar external items, also works dragging over trash.
+* feat: [#2852](https://github.com/gridstack/gridstack.js/pull/2852) better React example. Thank you [CNine](https://github.com/Aysnine)
 * fix: [#2852](https://github.com/gridstack/gridstack.js/pull/2852) grid in tabs correctly handles CSS. Thank you [Luciano Martorella](https://github.com/lmartorella)
 * fix: [#2900](https://github.com/gridstack/gridstack.js/issues/2900) use attr `data-gs-widget` instead of `gridstacknode` (supported as well for backward compatibility)
 

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -9,6 +9,7 @@ import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { GridItemHTMLElement, DDUIData, GridStackNode, GridStackPosition, DDDragOpt } from './types';
 import { DDElementHost } from './dd-element';
 import { isTouch, touchend, touchmove, touchstart, pointerdown } from './dd-touch';
+import { GridHTMLElement } from './gridstack';
 
 interface DragOffset {
   left: number;
@@ -264,17 +265,16 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal call when keys are being pressed - use Esc to cancel, R to rotate */
   protected _keyEvent(e: KeyboardEvent): void {
     const n = this.el.gridstackNode as GridStackNodeRotate;
-    if (!n?.grid) return;
-    const grid = n.grid;
+    const grid = n?.grid || (DDManager.dropElement?.el as GridHTMLElement)?.gridstack;
 
     if (e.key === 'Escape') {
-      if (n._origRotate) {
+      if (n && n._origRotate) {
         n._orig = n._origRotate;
         delete n._origRotate;
       }
-      grid.engine.restoreInitial();
+      grid?.cancelDrag();
       this._mouseUp(this.mouseDownEvent);
-    } else if (e.key === 'r' || e.key === 'R') {
+    } else if (n && grid && (e.key === 'r' || e.key === 'R')) {
       if (!Utils.canBeRotated(n)) return;
       n._origRotate = n._origRotate || { ...n._orig }; // store the real orig size in case we Esc after doing rotation
       delete n._moving; // force rotate to happen (move waits for >50% coverage otherwise)

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -506,7 +506,7 @@ export class GridStackEngine {
   /** @internal restore all the nodes back to initial values (called when we leave) */
   public restoreInitial(): GridStackEngine {
     this.nodes.forEach(n => {
-      if (Utils.samePos(n, n._orig)) return;
+      if (!n._orig || Utils.samePos(n, n._orig)) return;
       Utils.copyPos(n, n._orig);
       n._dirty = true;
     });


### PR DESCRIPTION
### Description
* fix 2695
* 'Esc' to cancel now works on sidebar external items
* also works dragging over trash

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
