### PR TITLE
touch event fixes

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -4285,7 +4285,7 @@ Subclasses should override to perform additional cleanup.
 drop(e): void;
 ```
 
-Defined in: [dd-droppable.ts:145](https://github.com/adumesny/gridstack.js/blob/master/src/dd-droppable.ts#L145)
+Defined in: [dd-droppable.ts:143](https://github.com/adumesny/gridstack.js/blob/master/src/dd-droppable.ts#L143)
 
 item is being dropped on us - called by the drag mouseup handler - this calls the client drop event
 

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -8,7 +8,7 @@ import { DragTransform, Utils } from './utils';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { GridItemHTMLElement, DDUIData, GridStackNode, GridStackPosition, DDDragOpt } from './types';
 import { DDElementHost } from './dd-element';
-import { isTouch, touchend, touchmove, touchstart, pointerdown } from './dd-touch';
+import { isTouch, touchend, touchmove, touchstart, pointerdown, DDTouch } from './dd-touch';
 import { GridHTMLElement } from './gridstack';
 
 interface DragOffset {
@@ -133,6 +133,9 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
 
   /** @internal call when mouse goes down before a dragstart happens */
   protected _mouseDown(e: MouseEvent): boolean {
+    // if real brower event (trusted:true vs false for our simulated ones) and we didn't correctly clear the last touch event, clear things up
+    if (DDTouch.touchHandled && e.isTrusted) DDTouch.touchHandled = false;
+
     // don't let more than one widget handle mouseStart
     if (DDManager.mouseHandled) return;
     if (e.button !== 0) return true; // only left click

--- a/src/dd-droppable.ts
+++ b/src/dd-droppable.ts
@@ -8,7 +8,7 @@ import { DDManager } from './dd-manager';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { Utils } from './utils';
 import { DDElementHost } from './dd-element';
-import { isTouch, pointerenter, pointerleave } from './dd-touch';
+import { DDTouch, isTouch, pointerenter, pointerleave } from './dd-touch';
 import { DDUIData } from './types';
 
 export interface DDDroppableOpt {
@@ -84,12 +84,10 @@ export class DDDroppable extends DDBaseImplement implements HTMLElementExtendOpt
   protected _mouseEnter(e: MouseEvent): void {
     // console.log(`${count++} Enter ${this.el.id || (this.el as GridHTMLElement).gridstack.opts.id}`); // TEST
     if (!DDManager.dragElement) return;
-    // During touch drag operations, ignore real browser-generated mouseenter events (isTrusted: true).
-    // Only process simulated mouseenter events (isTrusted: false) created by our touch handling code.
+    // During touch drag operations, ignore real browser-generated mouseenter events (isTrusted:true) vs our simulated ones (isTrusted:false).
     // The browser can fire spurious mouseenter events when we dispatch simulated mousemove events.
-    if (isTouch && e.isTrusted) {
-      return
-    }
+    if (DDTouch.touchHandled && e.isTrusted) return
+
     if (!this._canDrop(DDManager.dragElement.el)) return;
     e.preventDefault();
     e.stopPropagation();

--- a/src/dd-touch.ts
+++ b/src/dd-touch.ts
@@ -24,7 +24,8 @@ export const isTouch: boolean = typeof window !== 'undefined' && typeof document
 
 // interface TouchCoord {x: number, y: number};
 
-class DDTouch {
+export class DDTouch {
+  /** set to true while we are handling touch dragging, to prevent accepting browser real mouse events (trusted:true) vs our simulated ones (trusted:false) */
   public static touchHandled: boolean;
   public static pointerLeaveTimeout: number;
 }


### PR DESCRIPTION
### Description
* fix #3214 and better fix #3191
* linux fix should have used existing `DDTouch.touchHandled` which is set to true while handling touch events since a computer can have both touch and real mouse event
* added safetyc heck to make sure flag is reset if we're missing 'touchend' event.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
