### PR TITLE
loading into smaller screen with responsive layout:'list'

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -126,6 +126,8 @@ Change log
 ## 12-dev (TBD)
 * feat: [#2854](https://github.com/gridstack/gridstack.js/pull/2854) Removed dynamic stylesheet and migrated to CSS vars. Thank you [lmartorella](https://github.com/lmartorella)
 * feat: [#3013](https://github.com/gridstack/gridstack.js/pull/3013) columns no longer require custom classes nor `gridstack-extra.css` as we now use CSS vars.
+* fix: [#2978](https://github.com/gridstack/gridstack.js/issues/2978) Very slow operation in 11.2.0 and higher with large blocks
+* fix: [#2947](https://github.com/gridstack/gridstack.js/issues/2947) loading responsive `layout:'list'` into smaller screen doesn't layout correctly.
 
 ## 11.5.1 (2025-03-23)
 * revert: [#2981](https://github.com/gridstack/gridstack.js/issues/2981) Locked was incorrectly changed. fixed doc instead

--- a/spec/e2e/html/2947_load_responsive_list_smaller.html
+++ b/spec/e2e/html/2947_load_responsive_list_smaller.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<head>
+  <title>Responsive column</title>
+  <link rel="stylesheet" href="../../../demo/demo.css"/>
+  <script src="../../../dist/gridstack-all.js"></script>
+</head>
+<body>
+  <h1>Responsive: load into smaller size</h1>
+  <span>Number of Columns:</span> <span id="column-text"></span>
+  <div class="grid-stack">
+  
+  <script type="text/javascript">
+    let children = [ // our initial 12 column layout
+      {x: 0, y: 0, w: 12},
+      {x: 0, y: 1, w: 3},
+      {x: 3, y: 1, w: 3},
+      {x: 6, y: 1, w: 3},
+      {x: 9, y: 1, w: 3},
+    ];
+    children.forEach((n, i) => {n.id = i; n.content = String(i)});
+
+    let grid = GridStack.init({
+      cellHeight: 80,
+      columnOpts: {
+        breakpoints: [
+          { c: 8, w: 1200 },
+          { c: 6, w: 996 },
+          { c: 3, w: 768 },
+          { c: 1, w: 480 },
+        ],
+        layout: "list",
+      },
+      children})
+    .on('change', (ev, gsItems) => text.innerHTML = grid.getColumn());
+
+    let text = document.querySelector('#column-text');
+    text.innerHTML = grid.getColumn();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Description
* fix #2947
* make sure we detect loading into a smaller responsive screen by re-using engine relayout code.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
