### PR TITLE
fix: incorrect node._id check

### DIFF
--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -417,7 +417,7 @@ export class GridStackEngine {
     // remember it's position & width so we can restore back (1 -> 12 column) #1655 #1985
     // IFF we're not in the middle of column resizing!
     const saveOrig = (node.x || 0) + (node.w || 1) > this.column;
-    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && (node._id ?? false) && this.findCacheLayout(node, this.defaultColumn) === -1) {
+    if (saveOrig && this.column < this.defaultColumn && !this._inColumnResize && !this.skipCacheUpdate && node._id != null  && this.findCacheLayout(node, this.defaultColumn) === -1) {
       const copy = {...node}; // need _id + positions
       if (copy.autoPosition || copy.x === undefined) { delete copy.x; delete copy.y; }
       else copy.x = Math.min(this.defaultColumn - 1, copy.x);


### PR DESCRIPTION
### Description
Fixed a mistake I made in this PR https://github.com/gridstack/gridstack.js/pull/3072
`(node._id ?? false)` still is falsy when  `node_id = 0` 

### Checklist
- [-] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [-] Extended the README / documentation, if necessary

Also @adumesny  should I create a new issue for the incorrect order mentioned in #3071?