### PR TITLE
`resizeToContentCheck()` wasn't blocking _ignoreLayoutsNodeChange

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -130,6 +130,7 @@ Change log
 * rem [#3027](https://github.com/gridstack/gridstack.js/pull/3027) remove legacy code support for disableOneColumnMode, oneColumnSize, oneColumnModeDomSort
 * fix [#3028](https://github.com/gridstack/gridstack.js/pull/3028) `updateOptions()` no longer modifies passed in struct. only field we check are being handled too.
 * fix [#3029](https://github.com/gridstack/gridstack.js/pull/3029) `resizeToContent()` fix for nested grid with content above
+* fix [#3030](https://github.com/gridstack/gridstack.js/pull/3030) `resizeToContentCheck()` wasn't blocking _ignoreLayoutsNodeChange at end of the loop
 
 ## 12.0.0 (2025-04-12)
 * feat: [#2854](https://github.com/gridstack/gridstack.js/pull/2854) Removed dynamic stylesheet and migrated to CSS vars. Thank you [lmartorella](https://github.com/lmartorella)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1797,7 +1797,9 @@ export class GridStack {
       nodes.forEach(n => {
         if (Utils.shouldSizeToContent(n)) this.resizeToContentCBCheck(n.el);
       });
+      this._ignoreLayoutsNodeChange = true; // loop through each node will set/reset around each move, so set it here again
       this.batchUpdate(false);
+      this._ignoreLayoutsNodeChange = false;
     }
     // call this regardless of shouldSizeToContent because widget might need to stretch to take available space after a resize
     if (this._gsEventHandler['resizecontent']) this._gsEventHandler['resizecontent'](null, n ? [n] : this.engine.nodes);


### PR DESCRIPTION
### Description
`resizeToContentCheck()` wasn't blocking _ignoreLayoutsNodeChange

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
