### PR TITLE
remove no-op 'cursor: move' CSS

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [12.1.1-dev (TBD)](#1211-dev-tbd)
 - [12.1.1 (2024-04-28)](#1211-2024-04-28)
 - [12.1.0 (2024-04-23)](#1210-2024-04-23)
 - [12.0.0 (2025-04-12)](#1200-2025-04-12)

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -312,7 +312,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     // TODO: set all at once with style.cssText += ... ? https://stackoverflow.com/questions/3968593
     const style = this.helper.style;
     style.pointerEvents = 'none'; // needed for over items to get enter/leave
-    // style.cursor = 'move'; //  TODO: can't set with pointerEvents=none ! (done in CSS as well)
+    // style.cursor = 'move'; //  TODO: can't set with pointerEvents=none ! (no longer in CSS either as no-op)
     style.width = this.dragOffset.width + 'px';
     style.height = this.dragOffset.height + 'px';
     style.willChange = 'left, top';

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -118,7 +118,6 @@ $animation_speed: .3s !default;
 
   &.ui-draggable-dragging {
     will-change: left, top;
-    cursor: move;
   }
 
   &.ui-resizable-resizing {


### PR DESCRIPTION
### Description
* fix #3044

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
