### PR TITLE
Fixed touch issue on Linux

### DIFF
--- a/src/dd-droppable.ts
+++ b/src/dd-droppable.ts
@@ -88,6 +88,12 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _mouseEnter(e: MouseEvent): void {
     // console.log(`${count++} Enter ${this.el.id || (this.el as GridHTMLElement).gridstack.opts.id}`); // TEST
     if (!DDManager.dragElement) return;
+    // During touch drag operations, ignore real browser-generated mouseenter events (isTrusted: true).
+    // Only process simulated mouseenter events (isTrusted: false) created by our touch handling code.
+    // The browser can fire spurious mouseenter events when we dispatch simulated mousemove events.
+    if (isTouch && e.isTrusted) {
+      return
+    }
     if (!this._canDrop(DDManager.dragElement.el)) return;
     e.preventDefault();
     e.stopPropagation();


### PR DESCRIPTION
### Description
Fixed this touch issue happening on Linux device with touch screen running the application under Electron (Chromium):
When user starts dragging an item, as soon finger leaves the element, _mouseLeave is run, called from @dd-touch.js simulating mouse event. But on next move, _mouseEnter is run even though pointer has not reentered the element. _mouseEnter is not called by @dd-touch.js as part of simulating mouse, but is called as a real mouse event by browser. Strange part is that event.screenX from the _mouseEvent argument, gives a coordinate that matches where finger started dragging, not the coordinate of where the finger left the element.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
