### PR TITLE
shadow DOM drag re-append fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -125,6 +125,7 @@ Change log
 * fix: [#2921](https://github.com/gridstack/gridstack.js/pull/2921) replace initMouseEvent with MouseEvent constructor and added composed: true
 * fix: [#2939](https://github.com/gridstack/gridstack.js/issues/2939) custom drag handle not working with LazyLoad
 * fix: [#2955](https://github.com/gridstack/gridstack.js/issues/2955) angular circular dependency
+* fix: [#2951](https://github.com/gridstack/gridstack.js/issues/2951) shadow DOM dragging re-appending fix
 
 ## 11.3.0 (2025-01-26)
 * feat: added `isIgnoreChangeCB()` if changeCB should be ignored due to column change, sizeToContent, loading, etc...

--- a/spec/e2e/html/2951_shadow_dom.html
+++ b/spec/e2e/html/2951_shadow_dom.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Shadow DOM dragging</title>
+    <script src="../../../dist/gridstack-all.js"></script>
+  </head>
+  <body>
+    <h2>Inside Custom Element with Shadow DOM</h2>
+    <demo-gridstack></demo-gridstack>
+    <script type="text/javascript">
+      class HTMLDemoGridStack extends HTMLElement {
+        constructor() {
+          super();
+          this.attachShadow({
+            mode: "open",
+          });
+        }
+
+        connectedCallback() {
+          const styleBlocks = `
+<link href="https://unpkg.com/gridstack@11.3.0/dist/gridstack.min.css" rel="stylesheet" />
+<style type="text/css">
+*, *::before, *::after {
+box-sizing: border-box;
+}
+:host { display: block; }
+
+.grid-stack {
+background-color: #fafad2;
+}
+.grid-stack-item-content {
+background-color: #18bc9c;
+}
+</style>
+`;
+
+          this.shadowRoot.innerHTML = `${styleBlocks}<div class="grid-stack"></div>`;
+          const gridEl = this.shadowRoot.querySelector("div");
+          const items = [
+            {
+              content: "my first widget",
+            }, // will default to location (0,0) and 1x1
+            {
+              w: 2,
+              content: "another longer widget!",
+            }, // will be placed next at (1,0) and 2x1
+            {
+              content: "3rd Widget",
+            },
+          ];
+          const grid = GridStack.init(
+            {
+              disableOneColumnMode: true,
+              draggable: {
+                appendTo: "parent",
+              },
+              cellHeight: 100,
+            },
+            gridEl
+          );
+          grid.load(items);
+        }
+      }
+
+      customElements.define("demo-gridstack", HTMLDemoGridStack);
+    </script>
+  </body>
+</html>

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -299,7 +299,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     } else if (this.option.helper === 'clone') {
       helper = Utils.cloneNode(this.el);
     }
-    if (!document.body.contains(helper)) {
+    if (!helper.parentElement) {
       Utils.appendTo(helper, this.option.appendTo === 'parent' ? this.el.parentElement : this.option.appendTo);
     }
     this.dragElementOriginStyle = DDDraggable.originStyleProp.map(prop => this.el.style[prop]);


### PR DESCRIPTION
### Description
* fix #2951
* check for helper not having a parent before re-appending (rather than search though entire dom + shadow)
* added example test

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
