### PR TITLE
Fix bug where removeWidget does not function properly

### DIFF
--- a/react/lib/grid-stack-provider.tsx
+++ b/react/lib/grid-stack-provider.tsx
@@ -1,4 +1,4 @@
-import type { GridStack, GridStackOptions, GridStackWidget } from "gridstack";
+import type { GridItemHTMLElement, GridStack, GridStackOptions, GridStackWidget } from "gridstack";
 import { type PropsWithChildren, useCallback, useState } from "react";
 import { GridStackContext } from "./grid-stack-context";
 
@@ -72,7 +72,12 @@ export function GridStackProvider({
 
   const removeWidget = useCallback(
     (id: string) => {
-      gridStack?.removeWidget(id);
+      const element = document.body.querySelector(`[gs-id="${id}"]`);
+
+      if (element) {
+        gridStack?.removeWidget(element as GridItemHTMLElement);
+      }
+
       setRawWidgetMetaMap((prev) => {
         const newMap = new Map<string, GridStackWidget>(prev);
         newMap.delete(id);


### PR DESCRIPTION
### Description
resolving the issue where only the internal elements were removed when an ID was provided. Passing the element now ensures that the entire grid-stack-item-content is removed as intended.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
