### PR TITLE
correctly reset widget back

### DIFF
--- a/demo/two_vertical.html
+++ b/demo/two_vertical.html
@@ -26,7 +26,7 @@
       acceptWidgets: true
     }
     GridStack.init(opts, document.getElementById('grid1'))
-      .load([{x:0, y:0, content: '0'}, {x:1, y:0, content: '1'}]);
+      .load([{x:1, y:0, content: '0'}, {x:2, y:0, content: '1'}]);
     GridStack.init(opts, document.getElementById('grid2'))
       .load([{x:0, y:0, content: '2'}, {x:1, y:0, content: '3'}]);
   </script>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -135,6 +135,7 @@ Change log
 * fix: [#3099](https://github.com/gridstack/gridstack.js/issues/3099) scroll take into account ScrollContainer position
 * fix: [#3102](https://github.com/gridstack/gridstack.js/pull/3102) React demo now support multiple grids
 * fix: [#3047](https://github.com/gridstack/gridstack.js/issues/3047) added `.grid-stack-dragging` to grid when child is being dragged so we can set cursor:grabbing, updated demo.
+* fix: [#3021](https://github.com/gridstack/gridstack.js/issues/3021) correctly reset widget back (to last known position) when released outside
 
 ## 12.2.2 (2025-07-06)
 * fix: [#3070](https://github.com/gridstack/gridstack.js/pull/3070) incorrect property name 'sizeToContent' when cleaning up invalid attributes

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -553,7 +553,7 @@ export class GridStack {
     if (nodeToAdd?._moving) subGrid._isTemp = true; // prevent re-nesting as we add over
     if (autoColumn) subGrid._autoColumn = true;
 
-    // add the original content back as a child of hte newly created grid
+    // add the original content back as a child of the newly created grid
     if (saveContent) {
       subGrid.makeWidget(newItem, newItemOpt);
     }
@@ -2424,8 +2424,7 @@ export class GridStack {
         } else {
           Utils.removePositioningStyles(target);
           if (node._temporaryRemoved) {
-            // got removed - restore item back to before dragging position
-            Utils.copyPos(node, node._orig);// @ts-ignore
+            // use last position we were at (not _orig as we may have pushed others and moved) and add it back
             this._writePosAttr(target, node);
             this.engine.addNode(node);
           } else {


### PR DESCRIPTION
### Description
* fix #3021 
* correctly reset widget back (to last known position) when released outside (to last known position) when released outside

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
