### PR TITLE
react: improve wrapper — fix cross-grid DnD, perf, parity with Angular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 .idea/
 .DS_Store
 doc/html/
+.claude

--- a/angular/doc/api/gridstack-item.component.md
+++ b/angular/doc/api/gridstack-item.component.md
@@ -2671,6 +2671,7 @@ GridItemHTMLElement.replaceChildren
 
 | Property | Modifier | Type | Description | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ |
+| <a id="gridstacknode"></a> `gridstackNode?` | `public` | `GridStackNode` | Pointer to the associated grid node instance containing position, size, and other widget data | `GridItemHTMLElement.gridstackNode` | dist/types.d.ts:45 |
 | <a id="_griditemcomp"></a> `_gridItemComp?` | `public` | [`GridstackItemComponent`](#gridstackitemcomponent) | Back-reference to the Angular GridStackItem component | - | [angular/projects/lib/src/lib/gridstack-item.component.ts:16](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack-item.component.ts#L16) |
 | <a id="ariaatomic"></a> `ariaAtomic` | `public` | `null` \| `string` | - | `GridItemHTMLElement.ariaAtomic` | node\_modules/typescript/lib/lib.dom.d.ts:2020 |
 | <a id="ariaautocomplete"></a> `ariaAutoComplete` | `public` | `null` \| `string` | - | `GridItemHTMLElement.ariaAutoComplete` | node\_modules/typescript/lib/lib.dom.d.ts:2021 |

--- a/angular/doc/api/gridstack.component.md
+++ b/angular/doc/api/gridstack.component.md
@@ -2860,6 +2860,7 @@ GridHTMLElement.replaceChildren
 
 | Property | Modifier | Type | Description | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ |
+| <a id="gridstack"></a> `gridstack?` | `public` | `GridStack` | - | `GridHTMLElement.gridstack` | dist/gridstack.d.ts:24 |
 | <a id="_gridcomp"></a> `_gridComp?` | `public` | [`GridstackComponent`](#gridstackcomponent) | Back-reference to the Angular GridStack component | - | [angular/projects/lib/src/lib/gridstack.component.ts:41](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L41) |
 | <a id="ariaatomic"></a> `ariaAtomic` | `public` | `null` \| `string` | - | `GridHTMLElement.ariaAtomic` | node\_modules/typescript/lib/lib.dom.d.ts:2020 |
 | <a id="ariaautocomplete"></a> `ariaAutoComplete` | `public` | `null` \| `string` | - | `GridHTMLElement.ariaAutoComplete` | node\_modules/typescript/lib/lib.dom.d.ts:2021 |

--- a/angular/doc/api/types.md
+++ b/angular/doc/api/types.md
@@ -15,11 +15,28 @@ Adds Angular-specific properties for dynamic component creation.
 
 #### Properties
 
-| Property | Type | Description | Overrides | Defined in |
-| ------ | ------ | ------ | ------ | ------ |
-| <a id="selector"></a> `selector?` | `string` | Angular component selector for dynamic creation (e.g., 'my-widget') | - | [angular/projects/lib/src/lib/types.ts:14](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L14) |
-| <a id="input"></a> `input?` | [`NgCompInputs`](#ngcompinputs) | Serialized data for component @Input() properties | - | [angular/projects/lib/src/lib/types.ts:16](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L16) |
-| <a id="subgridopts"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids | `GridStackWidget.subGridOpts` | [angular/projects/lib/src/lib/types.ts:18](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L18) |
+| Property | Type | Description | Overrides | Inherited from | Defined in |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| <a id="x"></a> `x?` | `number` | widget position x (default?: 0) | - | `GridStackWidget.x` | dist/types.d.ts:321 |
+| <a id="y"></a> `y?` | `number` | widget position y (default?: 0) | - | `GridStackWidget.y` | dist/types.d.ts:323 |
+| <a id="w"></a> `w?` | `number` | widget dimension width (default?: 1) | - | `GridStackWidget.w` | dist/types.d.ts:325 |
+| <a id="h"></a> `h?` | `number` | widget dimension height (default?: 1) | - | `GridStackWidget.h` | dist/types.d.ts:327 |
+| <a id="autoposition"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | - | `GridStackWidget.autoPosition` | dist/types.d.ts:334 |
+| <a id="minw"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | - | `GridStackWidget.minW` | dist/types.d.ts:336 |
+| <a id="maxw"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | - | `GridStackWidget.maxW` | dist/types.d.ts:338 |
+| <a id="minh"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | - | `GridStackWidget.minH` | dist/types.d.ts:340 |
+| <a id="maxh"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | - | `GridStackWidget.maxH` | dist/types.d.ts:342 |
+| <a id="noresize"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | - | `GridStackWidget.noResize` | dist/types.d.ts:344 |
+| <a id="nomove"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | - | `GridStackWidget.noMove` | dist/types.d.ts:346 |
+| <a id="locked"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | - | `GridStackWidget.locked` | dist/types.d.ts:348 |
+| <a id="id"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | - | `GridStackWidget.id` | dist/types.d.ts:350 |
+| <a id="content"></a> `content?` | `string` | html to append inside as content | - | `GridStackWidget.content` | dist/types.d.ts:352 |
+| <a id="lazyload"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | - | `GridStackWidget.lazyLoad` | dist/types.d.ts:354 |
+| <a id="sizetocontent"></a> `sizeToContent?` | `number` \| `boolean` | local (vs grid) override - see GridStackOptions. Note: This also allow you to set a maximum h value (but user changeable during normal resizing) to prevent unlimited content from taking too much space (get scrollbar) | - | `GridStackWidget.sizeToContent` | dist/types.d.ts:357 |
+| <a id="resizetocontentparent"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | - | `GridStackWidget.resizeToContentParent` | dist/types.d.ts:359 |
+| <a id="selector"></a> `selector?` | `string` | Angular component selector for dynamic creation (e.g., 'my-widget') | - | - | [angular/projects/lib/src/lib/types.ts:14](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L14) |
+| <a id="input"></a> `input?` | [`NgCompInputs`](#ngcompinputs) | Serialized data for component @Input() properties | - | - | [angular/projects/lib/src/lib/types.ts:16](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L16) |
+| <a id="subgridopts"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids | `GridStackWidget.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:18](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L18) |
 
 ***
 
@@ -36,9 +53,31 @@ Adds component selector for dynamic content creation.
 
 #### Properties
 
-| Property | Type | Description | Defined in |
-| ------ | ------ | ------ | ------ |
-| <a id="selector-1"></a> `selector?` | `string` | Angular component selector for this node's content | [angular/projects/lib/src/lib/types.ts:27](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L27) |
+| Property | Type | Description | Inherited from | Defined in |
+| ------ | ------ | ------ | ------ | ------ |
+| <a id="x-1"></a> `x?` | `number` | widget position x (default?: 0) | `GridStackNode.x` | dist/types.d.ts:321 |
+| <a id="y-1"></a> `y?` | `number` | widget position y (default?: 0) | `GridStackNode.y` | dist/types.d.ts:323 |
+| <a id="w-1"></a> `w?` | `number` | widget dimension width (default?: 1) | `GridStackNode.w` | dist/types.d.ts:325 |
+| <a id="h-1"></a> `h?` | `number` | widget dimension height (default?: 1) | `GridStackNode.h` | dist/types.d.ts:327 |
+| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | `GridStackNode.autoPosition` | dist/types.d.ts:334 |
+| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | `GridStackNode.minW` | dist/types.d.ts:336 |
+| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | `GridStackNode.maxW` | dist/types.d.ts:338 |
+| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | `GridStackNode.minH` | dist/types.d.ts:340 |
+| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | `GridStackNode.maxH` | dist/types.d.ts:342 |
+| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | `GridStackNode.noResize` | dist/types.d.ts:344 |
+| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | `GridStackNode.noMove` | dist/types.d.ts:346 |
+| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | `GridStackNode.locked` | dist/types.d.ts:348 |
+| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | `GridStackNode.id` | dist/types.d.ts:350 |
+| <a id="content-1"></a> `content?` | `string` | html to append inside as content | `GridStackNode.content` | dist/types.d.ts:352 |
+| <a id="lazyload-1"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | `GridStackNode.lazyLoad` | dist/types.d.ts:354 |
+| <a id="sizetocontent-1"></a> `sizeToContent?` | `number` \| `boolean` | local (vs grid) override - see GridStackOptions. Note: This also allow you to set a maximum h value (but user changeable during normal resizing) to prevent unlimited content from taking too much space (get scrollbar) | `GridStackNode.sizeToContent` | dist/types.d.ts:357 |
+| <a id="resizetocontentparent-1"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | `GridStackNode.resizeToContentParent` | dist/types.d.ts:359 |
+| <a id="subgridopts-1"></a> `subGridOpts?` | `GridStackOptions` | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | `GridStackNode.subGridOpts` | dist/types.d.ts:361 |
+| <a id="el"></a> `el?` | `GridItemHTMLElement` | pointer back to HTML element | `GridStackNode.el` | dist/types.d.ts:431 |
+| <a id="grid"></a> `grid?` | `GridStack` | pointer back to parent Grid instance | `GridStackNode.grid` | dist/types.d.ts:433 |
+| <a id="subgrid"></a> `subGrid?` | `GridStack` | actual sub-grid instance | `GridStackNode.subGrid` | dist/types.d.ts:435 |
+| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | `GridStackNode.visibleObservable` | dist/types.d.ts:437 |
+| <a id="selector-1"></a> `selector?` | `string` | Angular component selector for this node's content | - | [angular/projects/lib/src/lib/types.ts:27](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L27) |
 
 ***
 
@@ -55,10 +94,50 @@ Supports Angular-specific widget definitions and nested grids.
 
 #### Properties
 
-| Property | Type | Description | Overrides | Defined in |
-| ------ | ------ | ------ | ------ | ------ |
-| <a id="children"></a> `children?` | [`NgGridStackWidget`](#nggridstackwidget)[] | Array of Angular widget definitions for initial grid setup | `GridStackOptions.children` | [angular/projects/lib/src/lib/types.ts:36](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L36) |
-| <a id="subgridopts-1"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids (Angular-aware) | `GridStackOptions.subGridOpts` | [angular/projects/lib/src/lib/types.ts:38](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L38) |
+| Property | Type | Description | Overrides | Inherited from | Defined in |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| <a id="acceptwidgets"></a> `acceptWidgets?` | `string` \| `boolean` \| (`element`) => `boolean` | Accept widgets dragged from other grids or from outside (default: `false`). Can be: - `true`: will accept HTML elements having 'grid-stack-item' as class attribute - `false`: will not accept any external widgets - string: explicit class name to accept instead of default - function: callback called before an item will be accepted when entering a grid **Example** `// Accept all grid items acceptWidgets: true // Accept only items with specific class acceptWidgets: 'my-draggable-item' // Custom validation function acceptWidgets: (el) => { return el.getAttribute('data-accept') === 'true'; }` **See** [http://gridstack.github.io/gridstack.js/demo/two.html](http://gridstack.github.io/gridstack.js/demo/two.html) for complete example | - | `GridStackOptions.acceptWidgets` | dist/types.d.ts:155 |
+| <a id="alwaysshowresizehandle"></a> `alwaysShowResizeHandle?` | `boolean` \| `"mobile"` | possible values (default: `mobile`) - does not apply to non-resizable widgets `false` the resizing handles are only shown while hovering over a widget `true` the resizing handles are always shown 'mobile' if running on a mobile device, default to `true` (since there is no hovering per say), else `false`. See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html) | - | `GridStackOptions.alwaysShowResizeHandle` | dist/types.d.ts:161 |
+| <a id="animate"></a> `animate?` | `boolean` | turns animation on (default?: true) | - | `GridStackOptions.animate` | dist/types.d.ts:163 |
+| <a id="auto"></a> `auto?` | `boolean` | if false gridstack will not initialize existing items (default?: true) | - | `GridStackOptions.auto` | dist/types.d.ts:165 |
+| <a id="cellheight"></a> `cellHeight?` | `numberOrString` | One cell height (default: 'auto'). Can be: - an integer (px): fixed pixel height - a string (ex: '100px', '10em', '10rem'): CSS length value - 0: library will not generate styles for rows (define your own CSS) - 'auto': height calculated for square cells (width / column) and updated live on window resize - 'initial': similar to 'auto' but stays fixed size during window resizing Note: % values don't work correctly - see demo/cell-height.html **Example** `// Fixed 100px height cellHeight: 100 // CSS units cellHeight: '5rem' cellHeight: '100px' // Auto-sizing for square cells cellHeight: 'auto' // No CSS generation (custom styles) cellHeight: 0` | - | `GridStackOptions.cellHeight` | dist/types.d.ts:190 |
+| <a id="cellheightthrottle"></a> `cellHeightThrottle?` | `number` | throttle time delay (in ms) used when cellHeight='auto' to improve performance vs usability (default?: 100). A value of 0 will make it instant at a cost of re-creating the CSS file at ever window resize event! | - | `GridStackOptions.cellHeightThrottle` | dist/types.d.ts:194 |
+| <a id="cellheightunit"></a> `cellHeightUnit?` | `string` | (internal) unit for cellHeight (default? 'px') which is set when a string cellHeight with a unit is passed (ex: '10rem') | - | `GridStackOptions.cellHeightUnit` | dist/types.d.ts:196 |
+| <a id="column"></a> `column?` | `number` \| `"auto"` | number of columns (default?: 12). Note: IF you change this, CSS also have to change. See https://github.com/gridstack/gridstack.js#change-grid-columns. Note: for nested grids, it is recommended to use 'auto' which will always match the container grid-item current width (in column) to keep inside and outside items always the same. flag is NOT supported for regular non-nested grids. | - | `GridStackOptions.column` | dist/types.d.ts:203 |
+| <a id="columnopts"></a> `columnOpts?` | `Responsive` | responsive column layout for width:column behavior | - | `GridStackOptions.columnOpts` | dist/types.d.ts:205 |
+| <a id="class"></a> `class?` | `string` | additional class on top of '.grid-stack' (which is required for our CSS) to differentiate this instance. Note: only used by addGrid(), else your element should have the needed class | - | `GridStackOptions.class` | dist/types.d.ts:208 |
+| <a id="disabledrag"></a> `disableDrag?` | `boolean` | disallows dragging of widgets (default?: false) | - | `GridStackOptions.disableDrag` | dist/types.d.ts:210 |
+| <a id="disableresize"></a> `disableResize?` | `boolean` | disallows resizing of widgets (default?: false). | - | `GridStackOptions.disableResize` | dist/types.d.ts:212 |
+| <a id="draggable"></a> `draggable?` | `DDDragOpt` | allows to override UI draggable options. (default?: { handle?: '.grid-stack-item-content', appendTo?: 'body' }) | - | `GridStackOptions.draggable` | dist/types.d.ts:214 |
+| <a id="engineclass"></a> `engineClass?` | *typeof* `GridStackEngine` | the type of engine to create (so you can subclass) default to GridStackEngine | - | `GridStackOptions.engineClass` | dist/types.d.ts:217 |
+| <a id="float"></a> `float?` | `boolean` | enable floating widgets (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/float.html) | - | `GridStackOptions.float` | dist/types.d.ts:219 |
+| <a id="handle"></a> `handle?` | `string` | draggable handle selector (default?: '.grid-stack-item-content') | - | `GridStackOptions.handle` | dist/types.d.ts:221 |
+| <a id="handleclass"></a> `handleClass?` | `string` | draggable handle class (e.g. 'grid-stack-item-content'). If set 'handle' is ignored (default?: null) | - | `GridStackOptions.handleClass` | dist/types.d.ts:223 |
+| <a id="itemclass"></a> `itemClass?` | `string` | additional widget class (default?: 'grid-stack-item') | - | `GridStackOptions.itemClass` | dist/types.d.ts:225 |
+| <a id="layout"></a> `layout?` | `ColumnOptions` | re-layout mode when we're a subgrid and we are being resized. default to 'list' | - | `GridStackOptions.layout` | dist/types.d.ts:227 |
+| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | - | `GridStackOptions.lazyLoad` | dist/types.d.ts:229 |
+| <a id="margin"></a> `margin?` | `numberOrString` | gap between grid item and content (default?: 10). This will set all 4 sides and support the CSS formats below an integer (px) a string with possible units (ex: '2em', '20px', '2rem') string with space separated values (ex: '5px 10px 0 20px' for all 4 sides, or '5em 10em' for top/bottom and left/right pairs like CSS). Note: all sides must have same units (last one wins, default px) | - | `GridStackOptions.margin` | dist/types.d.ts:237 |
+| <a id="margintop"></a> `marginTop?` | `numberOrString` | OLD way to optionally set each side - use margin: '5px 10px 0 20px' instead. Used internally to store each side. | - | `GridStackOptions.marginTop` | dist/types.d.ts:239 |
+| <a id="marginright"></a> `marginRight?` | `numberOrString` | - | - | `GridStackOptions.marginRight` | dist/types.d.ts:240 |
+| <a id="marginbottom"></a> `marginBottom?` | `numberOrString` | - | - | `GridStackOptions.marginBottom` | dist/types.d.ts:241 |
+| <a id="marginleft"></a> `marginLeft?` | `numberOrString` | - | - | `GridStackOptions.marginLeft` | dist/types.d.ts:242 |
+| <a id="marginunit"></a> `marginUnit?` | `string` | (internal) unit for margin (default? 'px') set when `margin` is set as string with unit (ex: 2rem') | - | `GridStackOptions.marginUnit` | dist/types.d.ts:244 |
+| <a id="maxrow"></a> `maxRow?` | `number` | maximum rows amount. Default? is 0 which means no maximum rows | - | `GridStackOptions.maxRow` | dist/types.d.ts:246 |
+| <a id="minrow"></a> `minRow?` | `number` | minimum rows amount which is handy to prevent grid from collapsing when empty. Default is `0`. When no set the `min-height` CSS attribute on the grid div (in pixels) can be used, which will round to the closest row. | - | `GridStackOptions.minRow` | dist/types.d.ts:250 |
+| <a id="nonce"></a> `nonce?` | `string` | If you are using a nonce-based Content Security Policy, pass your nonce here and GridStack will add it to the `<style>` elements it creates. | - | `GridStackOptions.nonce` | dist/types.d.ts:253 |
+| <a id="placeholderclass"></a> `placeholderClass?` | `string` | class for placeholder (default?: 'grid-stack-placeholder') | - | `GridStackOptions.placeholderClass` | dist/types.d.ts:255 |
+| <a id="placeholdertext"></a> `placeholderText?` | `string` | placeholder default content (default?: '') | - | `GridStackOptions.placeholderText` | dist/types.d.ts:257 |
+| <a id="resizable"></a> `resizable?` | `DDResizeOpt` | allows to override UI resizable options. default is { handles: 'se', autoHide: true on desktop, false on mobile } | - | `GridStackOptions.resizable` | dist/types.d.ts:259 |
+| <a id="removable"></a> `removable?` | `string` \| `boolean` | if true widgets could be removed by dragging outside of the grid. It could also be a selector string (ex: ".trash"), in this case widgets will be removed by dropping them there (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/two.html) | - | `GridStackOptions.removable` | dist/types.d.ts:265 |
+| <a id="removableoptions"></a> `removableOptions?` | `DDRemoveOpt` | allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) | - | `GridStackOptions.removableOptions` | dist/types.d.ts:267 |
+| <a id="row"></a> `row?` | `number` | fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) | - | `GridStackOptions.row` | dist/types.d.ts:269 |
+| <a id="rtl"></a> `rtl?` | `boolean` \| `"auto"` | if true turns grid to RTL. Possible values are true, false, 'auto' (default?: 'auto') See [example](http://gridstack.github.io/gridstack.js/demo/right-to-left(rtl).html) | - | `GridStackOptions.rtl` | dist/types.d.ts:274 |
+| <a id="sizetocontent-2"></a> `sizeToContent?` | `boolean` | set to true if all grid items (by default, but item can also override) height should be based on content size instead of WidgetItem.h to avoid v-scrollbars. Note: this is still row based, not pixels, so it will use ceil(getBoundingClientRect().height / getCellHeight()) | - | `GridStackOptions.sizeToContent` | dist/types.d.ts:278 |
+| <a id="staticgrid"></a> `staticGrid?` | `boolean` | makes grid static (default?: false). If `true` widgets are not movable/resizable. You don't even need draggable/resizable. A CSS class 'grid-stack-static' is also added to the element. | - | `GridStackOptions.staticGrid` | dist/types.d.ts:284 |
+| <a id="styleinhead"></a> ~~`styleInHead?`~~ | `boolean` | **Deprecated** Not used anymore, styles are now implemented with local CSS variables | - | `GridStackOptions.styleInHead` | dist/types.d.ts:288 |
+| <a id="subgriddynamic"></a> `subGridDynamic?` | `boolean` | enable/disable the creation of sub-grids on the fly by dragging items completely over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that. | - | `GridStackOptions.subGridDynamic` | dist/types.d.ts:293 |
+| <a id="children"></a> `children?` | [`NgGridStackWidget`](#nggridstackwidget)[] | Array of Angular widget definitions for initial grid setup | `GridStackOptions.children` | - | [angular/projects/lib/src/lib/types.ts:36](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L36) |
+| <a id="subgridopts-2"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids (Angular-aware) | `GridStackOptions.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:38](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L38) |
 
 ## Type Aliases
 

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -10,6 +10,9 @@
     "paths": {
       "lib": [
         "../dist/angular"
+      ],
+      "gridstack": [
+        "../dist/gridstack"
       ]
     },
     "noPropertyAccessFromIndexSignature": true,

--- a/doc/API.md
+++ b/doc/API.md
@@ -2840,7 +2840,7 @@ return true if can fit in grid height constrain only (always true if no maxRow)
 <a id="utils"></a>
 ### Utils
 
-Defined in: [utils.ts:97](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L97)
+Defined in: [utils.ts:98](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L98)
 
 Collection of utility methods used throughout GridStack.
 These are general-purpose helper functions for DOM manipulation,
@@ -2866,7 +2866,7 @@ new Utils(): Utils;
 static addElStyles(el, styles): void;
 ```
 
-Defined in: [utils.ts:667](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L667)
+Defined in: [utils.ts:703](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L703)
 
 ###### Parameters
 
@@ -2885,7 +2885,7 @@ Defined in: [utils.ts:667](https://github.com/adumesny/gridstack.js/blob/master/
 static appendTo(el, parent): void;
 ```
 
-Defined in: [utils.ts:649](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L649)
+Defined in: [utils.ts:685](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L685)
 
 ###### Parameters
 
@@ -2904,7 +2904,7 @@ Defined in: [utils.ts:649](https://github.com/adumesny/gridstack.js/blob/master/
 static area(a): number;
 ```
 
-Defined in: [utils.ts:297](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L297)
+Defined in: [utils.ts:298](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L298)
 
 Calculate the total area of a grid position.
 
@@ -2932,7 +2932,7 @@ const area = Utils.area({x: 0, y: 0, w: 3, h: 2}); // returns 6
 static areaIntercept(a, b): number;
 ```
 
-Defined in: [utils.ts:278](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L278)
+Defined in: [utils.ts:279](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L279)
 
 Calculate the overlapping area between two grid positions.
 
@@ -2964,7 +2964,7 @@ const overlap = Utils.areaIntercept(
 static canBeRotated(n): boolean;
 ```
 
-Defined in: [utils.ts:770](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L770)
+Defined in: [utils.ts:806](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L806)
 
 true if the item can be rotated (checking for prop, not space available)
 
@@ -2984,7 +2984,7 @@ true if the item can be rotated (checking for prop, not space available)
 static clone<T>(obj): T;
 ```
 
-Defined in: [utils.ts:612](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L612)
+Defined in: [utils.ts:648](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L648)
 
 single level clone, returning a new object with same top fields. This will share sub objects and arrays
 
@@ -3010,7 +3010,7 @@ single level clone, returning a new object with same top fields. This will share
 static cloneDeep<T>(obj): T;
 ```
 
-Defined in: [utils.ts:628](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L628)
+Defined in: [utils.ts:664](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L664)
 
 Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
 Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
@@ -3037,9 +3037,9 @@ Note: this will use as-is any key starting with double __ (and not copy inside) 
 static cloneNode(el): HTMLElement;
 ```
 
-Defined in: [utils.ts:643](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L643)
+Defined in: [utils.ts:679](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L679)
 
-deep clone the given HTML node, removing teh unique id field
+deep clone the given HTML node, removing the unique id field
 
 ###### Parameters
 
@@ -3060,7 +3060,7 @@ static copyPos(
    doMinMax): GridStackWidget;
 ```
 
-Defined in: [utils.ts:474](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L474)
+Defined in: [utils.ts:510](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L510)
 
 Copy position and size properties from one widget to another.
 Copies x, y, w, h and optionally min/max constraints.
@@ -3092,7 +3092,7 @@ Utils.copyPos(widget1, widget2, true); // Also copy constraints
 static createDiv(classes, parent?): HTMLElement;
 ```
 
-Defined in: [utils.ts:206](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L206)
+Defined in: [utils.ts:207](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L207)
 
 Create a div element with the specified CSS classes.
 
@@ -3122,7 +3122,7 @@ const nested = Utils.createDiv(['content'], parentDiv);
 static defaults(target, ...sources): object;
 ```
 
-Defined in: [utils.ts:421](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L421)
+Defined in: [utils.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L457)
 
 Copy unset fields from source objects to target object (shallow merge with defaults).
 Similar to Object.assign but only sets undefined/null fields.
@@ -3154,7 +3154,7 @@ Utils.defaults(config, { width: 200, height: 50 });
 static find(nodes, id): GridStackNode;
 ```
 
-Defined in: [utils.ts:332](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L332)
+Defined in: [utils.ts:344](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L344)
 
 Find a grid node by its ID.
 
@@ -3178,13 +3178,47 @@ const node = Utils.find(nodes, 'widget-1');
 if (node) console.log('Found node at:', node.x, node.y);
 ```
 
+##### findInGrid()
+
+```ts
+static findInGrid(
+   g, 
+   id, 
+   recursive?): GridStackNode;
+```
+
+Defined in: [utils.ts:360](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L360)
+
+Find a node by ID in a grid, optionally searching nested sub-grids.
+
+###### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `g` | [`GridStack`](#gridstack-1) | the grid to search |
+| `id` | `string` | the ID to search for |
+| `recursive?` | `boolean` | if true (default), also search nested sub-grids |
+
+###### Returns
+
+[`GridStackNode`](#gridstacknode-2)
+
+the node with matching ID, or undefined if not found
+
+###### Example
+
+```ts
+const node = Utils.findInGrid(grid, 'widget-1');          // recursive by default
+const top  = Utils.findInGrid(grid, 'widget-1', false);   // top-level only
+```
+
 ##### getElement()
 
 ```ts
 static getElement(els, root): HTMLElement;
 ```
 
-Defined in: [utils.ts:155](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L155)
+Defined in: [utils.ts:156](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L156)
 
 Convert a potential selector into a single HTML element.
 Similar to getElements() but returns only the first match.
@@ -3215,7 +3249,7 @@ const first = Utils.getElement('.grid-item');
 static getElements(els, root): HTMLElement[];
 ```
 
-Defined in: [utils.ts:112](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L112)
+Defined in: [utils.ts:113](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L113)
 
 Convert a potential selector into an actual list of HTML elements.
 Supports CSS selectors, element references, and special ID handling.
@@ -3247,7 +3281,7 @@ const fromShadow = Utils.getElements('.item', shadowRoot);
 static getValuesFromTransformedElement(parent): DragTransform;
 ```
 
-Defined in: [utils.ts:727](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L727)
+Defined in: [utils.ts:763](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L763)
 
 defines an element that is used to get the offset and scale from grid transforms
 returns the scale and offsets from said element
@@ -3268,7 +3302,7 @@ returns the scale and offsets from said element
 static initEvent<T>(e, info): T;
 ```
 
-Defined in: [utils.ts:684](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L684)
+Defined in: [utils.ts:720](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L720)
 
 ###### Type Parameters
 
@@ -3295,7 +3329,7 @@ Defined in: [utils.ts:684](https://github.com/adumesny/gridstack.js/blob/master/
 static isIntercepted(a, b): boolean;
 ```
 
-Defined in: [utils.ts:244](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L244)
+Defined in: [utils.ts:245](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L245)
 
 Check if two grid positions overlap/intersect.
 
@@ -3327,7 +3361,7 @@ const overlaps = Utils.isIntercepted(
 static isTouching(a, b): boolean;
 ```
 
-Defined in: [utils.ts:261](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L261)
+Defined in: [utils.ts:262](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L262)
 
 Check if two grid positions are touching (edges or corners).
 
@@ -3359,7 +3393,7 @@ const touching = Utils.isTouching(
 static lazyLoad(n): boolean;
 ```
 
-Defined in: [utils.ts:191](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L191)
+Defined in: [utils.ts:192](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L192)
 
 Check if a widget should be lazy loaded based on node or grid settings.
 
@@ -3389,7 +3423,7 @@ if (Utils.lazyLoad(node)) {
 static parseHeight(val): HeightData;
 ```
 
-Defined in: [utils.ts:388](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L388)
+Defined in: [utils.ts:424](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L424)
 
 Parse a height value with units into numeric value and unit string.
 Supports px, em, rem, vh, vw, %, cm, mm units.
@@ -3420,7 +3454,7 @@ Utils.parseHeight(50);       // {h: 50, unit: 'px'}
 static removeInternalAndSame(a, b): void;
 ```
 
-Defined in: [utils.ts:503](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L503)
+Defined in: [utils.ts:539](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L539)
 
 removes field from the first object if same as the second objects (like diffing) and internal '_' for saving
 
@@ -3441,7 +3475,7 @@ removes field from the first object if same as the second objects (like diffing)
 static removeInternalForSave(n, removeEl): void;
 ```
 
-Defined in: [utils.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L520)
+Defined in: [utils.ts:556](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L556)
 
 removes internal fields '_' and default values for saving
 
@@ -3462,7 +3496,7 @@ removes internal fields '_' and default values for saving
 static removePositioningStyles(el): void;
 ```
 
-Defined in: [utils.ts:553](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L553)
+Defined in: [utils.ts:589](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L589)
 
 ###### Parameters
 
@@ -3480,7 +3514,7 @@ Defined in: [utils.ts:553](https://github.com/adumesny/gridstack.js/blob/master/
 static same(a, b): boolean;
 ```
 
-Defined in: [utils.ts:450](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L450)
+Defined in: [utils.ts:486](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L486)
 
 Compare two objects for equality (shallow comparison).
 Checks if objects have the same fields and values at one level deep.
@@ -3511,7 +3545,7 @@ Utils.same({x: 1}, {x: 1, y: 2}); // false
 static samePos(a, b): boolean;
 ```
 
-Defined in: [utils.ts:489](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L489)
+Defined in: [utils.ts:525](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L525)
 
 true if a and b has same size & position
 
@@ -3532,7 +3566,7 @@ true if a and b has same size & position
 static sanitizeMinMax(node): void;
 ```
 
-Defined in: [utils.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L494)
+Defined in: [utils.ts:530](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L530)
 
 given a node, makes sure it's min/max are valid
 
@@ -3552,7 +3586,7 @@ given a node, makes sure it's min/max are valid
 static shouldSizeToContent(n, strict): boolean;
 ```
 
-Defined in: [utils.ts:225](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L225)
+Defined in: [utils.ts:226](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L226)
 
 Check if a widget should resize to fit its content.
 
@@ -3586,7 +3620,7 @@ static simulateMouseEvent(
    target?): void;
 ```
 
-Defined in: [utils.ts:700](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L700)
+Defined in: [utils.ts:736](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L736)
 
 copies the MouseEvent (or convert Touch) properties and sends it as another event to the given target
 
@@ -3608,7 +3642,7 @@ copies the MouseEvent (or convert Touch) properties and sends it as another even
 static sort(nodes, dir): GridStackNode[];
 ```
 
-Defined in: [utils.ts:312](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L312)
+Defined in: [utils.ts:313](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L313)
 
 Sort an array of grid nodes by position (y first, then x).
 
@@ -3641,7 +3675,7 @@ static swap(
    b): void;
 ```
 
-Defined in: [utils.ts:751](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L751)
+Defined in: [utils.ts:787](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L787)
 
 swap the given object 2 field values
 
@@ -3663,7 +3697,7 @@ swap the given object 2 field values
 static throttle(func, delay): () => void;
 ```
 
-Defined in: [utils.ts:543](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L543)
+Defined in: [utils.ts:579](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L579)
 
 delay calling the given function for given delay, preventing new calls from happening while waiting
 
@@ -3690,7 +3724,7 @@ delay calling the given function for given delay, preventing new calls from happ
 static toBool(v): boolean;
 ```
 
-Defined in: [utils.ts:350](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L350)
+Defined in: [utils.ts:386](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L386)
 
 Convert various value types to boolean.
 Handles strings like 'false', 'no', '0' as false.
@@ -3722,7 +3756,7 @@ Utils.toBool('1');     // true
 static toNumber(value): number;
 ```
 
-Defined in: [utils.ts:372](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L372)
+Defined in: [utils.ts:408](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L408)
 
 Convert a string value to a number, handling null and empty strings.
 
@@ -5444,16 +5478,16 @@ data that is passed during drag and resizing callbacks
 <a id="dragtransform"></a>
 ### DragTransform
 
-Defined in: [utils.ts:13](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L13)
+Defined in: [utils.ts:14](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L14)
 
 #### Properties
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="xoffset"></a> `xOffset` | `number` | [utils.ts:16](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L16) |
-| <a id="xscale"></a> `xScale` | `number` | [utils.ts:14](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L14) |
-| <a id="yoffset"></a> `yOffset` | `number` | [utils.ts:17](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L17) |
-| <a id="yscale"></a> `yScale` | `number` | [utils.ts:15](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L15) |
+| <a id="xoffset"></a> `xOffset` | `number` | [utils.ts:17](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L17) |
+| <a id="xscale"></a> `xScale` | `number` | [utils.ts:15](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L15) |
+| <a id="yoffset"></a> `yOffset` | `number` | [utils.ts:18](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L18) |
+| <a id="yscale"></a> `yScale` | `number` | [utils.ts:16](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L16) |
 
 ***
 
@@ -5675,14 +5709,14 @@ GridStack Widget creation options
 <a id="heightdata"></a>
 ### HeightData
 
-Defined in: [utils.ts:8](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L8)
+Defined in: [utils.ts:9](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L9)
 
 #### Properties
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="h-4"></a> `h` | `number` | [utils.ts:9](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L9) |
-| <a id="unit"></a> `unit` | `string` | [utils.ts:10](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L10) |
+| <a id="h-4"></a> `h` | `number` | [utils.ts:10](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L10) |
+| <a id="unit"></a> `unit` | `string` | [utils.ts:11](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L11) |
 
 ***
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "scripts": {
-    "build": "yarn build:ng && yarn build:react && grunt && webpack && tsc --project tsconfig.build.json --stripInternal && yarn doc",
+    "build": "grunt && webpack && tsc --project tsconfig.build.json --stripInternal && yarn build:ng && yarn build:react && yarn doc",
     "build:ng": "cd angular && yarn build lib",
     "build:react": "cd react && yarn build:lib",
     "w": "webpack",

--- a/react/package.json
+++ b/react/package.json
@@ -14,7 +14,6 @@
     "test:ui": "vitest --config vitest.config.ts --ui"
   },
   "dependencies": {
-    "gridstack": "^12.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-fast-compare": "^3.2.2",

--- a/react/projects/lib/src/gridstack-context.tsx
+++ b/react/projects/lib/src/gridstack-context.tsx
@@ -3,23 +3,20 @@ import type { GridStack } from "gridstack";
 
 export interface GridStackContextValue {
   grid: GridStack | null;
-  /** Bumped after GS-driven updates so descendants can re-sync */
+  /** Bumped after GS-driven structural changes (add/remove) so portal containers re-sync. */
   layoutVersion: number;
   /** @internal — used by `useWidgetSerializer` via `<GridStackItem>` */
   registerWidgetSerializer: (
     id: string,
-    fn: () => Record<string, unknown> | undefined
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void
   ) => () => void;
 }
 
-export const GridStackContext = createContext<GridStackContextValue | null>(
-  null
-);
+export const GridStackContext = createContext<GridStackContextValue | null>(null);
 
 export function useGridStackContextValue(): GridStackContextValue {
   const v = useContext(GridStackContext);
-  if (!v) {
-    throw new Error("useGridStack must be used within <GridStack>");
-  }
+  if (!v) throw new Error("useGridStack must be used within <GridStack>");
   return v;
 }

--- a/react/projects/lib/src/gridstack-item.tsx
+++ b/react/projects/lib/src/gridstack-item.tsx
@@ -8,7 +8,7 @@ import {
   type ReactElement,
 } from "react";
 import { createPortal } from "react-dom";
-import type { GridStack, GridStackNode } from "gridstack";
+import { Utils } from "gridstack";
 import { GridStackContext } from "./gridstack-context";
 import { GridStackWidgetContext } from "./gridstack-widget-context";
 import type { GridStackWidget } from "./types";
@@ -28,21 +28,9 @@ function stableOptsKey(options: Partial<GridStackWidget> | undefined): string {
   }
 }
 
-/** Recursively find a node by id across the grid and all nested sub-grids. */
-function findNodeInGrid(g: GridStack, id: string): GridStackNode | undefined {
-  const hit = g.engine.nodes.find((n) => String(n.id) === id) as GridStackNode | undefined;
-  if (hit) return hit;
-  for (const n of g.engine.nodes) {
-    if (n.subGrid) {
-      const nested = findNodeInGrid(n.subGrid as GridStack, id);
-      if (nested) return nested;
-    }
-  }
-  return undefined;
-}
-
 /**
- * Portal anchor for one grid item. Owns React subtree; survives cross-grid DnD while this component stays mounted.
+ * Portal anchor for one grid item. Owns the React subtree; survives cross-grid DnD
+ * because the component stays mounted and the portal re-points to the new container.
  */
 export function GridStackItem({
   id,
@@ -58,20 +46,20 @@ export function GridStackItem({
   const optsKey = stableOptsKey(options);
 
   const widgetCtx = useMemo(() => {
-    if (!registerWidgetSerializer) {
-      return { id };
-    }
+    if (!registerWidgetSerializer) return { id };
     return {
       id,
-      registerSerializer: (fn: () => Record<string, unknown> | undefined) =>
-        registerWidgetSerializer(id, fn),
+      registerSerializer: (
+        serialize: () => Record<string, unknown> | undefined,
+        deserialize?: (data: Record<string, unknown>) => void
+      ) => registerWidgetSerializer(id, serialize, deserialize),
     };
   }, [id, registerWidgetSerializer]);
 
   useLayoutEffect(() => {
     if (!grid) return;
 
-    const node = findNodeInGrid(grid, id);
+    const node = Utils.findInGrid(grid, id, true);
     if (!node?.el) {
       // Item not yet in any grid — add it to the outer grid.
       grid.addWidget({ ...options, id } as GridStackWidget);
@@ -84,15 +72,10 @@ export function GridStackItem({
 
   useLayoutEffect(() => {
     if (!grid) return;
-    const syncContainer = () => {
-      const node = findNodeInGrid(grid, id);
-      const cont =
-        (node?.el?.querySelector(
-          ".grid-stack-item-content"
-        ) as HTMLElement | null) ?? null;
-      setContainer((prev) => (prev === cont ? prev : cont));
-    };
-    syncContainer();
+    const node = Utils.findInGrid(grid, id, true);
+    const cont =
+      (node?.el?.querySelector(".grid-stack-item-content") as HTMLElement | null) ?? null;
+    setContainer((prev) => (prev === cont ? prev : cont));
   }, [grid, id, layoutVersion, optsKey]);
 
   // Tracks whether the component is "truly unmounting" vs. Strict Mode double-invoke.
@@ -100,21 +83,16 @@ export function GridStackItem({
 
   useEffect(() => {
     if (!grid) return () => undefined;
-    // In React 18 Strict Mode, useEffect is double-invoked: setup → cleanup → setup.
-    // The cleanup fires even though the component immediately remounts, which would
-    // incorrectly call removeWidget on still-live items.
-    // Guard: reset the flag on each setup; the cleanup defers via microtask.
-    // If setup re-runs before the microtask fires (Strict Mode), the flag is false
-    // and the removal is skipped.  On a real unmount no setup re-runs, so it proceeds.
     remountedRef.current = false;
     return () => {
       remountedRef.current = true;
       Promise.resolve().then(() => {
         if (!remountedRef.current) return; // setup re-ran (Strict Mode) — cancel
         if (!grid.engine) return;
-        const node = findNodeInGrid(grid, id);
+        const node = Utils.findInGrid(grid, id, true);
         if (!node?.el || !node.grid) return;
-        // Only remove if this item belongs to the outer grid; subgrid items are cleaned up by their own grid.
+        // Only remove if this item belongs to the outer grid; subgrid items are cleaned up
+        // by their own grid when that grid is destroyed.
         if (node.grid === grid) {
           try {
             grid.removeWidget(node.el, false);
@@ -126,20 +104,15 @@ export function GridStackItem({
     };
   }, [grid, id]);
 
-  // After the portal has been committed to the DOM, re-scan the item element for any
-  // custom drag-handle elements that live inside the (now-rendered) React content.
-  // This is a no-op for the default `.grid-stack-item-content` handle (always present),
-  // but is essential when users configure a `draggable.handle` selector inside the portal.
+  // Re-scan for custom drag-handle elements after the portal content is committed.
   useEffect(() => {
     if (!grid || !container) return;
-    const node = findNodeInGrid(grid, id);
+    const node = Utils.findInGrid(grid, id, true);
     if (!node?.el) return;
     grid.refreshDragHandles(node.el);
   }, [grid, id, container]);
 
-  if (!grid || !container || children == null) {
-    return null;
-  }
+  if (!grid || !container || children == null) return null;
 
   return (
     <GridStackWidgetContext.Provider value={widgetCtx}>

--- a/react/projects/lib/src/gridstack-widget-context.tsx
+++ b/react/projects/lib/src/gridstack-widget-context.tsx
@@ -3,7 +3,8 @@ import { createContext, useContext } from "react";
 export interface GridStackWidgetContextValue {
   id: string;
   registerSerializer?: (
-    fn: () => Record<string, unknown> | undefined
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void
   ) => () => void;
 }
 

--- a/react/projects/lib/src/gridstack.tsx
+++ b/react/projects/lib/src/gridstack.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import type { ComponentType, ReactNode } from "react";
-import { GridStack } from "gridstack";
+import { GridStack, Utils } from "gridstack";
 import type {
   GridStackDroppedHandler,
   GridStackElementHandler,
@@ -18,8 +18,13 @@ import type {
 import { GridStackContext } from "./gridstack-context";
 import { GridStackItem } from "./gridstack-item";
 import { installGridStackReactCallbacks } from "./registry";
-import type { GridStackHostApi, GridStackOptions, GridStackWidget, GridHTMLElement, GridItemHTMLElement } from "./types";
-
+import type {
+  GridStackHostApi,
+  GridStackOptions,
+  GridStackWidget,
+  GridHTMLElement,
+  GridItemHTMLElement,
+} from "./types";
 /** Maps `component` JSON keys to React components (props are merged from saved `props`). */
 export type ComponentMap = Record<string, ComponentType<Record<string, unknown>>>;
 
@@ -28,11 +33,15 @@ export interface GridStackProps {
   /** Map `component` field in widget JSON to React components (recommended / component mode) */
   components?: ComponentMap;
   children?: ReactNode;
+  /** Content to render when the grid has no items (mirrors Angular `[empty-content]`). */
+  emptyContent?: ReactNode;
   className?: string;
   style?: React.CSSProperties;
   onAdded?: (e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => void;
   onChange?: (e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => void;
   onRemoved?: (e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => void;
+  onEnable?: (e: Event) => void;
+  onDisable?: (e: Event) => void;
   onDrag?: GridStackElementHandler;
   onDragStart?: GridStackElementHandler;
   onDragStop?: GridStackElementHandler;
@@ -54,30 +63,20 @@ function optionsSignature(o: GridStackOptions): string {
   }
 }
 
-/** Recursively find a node by id across the grid and all nested sub-grids. */
-function findNodeInGrid(g: GridStack, id: string): GridStackWidget | undefined {
-  const hit = g.engine.nodes.find((n) => String(n.id) === id) as GridStackWidget | undefined;
-  if (hit) return hit;
-  for (const n of g.engine.nodes) {
-    if (n.subGrid) {
-      const nested = findNodeInGrid(n.subGrid as GridStack, id);
-      if (nested) return nested;
-    }
-  }
-  return undefined;
-}
-
 export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
   function GridStackComponent(
     {
       options,
       components = {},
       children,
+      emptyContent,
       className,
       style,
       onAdded,
       onChange,
       onRemoved,
+      onEnable,
+      onDisable,
       onDrag,
       onDragStart,
       onDragStop,
@@ -92,18 +91,22 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
     const gridRef = useRef<GridStack | null>(null);
     const [syntheticIds, setSyntheticIds] = useState<Set<string>>(() => new Set());
     const [layoutVersion, setLayoutVersion] = useState(0);
-    /** Bumps only when a new `GridStack` instance is created (not on every layout change). */
     const [gridSession, setGridSession] = useState(0);
-    const serializersRef = useRef(
-      new Map<string, () => Record<string, unknown> | undefined>()
-    );
+    const [isEmpty, setIsEmpty] = useState(false);
 
-    const bumpLayout = useCallback(() => {
-      setLayoutVersion((v) => v + 1);
-    }, []);
+    // Ids scheduled for deferred removal — cancelled if the same id re-registers
+    // within the same microtask (cross-grid DnD: remove fires before add).
+    const pendingRemovalRef = useRef(new Set<string>());
+
+    const serializersRef = useRef(new Map<string, () => Record<string, unknown> | undefined>());
+    const deserializersRef = useRef(new Map<string, (data: Record<string, unknown>) => void>());
+
+    const bumpLayout = useCallback(() => setLayoutVersion((v) => v + 1), []);
 
     const registerSyntheticItemId = useCallback((id: string) => {
+      pendingRemovalRef.current.delete(id); // cancel deferred removal for cross-grid DnD
       setSyntheticIds((prev) => {
+        if (prev.has(id)) return prev;
         const n = new Set(prev);
         n.add(id);
         return n;
@@ -111,47 +114,75 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
     }, []);
 
     const unregisterSyntheticItemId = useCallback((id: string) => {
-      setSyntheticIds((prev) => {
-        const n = new Set(prev);
-        n.delete(id);
-        return n;
+      // Defer by one microtask — if registerSyntheticItemId fires in the same sync block
+      // (cross-grid DnD), it cancels this removal and the React subtree never unmounts.
+      pendingRemovalRef.current.add(id);
+      Promise.resolve().then(() => {
+        if (!pendingRemovalRef.current.has(id)) return;
+        pendingRemovalRef.current.delete(id);
+        setSyntheticIds((prev) => {
+          if (!prev.has(id)) return prev;
+          const n = new Set(prev);
+          n.delete(id);
+          return n;
+        });
+        serializersRef.current.delete(id);
+        deserializersRef.current.delete(id);
       });
-      serializersRef.current.delete(id);
     }, []);
 
     const registerWidgetSerializer = useCallback(
-      (id: string, fn: () => Record<string, unknown> | undefined) => {
-        serializersRef.current.set(id, fn);
+      (
+        id: string,
+        serialize: () => Record<string, unknown> | undefined,
+        deserialize?: (data: Record<string, unknown>) => void
+      ) => {
+        serializersRef.current.set(id, serialize);
+        if (deserialize) deserializersRef.current.set(id, deserialize);
         return () => {
           serializersRef.current.delete(id);
+          deserializersRef.current.delete(id);
         };
       },
       []
     );
 
     const mergeWidgetPropsForSave = useCallback((id: string, w: GridStackWidget) => {
-      const fn = serializersRef.current.get(id);
-      const extra = fn?.();
+      const extra = serializersRef.current.get(id)?.();
       if (extra) w.props = { ...(w.props ?? {}), ...extra };
     }, []);
 
-    const hostApiRef = useRef<GridStackHostApi | null>(null);
-    if (!hostApiRef.current) {
-      hostApiRef.current = {
-        registerSyntheticItemId,
-        unregisterSyntheticItemId,
-        requestUpdate: bumpLayout,
-        registerWidgetSerializer,
-        mergeWidgetPropsForSave,
-      };
-    } else {
-      const h = hostApiRef.current;
-      h.registerSyntheticItemId = registerSyntheticItemId;
-      h.unregisterSyntheticItemId = unregisterSyntheticItemId;
-      h.requestUpdate = bumpLayout;
-      h.registerWidgetSerializer = registerWidgetSerializer;
-      h.mergeWidgetPropsForSave = mergeWidgetPropsForSave;
-    }
+    const deserializeWidget = useCallback((id: string, w: GridStackWidget) => {
+      if (w.props) deserializersRef.current.get(id)?.(w.props);
+    }, []);
+
+    // Stable callbacks ref — updated every render so the hostApi always calls fresh closures
+    // without the hostApi object itself ever changing identity.
+    const callbacksRef = useRef({
+      registerSyntheticItemId,
+      unregisterSyntheticItemId,
+      bumpLayout,
+      registerWidgetSerializer,
+      mergeWidgetPropsForSave,
+      deserializeWidget,
+    });
+    callbacksRef.current.registerSyntheticItemId = registerSyntheticItemId;
+    callbacksRef.current.unregisterSyntheticItemId = unregisterSyntheticItemId;
+    callbacksRef.current.bumpLayout = bumpLayout;
+    callbacksRef.current.registerWidgetSerializer = registerWidgetSerializer;
+    callbacksRef.current.mergeWidgetPropsForSave = mergeWidgetPropsForSave;
+    callbacksRef.current.deserializeWidget = deserializeWidget;
+
+    // Created once — delegates to callbacksRef so all callers always get fresh closures.
+    const hostApiRef = useRef<GridStackHostApi>({
+      registerSyntheticItemId: (id) => callbacksRef.current.registerSyntheticItemId(id),
+      unregisterSyntheticItemId: (id) => callbacksRef.current.unregisterSyntheticItemId(id),
+      requestUpdate: () => callbacksRef.current.bumpLayout(),
+      registerWidgetSerializer: (id, serialize, deserialize) =>
+        callbacksRef.current.registerWidgetSerializer(id, serialize, deserialize),
+      mergeWidgetPropsForSave: (id, w) => callbacksRef.current.mergeWidgetPropsForSave(id, w),
+      deserializeWidget: (id, w) => callbacksRef.current.deserializeWidget(id, w),
+    });
 
     useLayoutEffect(() => {
       installGridStackReactCallbacks();
@@ -160,46 +191,49 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
     const optsSig = optionsSignature(options);
     const prevOptsSig = useRef<string | null>(null);
 
+    // Grid init — runs once on mount, tears down on unmount.
+    // Splitting init from the options-update effect prevents destroying + recreating the grid
+    // when the caller passes a new options object reference with the same content.
     useLayoutEffect(() => {
       const el = rootRef.current as GridHTMLElement | null;
       if (!el) return;
 
-      const host = hostApiRef.current;
-      if (!host) return;
-      el._gridComp = host;
+      el._gridComp = hostApiRef.current;
 
-      if (!gridRef.current) {
-        // Remove orphaned .grid-stack-item children left by a previous destroy(false).
-        // In React 18 StrictMode the useLayoutEffect cleanup+setup cycle runs before
-        // useEffect cleanup, so orphans can accumulate. Clearing them before init
-        // prevents the auto-scan (opts.auto) from re-registering stale elements.
-        const itemClass = (options as Record<string, unknown>).itemClass as string | undefined ?? 'grid-stack-item';
-        Array.from(el.children).forEach(child => {
-          if (child.classList.contains(itemClass) && !(child as GridItemHTMLElement).gridstackNode) {
-            child.remove();
-          }
-        });
-        gridRef.current = GridStack.init(options, el);
-        prevOptsSig.current = optsSig;
-        setLayoutVersion((v) => v + 1);
-        setGridSession((s) => s + 1);
-      } else if (prevOptsSig.current !== optsSig) {
-        gridRef.current.updateOptions(options);
-        prevOptsSig.current = optsSig;
-        setLayoutVersion((v) => v + 1);
-      }
+      const itemClass =
+        (options as Record<string, unknown>).itemClass as string | undefined ??
+        "grid-stack-item";
+      // Remove orphaned items left by a prior destroy(false) / StrictMode cycle.
+      Array.from(el.children).forEach((child) => {
+        if (
+          child.classList.contains(itemClass) &&
+          !(child as GridItemHTMLElement).gridstackNode
+        ) {
+          child.remove();
+        }
+      });
+
+      gridRef.current = GridStack.init(options, el); // eslint-disable-line react-hooks/exhaustive-deps
+      prevOptsSig.current = optsSig;
+      setLayoutVersion((v) => v + 1);
+      setGridSession((s) => s + 1);
+      setIsEmpty(!gridRef.current.engine.nodes.length);
 
       return () => {
         delete el._gridComp;
-        // Destroy the grid in the same phase (useLayoutEffect) so that StrictMode's
-        // cleanup+remount cycle fully tears down and rebuilds the grid before any
-        // useEffect cleanup can run.  This prevents useEffect cleanup from destroying
-        // a grid that was just freshly created by the remount's useLayoutEffect setup.
         gridRef.current?.destroy(false);
         gridRef.current = null;
         prevOptsSig.current = null;
       };
-    }, [options, optsSig]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentionally init once
+
+    // Options update — calls GS updateOptions when content changes without recreating the grid.
+    useLayoutEffect(() => {
+      if (!gridRef.current || prevOptsSig.current === null || prevOptsSig.current === optsSig)
+        return;
+      gridRef.current.updateOptions(options); // eslint-disable-line react-hooks/exhaustive-deps
+      prevOptsSig.current = optsSig;
+    }, [optsSig]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       const g = gridRef.current;
@@ -207,47 +241,40 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
 
       const addedHandler: GridStackNodesHandler = (e, nodes) => {
         bumpLayout();
+        setIsEmpty(false);
         onAdded?.(e, nodes);
       };
       g.on("added", addedHandler);
 
+      // change = position/size update; portal containers are unaffected so no layoutVersion bump.
       const changeHandler: GridStackNodesHandler = (e, nodes) => {
-        bumpLayout();
         onChange?.(e, nodes);
       };
       g.on("change", changeHandler);
 
       const removedHandler: GridStackNodesHandler = (e, nodes) => {
         bumpLayout();
+        setIsEmpty(!g.engine.nodes.length);
         onRemoved?.(e, nodes);
       };
       g.on("removed", removedHandler);
-      if (onDrag) {
-        g.on("drag", onDrag);
-      }
-      if (onDragStart) {
-        g.on("dragstart", onDragStart);
-      }
-      if (onDragStop) {
-        g.on("dragstop", onDragStop);
-      }
-      if (onDropped) {
-        g.on("dropped", onDropped);
-      }
-      if (onResize) {
-        g.on("resize", onResize);
-      }
-      if (onResizeStart) {
-        g.on("resizestart", onResizeStart);
-      }
-      if (onResizeStop) {
-        g.on("resizestop", onResizeStop);
-      }
+
+      if (onEnable) g.on("enable", onEnable);
+      if (onDisable) g.on("disable", onDisable);
+      if (onDrag) g.on("drag", onDrag);
+      if (onDragStart) g.on("dragstart", onDragStart);
+      if (onDragStop) g.on("dragstop", onDragStop);
+      if (onDropped) g.on("dropped", onDropped);
+      if (onResize) g.on("resize", onResize);
+      if (onResizeStart) g.on("resizestart", onResizeStart);
+      if (onResizeStop) g.on("resizestop", onResizeStop);
 
       return () => {
         g.off("added");
         g.off("change");
         g.off("removed");
+        if (onEnable) g.off("enable");
+        if (onDisable) g.off("disable");
         if (onDrag) g.off("drag");
         if (onDragStart) g.off("dragstart");
         if (onDragStop) g.off("dragstop");
@@ -262,6 +289,8 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
       onAdded,
       onChange,
       onRemoved,
+      onEnable,
+      onDisable,
       onDrag,
       onDragStart,
       onDragStop,
@@ -288,7 +317,7 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
       const g = gridRef.current;
       if (!g || syntheticIds.size === 0) return null;
       return Array.from(syntheticIds).map((synId) => {
-        const node = findNodeInGrid(g, synId);
+        const node = Utils.findInGrid(g, synId, true) as GridStackWidget | undefined;
         if (!node?.component) return null;
         const Comp = components[node.component];
         if (!Comp) return null;
@@ -309,6 +338,7 @@ export const GridStackComponent = forwardRef<GridStackHandle, GridStackProps>(
     return (
       <GridStackContext.Provider value={ctxValue}>
         <>
+          {isEmpty && emptyContent}
           <div ref={rootRef} className={rootClass} style={style}>
             {syntheticItems}
           </div>

--- a/react/projects/lib/src/hooks.ts
+++ b/react/projects/lib/src/hooks.ts
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useMemo, useRef } from "react";
+import { Utils } from "gridstack";
 import type { GridStackNode } from "gridstack";
 import { GridStackContext } from "./gridstack-context";
 import { GridStackWidgetContext } from "./gridstack-widget-context";
@@ -10,7 +11,9 @@ export interface UseWidgetSerializerOptions<T extends Record<string, unknown>> {
 }
 
 /**
- * Optional hook for widget components that participate in `grid.save()` via `saveCB` / `props`.
+ * Registers serialize/deserialize for a widget component.
+ * `serialize` is called during `grid.save()`; `deserialize` is called when GS
+ * updates the node (e.g. after `grid.load()` or `updateCB`).
  */
 export function useWidgetSerializer<T extends Record<string, unknown>>(
   _opts: UseWidgetSerializerOptions<T>
@@ -21,8 +24,9 @@ export function useWidgetSerializer<T extends Record<string, unknown>>(
 
   useEffect(() => {
     if (!ctx?.registerSerializer) return;
-    return ctx.registerSerializer(() =>
-      optsRef.current.serialize?.() as Record<string, unknown> | undefined
+    return ctx.registerSerializer(
+      () => optsRef.current.serialize?.() as Record<string, unknown> | undefined,
+      (data) => optsRef.current.deserialize?.(data as T)
     );
   }, [ctx]);
 }
@@ -64,16 +68,15 @@ export function useGridStackItem(): UseGridStackItemResult {
   const wctx = useContext(GridStackWidgetContext);
   const ctx = useContext(GridStackContext);
   if (!wctx?.id) {
-    throw new Error(
-      "useGridStackItem must be used inside <GridStackItem> content"
-    );
+    throw new Error("useGridStackItem must be used inside <GridStackItem> content");
   }
   if (!ctx) {
     throw new Error("useGridStackItem must be used within <GridStack>");
   }
   const { grid, layoutVersion } = ctx;
+  // Use recursive search so items dragged to sub-grids are still found.
   const node = useMemo(
-    () => grid?.engine.nodes.find((n) => String(n.id) === String(wctx.id)),
+    () => (grid ? Utils.findInGrid(grid, String(wctx.id), true) : undefined),
     [grid, wctx.id, layoutVersion]
   );
   return { id: wctx.id, node };

--- a/react/projects/lib/src/registry.ts
+++ b/react/projects/lib/src/registry.ts
@@ -49,8 +49,6 @@ export function gsCreateReactComponents(
       // Inherit the host's _gridComp so nested-grid children can register portals.
       const inherited = nearestGridComp(parent);
       if (inherited) el._gridComp = inherited;
-      // Must append to parent — mirrors what Utils.createDiv(classes, parent) does in the
-      // non-React code path (gridstack.ts addGrid) so the subgrid is in the DOM.
       parent?.appendChild(el);
       return el;
     }
@@ -67,8 +65,26 @@ export function gsCreateReactComponents(
     const id = opt.id != null ? String(opt.id) : undefined;
     if (id) {
       el._gridItemRef = { id, gridComp: gridHost };
-      if (opt.component) gridHost.registerSyntheticItemId(id);
+
+      if (opt.component) {
+        // Utils.lazyLoad checks opt.lazyLoad and grid.opts.lazyLoad with correct precedence.
+        const lazy = Utils.lazyLoad(w as GridStackNode);
+        if (lazy) {
+          el._lazyObserver = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+              el._lazyObserver?.disconnect();
+              delete el._lazyObserver;
+              gridHost.registerSyntheticItemId(id);
+            }
+          });
+          // Observe after GS sets position attributes (next frame).
+          setTimeout(() => el._lazyObserver?.observe(el));
+        } else {
+          gridHost.registerSyntheticItemId(id);
+        }
+      }
     }
+
     if (opt.content != null && opt.content !== "") {
       const content = el.querySelector(".grid-stack-item-content") as HTMLElement;
       if (content) content.textContent = String(opt.content);
@@ -76,7 +92,12 @@ export function gsCreateReactComponents(
     return el;
   }
 
+  // Remove path
   const el = (w as GridStackWidget).el as GridItemHTMLElement | undefined;
+  if (el?._lazyObserver) {
+    el._lazyObserver.disconnect();
+    delete el._lazyObserver;
+  }
   if (el?._gridItemRef) {
     const { id, gridComp } = el._gridItemRef;
     gridComp.unregisterSyntheticItemId(id);
@@ -104,6 +125,12 @@ export function gsSaveAdditionalReactInfo(
 }
 
 export function gsUpdateReactComponents(node: GridStackNode): void {
+  const w = node as GridStackWidget;
   const el = node.el as GridItemHTMLElement | undefined;
-  el?._gridItemRef?.gridComp?.requestUpdate?.();
+  const ref = el?._gridItemRef;
+  if (!ref) return;
+  const { id, gridComp } = ref;
+  // Call registered deserialize fn so widget components can react to updated props.
+  if (w.props) gridComp.deserializeWidget?.(id, w);
+  gridComp.requestUpdate?.();
 }

--- a/react/projects/lib/src/types.ts
+++ b/react/projects/lib/src/types.ts
@@ -18,10 +18,13 @@ export interface GridStackHostApi {
   requestUpdate(): void;
   registerWidgetSerializer: (
     id: string,
-    fn: () => Record<string, unknown> | undefined
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void
   ) => () => void;
   /** Merge `useWidgetSerializer` results into `w.props` during `grid.save()` */
   mergeWidgetPropsForSave(id: string, w: GridStackWidget): void;
+  /** Invoke the registered deserialize fn for an item after a GS `updateCB`. */
+  deserializeWidget(id: string, w: GridStackWidget): void;
 }
 
 export type GridStackWidgetProps = Record<string, unknown>;
@@ -36,6 +39,8 @@ export interface GridStackWidget extends Omit<CoreGridStackWidget, "subGridOpts"
   el?: HTMLElement;
   /** Nested grid options (recursive; uses React-extended widget children). */
   subGridOpts?: GridStackOptions;
+  /** Defer rendering the component until the item scrolls into view (mirrors Angular lazyLoad). */
+  lazyLoad?: boolean;
 }
 
 export interface GridStackNode extends CoreGridStackNode {
@@ -45,6 +50,8 @@ export interface GridStackNode extends CoreGridStackNode {
 export interface GridStackOptions extends Omit<CoreGridStackOptions, "children" | "subGridOpts"> {
   children?: GridStackWidget[];
   subGridOpts?: GridStackOptions;
+  /** Defer rendering all item components until they scroll into view. Per-item `lazyLoad` overrides. */
+  lazyLoad?: boolean;
 }
 
 export interface GridHTMLElement extends CoreGridHTMLElement {
@@ -53,4 +60,6 @@ export interface GridHTMLElement extends CoreGridHTMLElement {
 
 export interface GridItemHTMLElement extends CoreGridItemHTMLElement {
   _gridItemRef?: { id: string; gridComp: GridStackHostApi };
+  /** IntersectionObserver for lazy-loaded items; cleaned up when item is removed. */
+  _lazyObserver?: IntersectionObserver;
 }

--- a/react/projects/lib/tsconfig.build.json
+++ b/react/projects/lib/tsconfig.build.json
@@ -12,7 +12,10 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "gridstack": ["../../../dist/gridstack"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1255,10 +1255,6 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-gridstack@^12.6.0:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-12.6.0.tgz#acfd8c036b202304712c0562078c86ed2ab6e83f"
-  integrity sha512-dUrqsormSybFn/2P4Dz8AgprftKD5e/IiV7UmC0XLQU+G+/WtkAeFiCSNLoAGhPDXoJ/O61Xtj3gljY/Ds83yQ==
 
 has-flag@^4.0.0:
   version "4.0.0"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { GridStackElement, GridStackNode, numberOrString, GridStackPosition, GridStackWidget } from './types';
+import type { GridStack } from './gridstack';
 
 export interface HeightData {
   h: number;
@@ -331,6 +332,30 @@ export class Utils {
    */
   static find(nodes: GridStackNode[], id: string): GridStackNode | undefined {
     return id ? nodes.find(n => n.id === id) : undefined;
+  }
+
+  /**
+   * Find a node by ID in a grid, optionally searching nested sub-grids.
+   *
+   * @param g the grid to search
+   * @param id the ID to search for
+   * @param recursive if true (default), also search nested sub-grids
+   * @returns the node with matching ID, or undefined if not found
+   *
+   * @example
+   * const node = Utils.findInGrid(grid, 'widget-1');          // recursive by default
+   * const top  = Utils.findInGrid(grid, 'widget-1', false);   // top-level only
+   */
+  static findInGrid(g: GridStack, id: string, recursive?: boolean): GridStackNode | undefined {
+    const hit = g.engine.nodes.find(n => String(n.id) === id);
+    if (hit || !recursive) return hit;
+    for (const n of g.engine.nodes) {
+      if (n.subGrid) {
+        const nested = Utils.findInGrid(n.subGrid as GridStack, id);
+        if (nested) return nested;
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/vue/package.json
+++ b/vue/package.json
@@ -14,7 +14,6 @@
     "test:ui": "vitest --config vitest.config.ts --ui"
   },
   "dependencies": {
-    "gridstack": "^12.6.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/vue/projects/lib/tsconfig.build.json
+++ b/vue/projects/lib/tsconfig.build.json
@@ -11,7 +11,10 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "gridstack": ["../../../dist/gridstack"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/vue/yarn.lock
+++ b/vue/yarn.lock
@@ -1312,10 +1312,6 @@ globals@^15.9.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz"
   integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
-gridstack@^12.6.0:
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/gridstack/-/gridstack-12.6.0.tgz"
-  integrity sha512-dUrqsormSybFn/2P4Dz8AgprftKD5e/IiV7UmC0XLQU+G+/WtkAeFiCSNLoAGhPDXoJ/O61Xtj3gljY/Ds83yQ==
 
 has-flag@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Description

Bug fixes:
- Cross-grid DnD no longer destroys/recreates component content: unregister is deferred one microtask so a same-tick re-register (GS fires remove then add synchronously) cancels it; portal just re-points to new container
- useGridStackItem now uses Utils.findInGrid so items in sub-grids are found
- Grid was destroyed/recreated on every render when options object was inline; split into separate init (runs once) and updateOptions effects
- layoutVersion no longer bumped on `change` (position/resize); only added/removed are structural changes that affect portal containers
- useWidgetSerializer deserialize now actually called: gsUpdateReactComponents invokes registered deserialize fn with updated w.props before requestUpdate

New features (Angular parity):
- onEnable / onDisable event props
- emptyContent prop renders ReactNode above grid when empty (like Angular [empty-content])
- lazyLoad support: IntersectionObserver defers registerSyntheticItemId until item scrolls into view; uses existing Utils.lazyLoad() for option resolution

Internals:
- hostApiRef created once, delegates through callbacksRef updated each render (no more render-phase mutation of ref properties)

Core (src/utils.ts):
- Utils.findInGrid(g: GridStack, id, recursive?) for cross-subgrid node lookup; import type GridStack avoids runtime circular dep

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [x] Extended the README / documentation, if necessary
