### PR TITLE
#2667 Fixed sidebar items not honouring gs-w

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -456,6 +456,8 @@ export interface GridStackNode extends GridStackWidget {
   _temporaryRemoved?: boolean;
   /** @internal true if we should remove DOM element on _notify() rather than clearing _id (old way) */
   _removeDOM?: boolean;
+  /** @internal original position/size of item if dragged from sidebar */
+  _sidebarOrig?: GridStackPosition;
   /** @internal had drag&drop been initialized */
   _initDD?: boolean;
 }


### PR DESCRIPTION
### Description
#2667 
These changes fix sidebar items not honoring gs-w and gs-h when dragging between multiple grids. When dragging between multiple grids, the size of the widget is limited by nodeBoundFix() based on number of columns. Eg. if you enter a grid which limits the gs-w attribute then enter another grid, I would expect the gs-w to honor the original size defined in the sidebar item, but instead it keeps the value which was limited in the previous grid.

These changes add another property for tracking the sidebar item's original position, so any number of grids can be entered and it still respects the original size, only limiting gs-w when appropriate. The existing _gridstackNodeOrig logic was not sufficient to handle the different behavior of the sidebar item.

These changes also fix another bug I discovered, which can be seen in the original example sandbox provided in #2667 . writePosAttr was writing the updated values to the _original sidebar element_, permanently altering gs-w, so any subsequent drags of the item would use the updated value. Sidebar items should not be mutable in this way.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
