### PR TITLE
fix /angular circular dependencies

### DIFF
--- a/angular/projects/lib/src/index.ts
+++ b/angular/projects/lib/src/index.ts
@@ -2,7 +2,8 @@
  * Public API Surface of gridstack-angular
  */
 
+export * from './lib/types';
+export * from './lib/base-widget';
 export * from './lib/gridstack-item.component';
 export * from './lib/gridstack.component';
-export * from './lib/base-widget';
 export * from './lib/gridstack.module';

--- a/angular/projects/lib/src/lib/base-widget.ts
+++ b/angular/projects/lib/src/lib/base-widget.ts
@@ -8,7 +8,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import { NgCompInputs, NgGridStackWidget } from './gridstack.component';
+import { NgCompInputs, NgGridStackWidget } from './types';
 
  @Injectable()
  export abstract class BaseWidget {

--- a/angular/projects/lib/src/lib/gridstack.component.ts
+++ b/angular/projects/lib/src/lib/gridstack.component.ts
@@ -9,33 +9,15 @@ import { NgIf } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { GridHTMLElement, GridItemHTMLElement, GridStack, GridStackNode, GridStackOptions, GridStackWidget } from 'gridstack';
 
-import { GridItemCompHTMLElement, GridstackItemComponent } from './gridstack-item.component';
+import { NgGridStackNode, NgGridStackWidget } from './types';
 import { BaseWidget } from './base-widget';
+import { GridItemCompHTMLElement, GridstackItemComponent } from './gridstack-item.component';
 
 /** events handlers emitters signature for different events */
 export type eventCB = {event: Event};
 export type elementCB = {event: Event, el: GridItemHTMLElement};
 export type nodesCB = {event: Event, nodes: GridStackNode[]};
 export type droppedCB = {event: Event, previousNode: GridStackNode, newNode: GridStackNode};
-
-export type NgCompInputs = {[key: string]: any};
-
-/** extends to store Ng Component selector, instead/inAddition to content */
-export interface NgGridStackWidget extends GridStackWidget {
-  /** Angular tag selector for this component to create at runtime */
-  selector?: string;
-  /** serialized data for the component input fields */
-  input?: NgCompInputs;
-  /** nested grid options */
-  subGridOpts?: NgGridStackOptions;
-}
-export interface NgGridStackNode extends GridStackNode {
-  selector?: string; // component type to create as content
-}
-export interface NgGridStackOptions extends GridStackOptions {
-  children?: NgGridStackWidget[];
-  subGridOpts?: NgGridStackOptions;
-}
 
 /** store element to Ng Class pointer back */
 export interface GridCompHTMLElement extends GridHTMLElement {

--- a/angular/projects/lib/src/lib/gridstack.module.ts
+++ b/angular/projects/lib/src/lib/gridstack.module.ts
@@ -5,18 +5,18 @@
 
 import { NgModule } from "@angular/core";
 
-import { GridstackComponent } from "./gridstack.component";
 import { GridstackItemComponent } from "./gridstack-item.component";
+import { GridstackComponent } from "./gridstack.component";
 
 // @deprecated use GridstackComponent and GridstackItemComponent as standalone components
 @NgModule({
   imports: [
-    GridstackComponent,
     GridstackItemComponent,
+    GridstackComponent,
   ],
   exports: [
-    GridstackComponent,
     GridstackItemComponent,
+    GridstackComponent,
   ],
 })
 export class GridstackModule {}

--- a/angular/projects/lib/src/lib/types.ts
+++ b/angular/projects/lib/src/lib/types.ts
@@ -1,0 +1,27 @@
+/**
+ * gridstack-item.component.ts 11.3.0-dev
+ * Copyright (c) 2025 Alain Dumesny - see GridStack root license
+ */
+
+import { GridStackNode, GridStackOptions, GridStackWidget } from "gridstack";
+
+/** extends to store Ng Component selector, instead/inAddition to content */
+export interface NgGridStackWidget extends GridStackWidget {
+  /** Angular tag selector for this component to create at runtime */
+  selector?: string;
+  /** serialized data for the component input fields */
+  input?: NgCompInputs;
+  /** nested grid options */
+  subGridOpts?: NgGridStackOptions;
+}
+
+export interface NgGridStackNode extends GridStackNode {
+  selector?: string; // component type to create as content
+}
+
+export interface NgGridStackOptions extends GridStackOptions {
+  children?: NgGridStackWidget[];
+  subGridOpts?: NgGridStackOptions;
+}
+
+export type NgCompInputs = {[key: string]: any};

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -124,6 +124,7 @@ Change log
 ## 11.3.0-dev (TBD)
 * fix: [#2921](https://github.com/gridstack/gridstack.js/pull/2921) replace initMouseEvent with MouseEvent constructor and added composed: true
 * fix: [#2939](https://github.com/gridstack/gridstack.js/issues/2939) custom drag handle not working with LazyLoad
+* fix: [#2955](https://github.com/gridstack/gridstack.js/issues/2955) angular circular dependency
 
 ## 11.3.0 (2025-01-26)
 * feat: added `isIgnoreChangeCB()` if changeCB should be ignored due to column change, sizeToContent, loading, etc...


### PR DESCRIPTION
### Description
* fix #2955
* moves ng types into it's own plain file, fix order of include/export to reflect heirachy Note: gridComp depends on gridItem but not other way around

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
