### PR TITLE
fix(resize): update the grid to resize when initialised in the smaller screen

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -346,8 +346,6 @@ export class GridStack {
     opts = Utils.defaults(opts, defaults);
     this._initMargin(); // part of settings defaults...
 
-    // Now check if we're loading into 1 column mode FIRST so we don't do un-necessary work (like cellHeight = width / 12 then go 1 column)
-    this.checkDynamicColumn();
     this.el.classList.add('gs-' + opts.column);
 
     if (opts.rtl === 'auto') {
@@ -440,6 +438,9 @@ export class GridStack {
     this._setupRemoveDrop();
     this._setupAcceptWidget();
     this._updateResizeEvent();
+
+    // To ensure that the grid is resized to the current screen width when the grid is initialized
+    this.onResize()
   }
 
   /**


### PR DESCRIPTION
### Description
This change would help recalculate the grid-layout when it is getting initialised in the smaller screen

https://github.com/gridstack/gridstack.js/issues/2947

https://github.com/user-attachments/assets/7039b300-d881-4b76-b3c6-f3fa9ed45406


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
