### PR TITLE
fix: only show resize handles on hover in Chromium browsers when auto…

### DIFF
--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -77,6 +77,10 @@ $animation_speed: .3s !default;
 
   &.ui-resizable-disabled > .ui-resizable-handle,
   &.ui-resizable-autohide > .ui-resizable-handle { display: none; }
+  /* Fallback for Chromium browsers: only show handles on hover when autohide is enabled */
+  &.ui-resizable-autohide:hover > .ui-resizable-handle {
+    display: block;
+  }
 
   > .ui-resizable-ne,
   > .ui-resizable-nw,


### PR DESCRIPTION
# This PR adds a CSS fallback to ensure that resize handles are only visible on hover when autohide is enabled, fixing an issue where Chromium-based browsers (Chrome, Edge) always showed the handles regardless of hover state.

