### PR TITLE
fix: makeWidget breakpoint layout issue #3071

### DIFF
--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -417,14 +417,14 @@ export class GridStackEngine {
     // remember it's position & width so we can restore back (1 -> 12 column) #1655 #1985
     // IFF we're not in the middle of column resizing!
     const saveOrig = (node.x || 0) + (node.w || 1) > this.column;
-    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && node._id && this.findCacheLayout(node, this.defaultColumn) === -1) {
+    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && !isNaN(node._id) && this.findCacheLayout(node, this.defaultColumn) === -1) {
       const copy = {...node}; // need _id + positions
       if (copy.autoPosition || copy.x === undefined) { delete copy.x; delete copy.y; }
       else copy.x = Math.min(this.defaultColumn - 1, copy.x);
       copy.w = Math.min(this.defaultColumn, copy.w || 1);
       this.cacheOneLayout(copy, this.defaultColumn);
     }
-
+    
     if (node.w > this.column) {
       node.w = this.column;
     } else if (node.w < 1) {

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -417,7 +417,7 @@ export class GridStackEngine {
     // remember it's position & width so we can restore back (1 -> 12 column) #1655 #1985
     // IFF we're not in the middle of column resizing!
     const saveOrig = (node.x || 0) + (node.w || 1) > this.column;
-    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && !isNaN(node._id) && this.findCacheLayout(node, this.defaultColumn) === -1) {
+    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && (node._id ?? false) && this.findCacheLayout(node, this.defaultColumn) === -1) {
       const copy = {...node}; // need _id + positions
       if (copy.autoPosition || copy.x === undefined) { delete copy.x; delete copy.y; }
       else copy.x = Math.min(this.defaultColumn - 1, copy.x);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1633,7 +1633,9 @@ export class GridStack {
     el.gridstackNode = node;
     node.el = el;
     node.grid = this;
+    this.engine._loading = true; // help with collision
     node = this.engine.addNode(node, triggerAddEvent);
+    delete this.engine._loading; // done loading
 
     // write the dom sizes and class
     this._writeAttr(el, node);

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1633,9 +1633,7 @@ export class GridStack {
     el.gridstackNode = node;
     node.el = el;
     node.grid = this;
-    this.engine._loading = true; // help with collision
     node = this.engine.addNode(node, triggerAddEvent);
-    delete this.engine._loading; // done loading
 
     // write the dom sizes and class
     this._writeAttr(el, node);


### PR DESCRIPTION
### Description
See #3071 for description of issue. I added setting _loading to true in _prepareElement to fix the order issue and changed how we check if `node._id` is present (previously it would be false when called with the first element as it has an id of 0, not sure if this was wanted)

### Checklist
- [- ] Created tests which fail without the change (if possible)
- [X ] All tests passing (`yarn test`)
- [- ] Extended the README / documentation, if necessary
