### PR TITLE
[Bug Fix] Improve scrolling speed when dragging items

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -590,28 +590,31 @@ export class Utils {
     const elRect = el.getBoundingClientRect();
     const scrollRect = scrollEl.getBoundingClientRect();
     const innerHeightOrClientHeight = (window.innerHeight || document.documentElement.clientHeight);
-
-    const offsetDiffDown = elRect.bottom - Math.min(scrollRect.bottom, innerHeightOrClientHeight);
-    const offsetDiffUp = elRect.top - Math.max(scrollRect.top, 0);
     const prevScroll = scrollEl.scrollTop;
 
+    // Calculate how far element extends past viewport edges
+    const offsetDiffDown = elRect.bottom - Math.min(scrollRect.bottom, innerHeightOrClientHeight);
+    const offsetDiffUp = elRect.top - Math.max(scrollRect.top, 0);
+
+    // Cap the maximum scroll speed per update
+    const maxScrollPerUpdate = 10;
+    let scrollAmount = 0;
+
     if (offsetDiffUp < 0 && distance < 0) {
-      // scroll up
-      if (el.offsetHeight > scrollRect.height) {
-        scrollEl.scrollTop += distance;
-      } else {
-        scrollEl.scrollTop += Math.abs(offsetDiffUp) > Math.abs(distance) ? distance : offsetDiffUp;
-      }
+      // Element is above viewport, scroll up
+      // Limit scroll speed to maxScrollPerUpdate
+      scrollAmount = Math.max(offsetDiffUp, -maxScrollPerUpdate);
     } else if (offsetDiffDown > 0 && distance > 0) {
-      // scroll down
-      if (el.offsetHeight > scrollRect.height) {
-        scrollEl.scrollTop += distance;
-      } else {
-        scrollEl.scrollTop += offsetDiffDown > distance ? distance : offsetDiffDown;
-      }
+      // Element is below viewport, scroll down
+      // Limit scroll speed to maxScrollPerUpdate
+      scrollAmount = Math.min(offsetDiffDown, maxScrollPerUpdate);
     }
 
-    position.top += scrollEl.scrollTop - prevScroll;
+    // Apply scroll
+    if (scrollAmount !== 0) {
+      scrollEl.scrollTop += scrollAmount;
+      position.top += scrollEl.scrollTop - prevScroll;
+    }
   }
 
   /**


### PR DESCRIPTION
### Description
Fix: Capped auto-scroll speed to maximum 10 pixels per update when dragging items near viewport edges, preventing excessively fast scrolling regardless of drag speed.

## BEFORE
https://github.com/user-attachments/assets/ce4d0a29-c3b0-4ab8-bd85-10bc5392d9a1

## AFTER
https://github.com/user-attachments/assets/4b3e6756-1e06-44ab-af14-df7d4f30c568

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
