### PR TITLE
remove HTMLElement from GridStackElement type in API documentation

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -5988,7 +5988,7 @@ Drop event handler that receives previous and new node states
 ### GridStackElement
 
 ```ts
-type GridStackElement = string | HTMLElement | GridItemHTMLElement;
+type GridStackElement = string | GridItemHTMLElement;
 ```
 
 Defined in: [types.ts:87](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L87)


### PR DESCRIPTION
### Description
remove HTMLElement from GridStackElement type in API documentation

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
