### PR TITLE
more initMouseEvent replacement

### DIFF
--- a/src/dd-touch.ts
+++ b/src/dd-touch.ts
@@ -4,6 +4,7 @@
  */
 
 import { DDManager } from './dd-manager';
+import { Utils } from './gridstack';
 
 /**
  * Detect touch support - Windows Surface devices and other touch devices
@@ -51,26 +52,8 @@ function simulateMouseEvent(e: TouchEvent, simulatedType: string) {
   // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
   if (e.cancelable) e.preventDefault();
 
-  const touch = e.changedTouches[0], simulatedEvent = new MouseEvent(simulatedType, {
-    bubbles: true,
-    composed: true,
-    cancelable: true,
-    view: window,
-    detail: 1,
-    screenX: touch.screenX,
-    screenY: touch.screenY,
-    clientX: touch.clientX,
-    clientY: touch.clientY,
-    ctrlKey: false,
-    altKey: false,
-    shiftKey: false,
-    metaKey: false,
-    button: 0,
-    relatedTarget: null
-  });
-
   // Dispatch the simulated event to the target element
-  e.target.dispatchEvent(simulatedEvent);
+  Utils.simulateMouseEvent(e.changedTouches[0], simulatedType);
 }
 
 /**
@@ -83,29 +66,8 @@ function simulatePointerMouseEvent(e: PointerEvent, simulatedType: string) {
   // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
   if (e.cancelable) e.preventDefault();
 
-  const simulatedEvent = document.createEvent('MouseEvents');
-
-  // Initialize the simulated mouse event using the touch event's coordinates
-  simulatedEvent.initMouseEvent(
-    simulatedType,    // type
-    true,             // bubbles
-    true,             // cancelable
-    window,           // view
-    1,                // detail
-    e.screenX,    // screenX
-    e.screenY,    // screenY
-    e.clientX,    // clientX
-    e.clientY,    // clientY
-    false,            // ctrlKey
-    false,            // altKey
-    false,            // shiftKey
-    false,            // metaKey
-    0,                // button
-    null              // relatedTarget
-  );
-
   // Dispatch the simulated event to the target element
-  e.target.dispatchEvent(simulatedEvent);
+  Utils.simulateMouseEvent(e, simulatedType);
 }
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -562,26 +562,27 @@ export class Utils {
     return {...evt, ...obj} as unknown as T;
   }
 
-  /** copies the MouseEvent properties and sends it as another event to the given target */
-  public static simulateMouseEvent(e: MouseEvent, simulatedType: string, target?: EventTarget): void {
-    const simulatedEvent = document.createEvent('MouseEvents');
-    simulatedEvent.initMouseEvent(
-      simulatedType, // type
-      true,         // bubbles
-      true,         // cancelable
-      window,       // view
-      1,            // detail
-      e.screenX,    // screenX
-      e.screenY,    // screenY
-      e.clientX,    // clientX
-      e.clientY,    // clientY
-      e.ctrlKey,    // ctrlKey
-      e.altKey,     // altKey
-      e.shiftKey,   // shiftKey
-      e.metaKey,    // metaKey
-      0,            // button
-      e.target      // relatedTarget
-    );
+  /** copies the MouseEvent (or convert Touch) properties and sends it as another event to the given target */
+  public static simulateMouseEvent(e: MouseEvent | Touch, simulatedType: string, target?: EventTarget): void {
+    const me = e as MouseEvent;
+    const simulatedEvent = new MouseEvent(simulatedType, {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+      view: window,
+      detail: 1,
+      screenX: e.screenX,
+      screenY: e.screenY,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      ctrlKey: me.ctrlKey??false,
+      altKey: me.altKey??false,
+      shiftKey: me.shiftKey??false,
+      metaKey: me.metaKey??false,
+      button: 0,
+      relatedTarget: e.target
+    });
+  
     (target || e.target).dispatchEvent(simulatedEvent);
   }
 


### PR DESCRIPTION
### Description
fix #2921 to remove the remaining 2 initMouseEvent() calls.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
