### PR TITLE
fix Util:removeInternalForSave() to skip arrays

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2845,7 +2845,7 @@ new Utils(): Utils;
 static addElStyles(el, styles): void;
 ```
 
-Defined in: [utils.ts:690](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L690)
+Defined in: [utils.ts:692](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L692)
 
 ###### Parameters
 
@@ -2864,7 +2864,7 @@ Defined in: [utils.ts:690](https://github.com/adumesny/gridstack.js/blob/master/
 static appendTo(el, parent): void;
 ```
 
-Defined in: [utils.ts:672](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L672)
+Defined in: [utils.ts:674](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L674)
 
 ###### Parameters
 
@@ -2943,7 +2943,7 @@ const overlap = Utils.areaIntercept(
 static canBeRotated(n): boolean;
 ```
 
-Defined in: [utils.ts:793](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L793)
+Defined in: [utils.ts:795](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L795)
 
 true if the item can be rotated (checking for prop, not space available)
 
@@ -2963,7 +2963,7 @@ true if the item can be rotated (checking for prop, not space available)
 static clone<T>(obj): T;
 ```
 
-Defined in: [utils.ts:635](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L635)
+Defined in: [utils.ts:637](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L637)
 
 single level clone, returning a new object with same top fields. This will share sub objects and arrays
 
@@ -2989,7 +2989,7 @@ single level clone, returning a new object with same top fields. This will share
 static cloneDeep<T>(obj): T;
 ```
 
-Defined in: [utils.ts:651](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L651)
+Defined in: [utils.ts:653](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L653)
 
 Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
 Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
@@ -3016,7 +3016,7 @@ Note: this will use as-is any key starting with double __ (and not copy inside) 
 static cloneNode(el): HTMLElement;
 ```
 
-Defined in: [utils.ts:666](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L666)
+Defined in: [utils.ts:668](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L668)
 
 deep clone the given HTML node, removing teh unique id field
 
@@ -3226,7 +3226,7 @@ const fromShadow = Utils.getElements('.item', shadowRoot);
 static getValuesFromTransformedElement(parent): DragTransform;
 ```
 
-Defined in: [utils.ts:750](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L750)
+Defined in: [utils.ts:752](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L752)
 
 defines an element that is used to get the offset and scale from grid transforms
 returns the scale and offsets from said element
@@ -3247,7 +3247,7 @@ returns the scale and offsets from said element
 static initEvent<T>(e, info): T;
 ```
 
-Defined in: [utils.ts:707](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L707)
+Defined in: [utils.ts:709](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L709)
 
 ###### Type Parameters
 
@@ -3420,7 +3420,7 @@ removes field from the first object if same as the second objects (like diffing)
 static removeInternalForSave(n, removeEl): void;
 ```
 
-Defined in: [utils.ts:509](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L509)
+Defined in: [utils.ts:511](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L511)
 
 removes internal fields '_' and default values for saving
 
@@ -3441,7 +3441,7 @@ removes internal fields '_' and default values for saving
 static removePositioningStyles(el): void;
 ```
 
-Defined in: [utils.ts:542](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L542)
+Defined in: [utils.ts:544](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L544)
 
 ###### Parameters
 
@@ -3565,7 +3565,7 @@ static simulateMouseEvent(
    target?): void;
 ```
 
-Defined in: [utils.ts:723](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L723)
+Defined in: [utils.ts:725](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L725)
 
 copies the MouseEvent (or convert Touch) properties and sends it as another event to the given target
 
@@ -3620,7 +3620,7 @@ static swap(
    b): void;
 ```
 
-Defined in: [utils.ts:774](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L774)
+Defined in: [utils.ts:776](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L776)
 
 swap the given object 2 field values
 
@@ -3642,7 +3642,7 @@ swap the given object 2 field values
 static throttle(func, delay): () => void;
 ```
 
-Defined in: [utils.ts:532](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L532)
+Defined in: [utils.ts:534](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L534)
 
 delay calling the given function for given delay, preventing new calls from happening while waiting
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [12.3.2-dev (TBD)](#1232-dev-tbd)
 - [12.3.2 (2025-08-12)](#1232-2025-08-12)
 - [12.3.1 (2025-08-11)](#1231-2025-08-11)
 - [12.3.0 (2025-08-10)](#1230-2025-08-10)
@@ -132,6 +133,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 12.3.2-dev (TBD)
+* fix: [#3139](https://github.com/gridstack/gridstack.js/pull/3139) `Utils:removeInternalForSave()` to skip arrays
 
 ## 12.3.2 (2025-08-12)
 * fix: [#3136](https://github.com/gridstack/gridstack.js/pull/3136) more tweaks to save(columnCount) option. 

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -225,5 +225,31 @@ describe('gridstack utils', () => {
       expect(f).toEqual({first: 1, _dontskip: {second: 2}});
       expect(z).toEqual({first: 1, _dontskip: {second: 'two'}});
     });
-  });  
+  });
+  describe('removeInternalAndSame', () => {
+    it('should remove internal and same', () => {
+      const a = {first: 1, second: 'text', _skip: {second: 2}, arr: [1, 'second', 3]};
+      const b = {first: 1, second: 'text'};
+      Utils.removeInternalAndSame(a, b);
+      expect(a).toEqual({arr: [1, 'second', 3]});
+    });
+    it('should not remove items in an array', () => {
+      const a = {arr: [1, 2, 3]};
+      const b = {arr: [1, 3]};
+      Utils.removeInternalAndSame(a, b);
+      expect(a).toEqual({arr: [1, 2, 3]});
+    });
+    it('should remove nested object, and make empty', () => {
+      const a = {obj1: {first: 1, nested: {second: 2}}, obj2: {first: 1, second: 2}};
+      const b = {obj1: {first: 1, nested: {second: 2}}, obj2: {first: 1, second: 2}};
+      Utils.removeInternalAndSame(a, b);
+      expect(a).toEqual({});
+    });
+    it('should remove nested object, and make empty - part 2', () => {
+      const a = {obj1: {first: 1, nested: {second: 2}}, obj2: {first: 1, second: 2}};
+      const b = {obj1: {first: 1}, obj2: {first: 1, second: 2}};
+      Utils.removeInternalAndSame(a, b);
+      expect(a).toEqual({obj1: {nested: {second: 2}}});
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -493,6 +493,8 @@ export class Utils {
   /** removes field from the first object if same as the second objects (like diffing) and internal '_' for saving */
   static removeInternalAndSame(a: unknown, b: unknown):void {
     if (typeof a !== 'object' || typeof b !== 'object') return;
+    // skip arrays as we don't know how to hydrate them (unlike object spread operator)
+    if (Array.isArray(a) || Array.isArray(b)) return;
     for (let key in a) {
       const aVal = a[key];
       const bVal = b[key];


### PR DESCRIPTION
### Description
* since we don't know how to hydrate arrays (unlike object spread operator '...') skip them)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
