### PR TITLE
docs: fix typo "teh" → "the" in utils.ts JSDoc

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -639,7 +639,7 @@ export class Utils {
     return ret;
   }
 
-  /** deep clone the given HTML node, removing teh unique id field */
+  /** deep clone the given HTML node, removing the unique id field */
   public static cloneNode(el: HTMLElement): HTMLElement {
     const node = el.cloneNode(true) as HTMLElement;
     node.removeAttribute('id');


### PR DESCRIPTION
JSDoc-only typo fix in `src/utils.ts:642` on the `cloneNode` helper. No behavior change.