### PR TITLE
cleanup old rtl residue - do not apply direction to grid-stack-rtl

### DIFF
--- a/demo/right-to-left(rtl).html
+++ b/demo/right-to-left(rtl).html
@@ -32,7 +32,12 @@
       {x: 6, y: 0, w: 2, h: 2},
     ];
     items.forEach((item, i) => item.content = 'item ' + i);
-    let grid = GridStack.init({rtl: true, children: items});
+    let grid = GridStack.init({
+        rtl: true,
+        float: true,
+        children: items,
+        resizable: {handles: 'sw,se'}
+    });
 
     function addWidget() {
       let w = {

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -9,13 +9,6 @@
    position: relative;
  }
 
- .grid-stack-rtl {
-   direction: ltr;
-   > .grid-stack-item {
-     direction: rtl;
-   }
- }
-
  .grid-stack-placeholder > .placeholder-content {
    background-color: rgba(0,0,0,0.1);
    margin: 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,7 +354,7 @@ export interface GridStackOptions {
   row?: number;
 
   /**
-   * if true turns grid to RTL. Possible values are true, false, 'auto' (default?: 'auto')
+   * if true turns grid to RTL, and applies the `grid-stack-rtl class`. Possible values are true, false, 'auto' (default?: 'auto')
    * See [example](http://gridstack.github.io/gridstack.js/demo/right-to-left(rtl).html)
    */
   rtl?: boolean | 'auto';


### PR DESCRIPTION
### Description
Minor cleanup. more fix #819 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing (`yarn test`)
- [X] Extended the README / documentation, if necessary
