### PR TITLE
updateOptions() fixes for maxRow when set row

### DIFF
--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1508,7 +1508,7 @@ export class GridStack {
     if (o.disableResize !== undefined && !o.staticGrid) this.enableResize(!o.disableResize);
     if (o.float !== undefined) this.float(o.float);
     if (o.row !== undefined) {
-      opts.minRow = opts.maxRow = opts.row = o.row;
+      opts.minRow = opts.maxRow = this.engine.maxRow = opts.row = o.row;
       this._updateContainerHeight();
     } else {
       if (o.minRow !== undefined) { opts.minRow = o.minRow; this._updateContainerHeight(); }


### PR DESCRIPTION
### Description
This is the same change that was made in [#3237](https://github.com/gridstack/gridstack.js/pull/3237) for maxRow, but for the case where we specify an exact number of rows.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
