### PR TITLE
`resizeToContent()` fix for nested grid with content above

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -129,6 +129,7 @@ Change log
 * rem [#3022](https://github.com/gridstack/gridstack.js/pull/3022) removed ES5 support (IE doesn't support CSS vars needed now)
 * rem [#3027](https://github.com/gridstack/gridstack.js/pull/3027) remove legacy code support for disableOneColumnMode, oneColumnSize, oneColumnModeDomSort
 * fix [#3028](https://github.com/gridstack/gridstack.js/pull/3028) `updateOptions()` no longer modifies passed in struct. only field we check are being handled too.
+* fix [#3029](https://github.com/gridstack/gridstack.js/pull/3029) `resizeToContent()` fix for nested grid with content above
 
 ## 12.0.0 (2025-04-12)
 * feat: [#2854](https://github.com/gridstack/gridstack.js/pull/2854) Removed dynamic stylesheet and migrated to CSS vars. Thank you [lmartorella](https://github.com/lmartorella)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1427,7 +1427,7 @@ export class GridStack {
       // sub-grid - use their actual row count * their cell height, BUT append any content outside of the grid (eg: above text)
       wantedH = n.subGrid.getRow() * n.subGrid.getCellHeight(true);
       const subRec = n.subGrid.el.getBoundingClientRect();
-      const parentRec = n.subGrid.el.parentElement.getBoundingClientRect();
+      const parentRec = el.getBoundingClientRect();
       wantedH += subRec.top - parentRec.top;
     } else if (n.subGridOpts?.children?.length) {
       // not sub-grid just yet (case above) wait until we do


### PR DESCRIPTION
`resizeToContent()` fix for nested grid with content above

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
