### PR TITLE
react wrapper grid stack provider API to accept widget objects directly

### DIFF
--- a/react/lib/grid-stack-context.ts
+++ b/react/lib/grid-stack-context.ts
@@ -4,13 +4,15 @@ import { createContext, useContext } from "react";
 export const GridStackContext = createContext<{
   initialOptions: GridStackOptions;
   gridStack: GridStack | null;
-  addWidget: (fn: (id: string) => Omit<GridStackWidget, "id">) => void;
+  addWidget: (widget: GridStackWidget & { id: Required<GridStackWidget>["id"] }) => void;
   removeWidget: (id: string) => void;
   addSubGrid: (
-    fn: (
-      id: string,
-      withWidget: (w: Omit<GridStackWidget, "id">) => GridStackWidget
-    ) => Omit<GridStackWidget, "id">
+    subGrid: GridStackWidget & { 
+      id: Required<GridStackWidget>["id"]; 
+      subGridOpts: Required<GridStackWidget>["subGridOpts"] & { 
+        children: Array<GridStackWidget & { id: Required<GridStackWidget>["id"] }> 
+      } 
+    }
   ) => void;
   saveOptions: () => GridStackOptions | GridStackWidget[] | undefined;
   removeAll: () => void;

--- a/react/lib/grid-stack-provider.tsx
+++ b/react/lib/grid-stack-provider.tsx
@@ -26,13 +26,11 @@ export function GridStackProvider({
   });
 
   const addWidget = useCallback(
-    (fn: (id: string) => Omit<GridStackWidget, "id">) => {
-      const newId = `widget-${Math.random().toString(36).substring(2, 15)}`;
-      const widget = fn(newId);
-      gridStack?.addWidget({ ...widget, id: newId });
+    (widget: GridStackWidget & { id: Required<GridStackWidget>["id"] })  => {
+      gridStack?.addWidget(widget);
       setRawWidgetMetaMap((prev) => {
         const newMap = new Map<string, GridStackWidget>(prev);
-        newMap.set(newId, widget);
+        newMap.set(widget.id, widget);
         return newMap;
       });
     },
@@ -40,29 +38,18 @@ export function GridStackProvider({
   );
 
   const addSubGrid = useCallback(
-    (
-      fn: (
-        id: string,
-        withWidget: (w: Omit<GridStackWidget, "id">) => GridStackWidget
-      ) => Omit<GridStackWidget, "id">
-    ) => {
-      const newId = `sub-grid-${Math.random().toString(36).substring(2, 15)}`;
-      const subWidgetIdMap = new Map<string, GridStackWidget>();
-
-      const widget = fn(newId, (w) => {
-        const subWidgetId = `widget-${Math.random()
-          .toString(36)
-          .substring(2, 15)}`;
-        subWidgetIdMap.set(subWidgetId, w);
-        return { ...w, id: subWidgetId };
-      });
-
-      gridStack?.addWidget({ ...widget, id: newId });
+    (subGrid: GridStackWidget & { 
+      id: Required<GridStackWidget>["id"]; 
+      subGridOpts: Required<GridStackWidget>["subGridOpts"] & { 
+        children: Array<GridStackWidget & { id: Required<GridStackWidget>["id"] }> 
+      } 
+    }) => {
+      gridStack?.addWidget(subGrid);
 
       setRawWidgetMetaMap((prev) => {
         const newMap = new Map<string, GridStackWidget>(prev);
-        subWidgetIdMap.forEach((meta, id) => {
-          newMap.set(id, meta);
+        subGrid.subGridOpts?.children?.forEach((meta: GridStackWidget & { id: Required<GridStackWidget>["id"] }) => {
+          newMap.set(meta.id, meta);
         });
         return newMap;
       });

--- a/react/src/demo/demo.tsx
+++ b/react/src/demo/demo.tsx
@@ -141,7 +141,7 @@ export function GridStackDemo() {
     <>
     <GridStackProvider initialOptions={initialOptions}>
       <Toolbar />
-       <GridStackRenderProvider>
+        <GridStackRenderProvider>
         <GridStackRender componentMap={COMPONENT_MAP} />
       </GridStackRenderProvider>
       <DebugInfo />
@@ -149,7 +149,7 @@ export function GridStackDemo() {
 
     <GridStackProvider initialOptions={initialOptions2}>
       <Toolbar />
-       <GridStackRenderProvider>
+        <GridStackRenderProvider>
         <GridStackRender componentMap={COMPONENT_MAP} />
       </GridStackRenderProvider>
       <DebugInfo />
@@ -175,7 +175,10 @@ function Toolbar() {
     >
       <button
         onClick={() => {
-          addWidget((id) => ({
+          const id = `widget-${Math.random().toString(36).substring(2, 15)}`;
+          
+          addWidget({
+            id,
             w: 2,
             h: 2,
             x: 0,
@@ -184,7 +187,7 @@ function Toolbar() {
               name: "Text",
               props: { content: id },
             }),
-          }));
+          });
         }}
       >
         Add Text (2x2)
@@ -192,7 +195,11 @@ function Toolbar() {
 
       <button
         onClick={() => {
-          addSubGrid((id, withWidget) => ({
+          const subGridId = `sub-grid-${Math.random().toString(36).substring(2, 15)}`;
+          const widgetId = `widget-${Math.random().toString(36).substring(2, 15)}`;
+
+          addSubGrid({
+            id: subGridId,
             h: 5,
             noResize: false,
             sizeToContent: true,
@@ -203,7 +210,8 @@ function Toolbar() {
               minRow: 2,
               cellHeight: CELL_HEIGHT,
               children: [
-                withWidget({
+                {
+                  id: widgetId,
                   h: 1,
                   locked: true,
                   noMove: true,
@@ -213,15 +221,15 @@ function Toolbar() {
                   y: 0,
                   content: JSON.stringify({
                     name: "Text",
-                    props: { content: "Sub Grid 1 Title" + id },
+                    props: { content: "Sub Grid 1 Title" + widgetId },
                   }),
-                }),
+                },
               ],
             },
             w: 12,
             x: 0,
             y: 0,
-          }));
+          });
         }}
       >
         Add Sub Grid (12x1)


### PR DESCRIPTION
### Description
This PR updates the GridStackProvider API to accept widget objects directly instead of callback functions, simplifying the interface for adding widgets and subgrids.

**Changes**

- Modified `addWidget` implementation to accept widget object directly and use provided ID
- Modified `addSubGrid` implementation to accept subgrid object with children array
- Removed internal ID generation logic and callback-based widget creation

**Benefits**

- Simplified API usage - no need for callback functions
- Better control over widget IDs for consumers
- More predictable widget creation process
- Cleaner type definitions and implementation


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
