### PR TITLE
nested grid resizeToContentCBCheck() fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -129,6 +129,7 @@ Change log
 
 ## 12.1.1-dev (TBD)
 * fix [#3043](https://github.com/gridstack/gridstack.js/issues/3043) fix `opts.animate` again
+* fix [#3047](https://github.com/gridstack/gridstack.js/pull/3047) nested grid resizeToContentCBCheck() fix
 
 
 ## 12.1.1 (2024-04-28)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1616,7 +1616,7 @@ export class GridStack {
     }
 
     // if we're a nested grid inside an sizeToContent item, tell it to resize itself too
-    if (parent && !parent.grid.engine.batchMode && Utils.shouldSizeToContent(parent)) {
+    if (parent && Utils.shouldSizeToContent(parent)) {
       parent.grid.resizeToContentCBCheck(parent.el);
     }
 


### PR DESCRIPTION
### Description
* make sure nested items size they parent item even when in batch mode (eg: load()) otherwise it never happens

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
