### PR TITLE
`updateOptions()` no longer modifies passed in struct

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -126,8 +126,9 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 12.0.0-dev (TBD)
-* [#3022](https://github.com/gridstack/gridstack.js/pull/3022) removed ES5 support (IE doesn't support CSS vars needed now)
-* [#3024](https://github.com/gridstack/gridstack.js/pull/3024) remove legacy code support for disableOneColumnMode, oneColumnSize, oneColumnModeDomSort
+* rem [#3022](https://github.com/gridstack/gridstack.js/pull/3022) removed ES5 support (IE doesn't support CSS vars needed now)
+* rem [#3027](https://github.com/gridstack/gridstack.js/pull/3027) remove legacy code support for disableOneColumnMode, oneColumnSize, oneColumnModeDomSort
+* fix [#3028](https://github.com/gridstack/gridstack.js/pull/3028) `updateOptions()` no longer modifies passed in struct. only field we check are being handled too.
 
 ## 12.0.0 (2025-04-12)
 * feat: [#2854](https://github.com/gridstack/gridstack.js/pull/2854) Removed dynamic stylesheet and migrated to CSS vars. Thank you [lmartorella](https://github.com/lmartorella)

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     }
   ],
   "scripts": {
-    "build": "yarn --no-progress && yarn build:ng && grunt && yarn build:es6 && yarn doc",
-    "build:es6": "webpack && tsc --stripInternal",
+    "build": "yarn --no-progress && yarn build:ng && grunt && webpack && tsc --stripInternal && yarn doc",
     "build:ng": "cd angular && yarn --no-progress && yarn build lib",
     "w": "webpack",
     "t": "rm -rf dist/* && grunt && tsc --stripInternal",


### PR DESCRIPTION
### Description
* `updateOptions()` no longer modifies passed in struct
* only field we check are being handled too

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
