### PR TITLE
Avoid reflows via explicitly setting minRow

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -116,7 +116,7 @@ gridstack.js API
 - `marginBottom`: numberOrString
 - `marginLeft`: numberOrString
 - `maxRow` - maximum rows amount. Default is `0` which means no max.
-- `minRow` - minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`. You can also do this with `min-height` CSS attribute on the grid div in pixels, which will round to the closest row.
+- `minRow` - minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`. When no set set, the `min-height` CSS attribute on the grid div (in pixels) can be used as well, which will round to the closest row.
 - `nonce` - If you are using a nonce-based Content Security Policy, pass your nonce here and
 GridStack will add it to the `<style>` elements it creates.
 - `placeholderClass` - class for placeholder (default: `'grid-stack-placeholder'`)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1597,7 +1597,9 @@ export class GridStack {
     if (!cellHeight) return this;
 
     // check for css min height (non nested grid). TODO: support mismatch, say: min % while unit is px.
-    if (!parent) {
+    // If `minRow` was applied, don't override it with this check, and avoid performance issues
+    // (reflows) using `getComputedStyle`
+    if (!parent && !this.opts.minRow) {
       const cssMinHeight = Utils.parseHeight(getComputedStyle(this.el)['minHeight']);
       if (cssMinHeight.h > 0 && cssMinHeight.unit === unit) {
         const minRow = Math.floor(cssMinHeight.h / cellHeight);

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,8 +217,8 @@ export interface GridStackOptions {
   /** maximum rows amount. Default? is 0 which means no maximum rows */
   maxRow?: number;
 
-  /** minimum rows amount. Default is `0`. You can also do this with `min-height` CSS attribute
-   * on the grid div in pixels, which will round to the closest row.
+  /** minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`.
+   * When no set set, the `min-height` CSS attribute on the grid div (in pixels) can be used as well, which will round to the closest row.
    */
   minRow?: number;
 


### PR DESCRIPTION
### Description

If gridstack is used in a complex layout, the browser layout can be interrupted by a [reflow](https://gist.github.com/paulirish/5d52fb081b3570c81e3a) when the `getComputedStyle` function is called to ask for parent `min-height`.

<img width="353" alt="image" src="https://github.com/user-attachments/assets/e95b4ba3-b686-46c5-9a42-aa6075f7c80b" />

To mitigate this in the `_updateContainerHeight`, it could be possible to give a priority if both `minRow` option and the `min-height` CSS property of the parent div are set. In this way, applications that sets `minRow` programmatically would never trigger the reflow.

Since `0` is the default value, and `null`/`undefined` values can be tricky to manage due to falsy/truly check in JS, to I would say that checking a non-zero/non-null value would be the solution. Users that wants "0" to be a valid row count and still disable the CSS check, could be pass something like `-1` to obtain the same result.

Thanks, L

### Checklist
- [N/A] Created tests which fail without the change (can't find a test for the `min-height` CSS prop, please let me know if you would like to have this tested)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
