### PR TITLE
layoutsNodesChange() fix with neg values

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2118,7 +2118,7 @@ cacheLayout(
    clear): GridStackEngine;
 ```
 
-Defined in: [gridstack-engine.ts:1196](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1196)
+Defined in: [gridstack-engine.ts:1199](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1199)
 
 call to cache the given layout internally to the given location so we can restore back when column changes size
 
@@ -2140,7 +2140,7 @@ call to cache the given layout internally to the given location so we can restor
 cacheOneLayout(n, column): GridStackEngine;
 ```
 
-Defined in: [gridstack-engine.ts:1216](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1216)
+Defined in: [gridstack-engine.ts:1219](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1219)
 
 call to cache the given node layout internally to the given location so we can restore back when column changes size
 
@@ -2182,7 +2182,7 @@ true if x,y or w,h are different after clamping to min/max
 cleanupNode(node): GridStackEngine;
 ```
 
-Defined in: [gridstack-engine.ts:1247](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1247)
+Defined in: [gridstack-engine.ts:1250](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1250)
 
 called to remove all internal values but the _id
 
@@ -2345,7 +2345,7 @@ Defined in: [gridstack-engine.ts:1002](https://github.com/adumesny/gridstack.js/
 protected findCacheLayout(n, column): number;
 ```
 
-Defined in: [gridstack-engine.ts:1230](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1230)
+Defined in: [gridstack-engine.ts:1233](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1233)
 
 ###### Parameters
 
@@ -2668,7 +2668,7 @@ engine.removeNode(node, true, true);
 removeNodeFromLayoutCache(n): void;
 ```
 
-Defined in: [gridstack-engine.ts:1234](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1234)
+Defined in: [gridstack-engine.ts:1237](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack-engine.ts#L1237)
 
 ###### Parameters
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,7 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [12.4.0 (2025-11-26)](#1240-2025-11-26)
+- [12.4.0 (2025-12-12)](#1240-2025-12-12)
 - [12.3.3 (2025-08-13)](#1233-2025-08-13)
 - [12.3.2 (2025-08-12)](#1232-2025-08-12)
 - [12.3.1 (2025-08-11)](#1231-2025-08-11)
@@ -135,11 +135,12 @@ Change log
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## 12.4.0 (2025-11-26)
+## 12.4.0 (2025-12-12)
 * feat: [#3104](https://github.com/gridstack/gridstack.js/issues/3104) Custom resize div element target - thank you [Marvin Heilemann](https://github.com/muuvmuuv)
 * fix: [#3181](https://github.com/gridstack/gridstack.js/issues/3181) re-initing from DOM missing x:0, y:0 messing layout
 * fix: [#3191](https://github.com/gridstack/gridstack.js/pull/3191) touch issue on Linux
 * fix: [#3194](https://github.com/gridstack/gridstack.js/pull/3194) `updateOption()` update lazyLoad
+* fix: [#3200](https://github.com/gridstack/gridstack.js/pull/3200) updating higher column layout can cause negative values in `layoutsNodesChange()`
 
 ## 12.3.3 (2025-08-13)
 * fix: [#3139](https://github.com/gridstack/gridstack.js/pull/3139) `Utils:removeInternalForSave()` to skip arrays

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -1061,14 +1061,17 @@ export class GridStackEngine {
           // TODO: detect doing item 'swaps' will help instead of move (especially in 1 column mode)
           if (n.y >= 0 && node.y !== node._orig.y) {
             n.y += (node.y - node._orig.y);
+            if (n.y < 0) n.y = 0;
           }
           // X changed, scale from new position
           if (node.x !== node._orig.x) {
             n.x = Math.round(node.x * ratio);
+            if (n.x < 0) n.x = 0;
           }
           // width changed, scale from new width
           if (node.w !== node._orig.w) {
             n.w = Math.round(node.w * ratio);
+            if (n.w < 1) n.w = 1;
           }
           // ...height always carries over from cache
         });


### PR DESCRIPTION
### Description
* updating higher column layout can cause negative values in `layoutsNodesChange()`

Steps:
1. load into 3 column, size down to 2 column
2. move item 1 to the right
3. size item 0 to 1 column -> makes item 1 move to top causing layout[3] to have negative values y=-1 and apparently not fixed later when going back to 3 column (TBD)

    let grid = GridStack.init({
      cellHeight: 80,
      columnOpts: {
        layout: "compact",
        breakpoints: [{w:700, c:2},{w:850, c:3}]
      },
      children: [{x: 0, y: 0, w:2, content: '0'}, {x: 2, y: 0, content: '1'}]})


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
