### PR TITLE
vue: improve wrapper — fix cross-grid DnD, serializer leak, parity with Angular/React

### DIFF
--- a/vue/projects/lib/src/composables.ts
+++ b/vue/projects/lib/src/composables.ts
@@ -1,4 +1,5 @@
 import { computed, inject, onBeforeUnmount, onMounted } from 'vue'
+import { Utils } from 'gridstack'
 import type { GridStackNode } from 'gridstack'
 import { GS_CONTEXT_KEY, GS_ITEM_CONTEXT_KEY } from './gridstack-context'
 import type { GridStackWidget } from './types'
@@ -57,6 +58,7 @@ export interface UseGridStackItemResult {
  * contains the calling component. Must be called inside `<GridStackItem>` slot content.
  *
  * Recomputes whenever `layoutVersion` changes.
+ * Uses recursive grid search so items dragged to sub-grids are still found.
  */
 export function useGridStackItem(): UseGridStackItemResult {
   const itemCtx = inject(GS_ITEM_CONTEXT_KEY)
@@ -68,7 +70,8 @@ export function useGridStackItem(): UseGridStackItemResult {
   const node = computed<GridStackNode | undefined>(() => {
     // Access layoutVersion to make this reactive.
     void gsCtx.layoutVersion.value
-    return gsCtx.grid?.engine.nodes.find((n) => String(n.id) === String(itemCtx.id))
+    const g = gsCtx.grid
+    return g ? Utils.findInGrid(g, String(itemCtx.id), true) : undefined
   })
 
   return {
@@ -87,16 +90,20 @@ export interface UseWidgetSerializerOptions<T extends Record<string, unknown>> {
 }
 
 /**
- * Optional composable for widget components that need to participate in `grid.save()`.
+ * Optional composable for widget components that need to participate in `grid.save()` / `grid.load()`.
  *
  * Call this inside the `setup()` of a widget component rendered inside `<GridStackItem>`.
  * The `serialize` function is called during `grid.save()` and its return value is merged
  * into the widget's `props` in the serialized JSON.
+ * The `deserialize` function is called when GS updates the node (e.g. after `grid.load()`).
  *
  * @example
  * ```ts
  * const count = ref(0)
- * useWidgetSerializer({ serialize: () => ({ count: count.value }) })
+ * useWidgetSerializer({
+ *   serialize: () => ({ count: count.value }),
+ *   deserialize: (data) => { count.value = data.count as number ?? 0 },
+ * })
  * ```
  */
 export function useWidgetSerializer<T extends Record<string, unknown>>(
@@ -108,6 +115,7 @@ export function useWidgetSerializer<T extends Record<string, unknown>>(
     if (!itemCtx?.registerSerializer) return
     const cleanup = itemCtx.registerSerializer(
       () => opts.serialize?.() as Record<string, unknown> | undefined,
+      opts.deserialize ? (data) => opts.deserialize?.(data as T) : undefined,
     )
     onBeforeUnmount(cleanup)
   })

--- a/vue/projects/lib/src/gridstack-context.ts
+++ b/vue/projects/lib/src/gridstack-context.ts
@@ -7,12 +7,19 @@ export interface GsContext {
   grid: GridStack | null
   /** Bumped after GS-driven layout changes so descendants can re-sync. */
   layoutVersion: Ref<number>
-  registerWidgetSerializer(id: string, fn: () => Record<string, unknown> | undefined): () => void
+  registerWidgetSerializer(
+    id: string,
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void,
+  ): () => void
 }
 
 export interface GsItemContext {
   id: string
-  registerSerializer?: (fn: () => Record<string, unknown> | undefined) => () => void
+  registerSerializer?: (
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void,
+  ) => () => void
 }
 
 export const GS_CONTEXT_KEY: InjectionKey<GsContext> = Symbol('gs-context')

--- a/vue/projects/lib/src/gridstack-item.ts
+++ b/vue/projects/lib/src/gridstack-item.ts
@@ -10,22 +10,10 @@ import {
   watch,
   type PropType,
 } from 'vue'
-import type { GridStack, GridStackNode } from 'gridstack'
+import { Utils } from 'gridstack'
+import type { GridStackNode } from 'gridstack'
 import { GS_CONTEXT_KEY, GS_ITEM_CONTEXT_KEY } from './gridstack-context'
 import type { GridStackWidget } from './types'
-
-/** Recursively find a node by id across the grid and all nested sub-grids. */
-function findNodeInGrid(g: GridStack, id: string): GridStackNode | undefined {
-  const hit = g.engine.nodes.find((n) => String(n.id) === id)
-  if (hit) return hit
-  for (const n of g.engine.nodes) {
-    if (n.subGrid) {
-      const nested = findNodeInGrid(n.subGrid as GridStack, id)
-      if (nested) return nested
-    }
-  }
-  return undefined
-}
 
 /**
  * Teleport anchor for one grid item.
@@ -61,7 +49,7 @@ export const GridStackItem = defineComponent({
     function syncContainer() {
       const g = ctx!.grid
       if (!g) return
-      const node = findNodeInGrid(g, props.id)
+      const node = Utils.findInGrid(g, props.id, true)
       const cont = (node?.el?.querySelector('.grid-stack-item-content') as HTMLElement | null) ?? null
       containerEl.value = cont
     }
@@ -71,7 +59,7 @@ export const GridStackItem = defineComponent({
       const g = ctx!.grid
       if (!g) return
 
-      const node = findNodeInGrid(g, props.id)
+      const node = Utils.findInGrid(g, props.id, true)
       if (!node?.el) {
         // Item not yet in any grid — add it.
         g.addWidget({ ...props.options, id: props.id } as GridStackWidget)
@@ -87,7 +75,7 @@ export const GridStackItem = defineComponent({
       // any custom handle selectors the slot content may have introduced.
       void Promise.resolve().then(() => {
         if (!alive) return
-        const n = findNodeInGrid(g, props.id)
+        const n = Utils.findInGrid(g, props.id, true)
         if (n?.el) g.refreshDragHandles(n.el)
       })
     })
@@ -95,11 +83,24 @@ export const GridStackItem = defineComponent({
     // Re-sync the container whenever layoutVersion changes (GS rearranged the DOM).
     watch(() => ctx!.layoutVersion.value, syncContainer)
 
+    // Per-item serialize/deserialize fns — updated by child calling registerSerializer.
+    let serializeFn: (() => Record<string, unknown> | undefined) | undefined
+    let deserializeFn: ((data: Record<string, unknown>) => void) | undefined
+
+    // Register with parent context once; the delegate closures always call the latest fns.
+    const cleanupParentSerializer = ctx!.registerWidgetSerializer(
+      props.id,
+      () => serializeFn?.(),
+      (data) => deserializeFn?.(data),
+    )
+
     onBeforeUnmount(() => {
       alive = false
+      cleanupParentSerializer()
+
       const g = ctx!.grid
       if (!g?.engine) return
-      const node = findNodeInGrid(g, props.id)
+      const node = Utils.findInGrid(g, props.id, true)
       if (!node?.el || !node.grid) return
       if (node.grid === g) {
         try {
@@ -110,24 +111,18 @@ export const GridStackItem = defineComponent({
       }
     })
 
-    // Expose id + serialize registration to child composables via item context.
-    const serializers = new Map<string, () => Record<string, unknown> | undefined>()
-
-    function registerSerializer(fn: () => Record<string, unknown> | undefined) {
-      serializers.set(props.id, fn)
-      return () => { serializers.delete(props.id) }
+    // Expose id + serialize/deserialize registration to child composables via item context.
+    function registerSerializer(
+      serialize: () => Record<string, unknown> | undefined,
+      deserialize?: (data: Record<string, unknown>) => void,
+    ) {
+      serializeFn = serialize
+      deserializeFn = deserialize
+      return () => {
+        serializeFn = undefined
+        deserializeFn = undefined
+      }
     }
-
-    // Merge serializer output into props during grid.save() — called by registry.
-    // We stamp this onto the context so the host GridStack can reach it.
-    const gridComp = ctx!.grid ? (ctx as unknown as { _hostApi?: unknown })._hostApi : null
-    void gridComp // accessed via _gridComp on the DOM; here we register with parent ctx.
-
-    // Also register with parent grid's serializer registry.
-    ctx!.registerWidgetSerializer(props.id, () => {
-      const fn = serializers.get(props.id)
-      return fn?.()
-    })
 
     provide(GS_ITEM_CONTEXT_KEY, {
       id: props.id,

--- a/vue/projects/lib/src/gridstack.ts
+++ b/vue/projects/lib/src/gridstack.ts
@@ -9,7 +9,7 @@ import {
   type Component,
   type PropType,
 } from 'vue'
-import { GridStack } from 'gridstack'
+import { GridStack, Utils } from 'gridstack'
 import type {
   GridStackDroppedHandler,
   GridStackElementHandler,
@@ -29,26 +29,14 @@ import type {
 /** Maps `component` JSON keys to Vue components (props merged from saved `props`). */
 export type ComponentMap = Record<string, Component>
 
-/** Recursively find a node by id across the grid and all nested sub-grids. */
-function findNodeInGrid(g: GridStack, id: string): GridStackWidget | undefined {
-  const hit = g.engine.nodes.find((n) => String(n.id) === id) as GridStackWidget | undefined
-  if (hit) return hit
-  for (const n of g.engine.nodes) {
-    if (n.subGrid) {
-      const nested = findNodeInGrid(n.subGrid as GridStack, id)
-      if (nested) return nested
-    }
-  }
-  return undefined
-}
-
 /**
  * `<GridStack>` — root component.
  *
  * - Pass `options` (with `children`) to seed the initial layout.
  * - Pass `components` to map `component` strings in widget JSON to Vue components.
  * - Listens to all GS events via emits; also exposes `getGrid()` for imperative access.
- * - Slot content is rendered _outside_ the `.grid-stack` div (host chrome: toolbars etc.).
+ * - Use the `#empty` slot to render content when the grid has no items.
+ * - Slot content (default) is rendered _outside_ the `.grid-stack` div (host chrome: toolbars etc.).
  */
 export const GridStackComponent = defineComponent({
   name: 'GridStack',
@@ -68,6 +56,8 @@ export const GridStackComponent = defineComponent({
     'added',
     'change',
     'removed',
+    'enable',
+    'disable',
     'drag',
     'dragstart',
     'dragstop',
@@ -90,40 +80,68 @@ export const GridStackComponent = defineComponent({
      */
     const gridReady = ref(false)
 
-    /** Bumped after GS-driven layout changes so descendant composables re-compute. */
+    /** Bumped after GS-driven structural changes (added/removed) so descendant composables re-compute. */
     const layoutVersion = ref(0)
+
+    /** True when the grid currently has no items. */
+    const isEmpty = ref(false)
 
     /** IDs of widgets added by `addRemoveCB` that need a teleport anchor. */
     const syntheticIds = ref<Set<string>>(new Set())
 
+    // Ids scheduled for deferred removal — cancelled if the same id re-registers
+    // within the same microtask (cross-grid DnD: GS fires remove before add).
+    const pendingRemoval = new Set<string>()
+
     const serializersRef = new Map<string, () => Record<string, unknown> | undefined>()
+    const deserializersRef = new Map<string, (data: Record<string, unknown>) => void>()
 
     function registerSyntheticItemId(id: string) {
+      pendingRemoval.delete(id) // cancel deferred removal for cross-grid DnD
       const next = new Set(syntheticIds.value)
       next.add(id)
       syntheticIds.value = next
     }
 
     function unregisterSyntheticItemId(id: string) {
-      const next = new Set(syntheticIds.value)
-      next.delete(id)
-      syntheticIds.value = next
-      serializersRef.delete(id)
+      // Defer by one microtask — if registerSyntheticItemId fires in the same sync block
+      // (cross-grid DnD), it cancels this removal and the Vue subtree never unmounts.
+      pendingRemoval.add(id)
+      void Promise.resolve().then(() => {
+        if (!pendingRemoval.has(id)) return
+        pendingRemoval.delete(id)
+        const next = new Set(syntheticIds.value)
+        next.delete(id)
+        syntheticIds.value = next
+        serializersRef.delete(id)
+        deserializersRef.delete(id)
+      })
     }
 
     function requestUpdate() {
       layoutVersion.value++
     }
 
-    function registerWidgetSerializer(id: string, fn: () => Record<string, unknown> | undefined) {
-      serializersRef.set(id, fn)
-      return () => { serializersRef.delete(id) }
+    function registerWidgetSerializer(
+      id: string,
+      serialize: () => Record<string, unknown> | undefined,
+      deserialize?: (data: Record<string, unknown>) => void,
+    ) {
+      serializersRef.set(id, serialize)
+      if (deserialize) deserializersRef.set(id, deserialize)
+      return () => {
+        serializersRef.delete(id)
+        deserializersRef.delete(id)
+      }
     }
 
     function mergeWidgetPropsForSave(id: string, w: GridStackWidget) {
-      const fn = serializersRef.get(id)
-      const extra = fn?.()
+      const extra = serializersRef.get(id)?.()
       if (extra) w.props = { ...(w.props ?? {}), ...extra }
+    }
+
+    function deserializeWidget(id: string, w: GridStackWidget) {
+      if (w.props) deserializersRef.get(id)?.(w.props)
     }
 
     const hostApi: GridStackHostApi = {
@@ -132,6 +150,7 @@ export const GridStackComponent = defineComponent({
       requestUpdate,
       registerWidgetSerializer,
       mergeWidgetPropsForSave,
+      deserializeWidget,
     }
 
     /** Reference to the `.grid-stack` root div — set via `onVnodeMounted`. */
@@ -161,6 +180,7 @@ export const GridStackComponent = defineComponent({
       grid = GridStack.init(props.options, rootEl)
       gridReady.value = true
       layoutVersion.value++
+      isEmpty.value = !grid.engine.nodes.length
 
       hookEvents()
     })
@@ -173,14 +193,12 @@ export const GridStackComponent = defineComponent({
       gridReady.value = false
     })
 
-    // Watch for options changes and forward them to the live grid instance.
+    // Watch for options reference changes and forward to the live grid instance.
     watch(
       () => props.options,
       (next) => {
         grid?.updateOptions(next)
-        layoutVersion.value++
       },
-      { deep: true },
     )
 
     function hookEvents() {
@@ -188,18 +206,23 @@ export const GridStackComponent = defineComponent({
 
       grid.on('added', ((e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => {
         layoutVersion.value++
+        isEmpty.value = false
         emit('added', e, nodes)
       }) as GridStackNodesHandler)
 
+      // change = position/resize; portal targets don't move so no layoutVersion bump.
       grid.on('change', ((e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => {
-        layoutVersion.value++
         emit('change', e, nodes)
       }) as GridStackNodesHandler)
 
       grid.on('removed', ((e: Event, nodes: Parameters<GridStackNodesHandler>[1]) => {
         layoutVersion.value++
+        isEmpty.value = !grid!.engine.nodes.length
         emit('removed', e, nodes)
       }) as GridStackNodesHandler)
+
+      grid.on('enable', (e: Event) => emit('enable', e))
+      grid.on('disable', (e: Event) => emit('disable', e))
 
       grid.on('drag', (e: Event, el: HTMLElement) => {
         emit('drag', e, el)
@@ -226,7 +249,7 @@ export const GridStackComponent = defineComponent({
 
     function unhookEvents() {
       if (!grid) return
-      ;['added', 'change', 'removed', 'drag', 'dragstart', 'dragstop',
+      ;['added', 'change', 'removed', 'enable', 'disable', 'drag', 'dragstart', 'dragstop',
         'dropped', 'resize', 'resizestart', 'resizestop'].forEach((ev) => grid!.off(ev))
     }
 
@@ -246,7 +269,7 @@ export const GridStackComponent = defineComponent({
       const synItems: ReturnType<typeof h>[] = []
       if (gridReady.value && grid && syntheticIds.value.size > 0) {
         for (const synId of syntheticIds.value) {
-          const node = findNodeInGrid(grid, synId)
+          const node = Utils.findInGrid(grid, synId, true) as GridStackWidget | undefined
           if (!node?.component) continue
           const Comp = props.components[node.component]
           if (!Comp) continue
@@ -260,6 +283,8 @@ export const GridStackComponent = defineComponent({
       }
 
       return h('div', { class: 'gs-wrapper' }, [
+        // Empty slot — rendered when grid has no items (mirrors Angular [empty-content]).
+        isEmpty.value ? slots.empty?.() : undefined,
         // The `.grid-stack` div — onVnodeMounted captures the DOM reference.
         h('div', {
           class: 'grid-stack',
@@ -267,7 +292,7 @@ export const GridStackComponent = defineComponent({
             rootEl = vnode.el as GridHTMLElement | null
           },
         }, synItems),
-        // Slot content rendered outside the grid (toolbars, debug panels, etc.).
+        // Default slot rendered outside the grid (toolbars, debug panels, etc.).
         slots.default?.(),
       ])
     }

--- a/vue/projects/lib/src/registry.ts
+++ b/vue/projects/lib/src/registry.ts
@@ -99,5 +99,10 @@ export function gsSaveAdditionalVueInfo(
 
 export function gsUpdateVueComponents(node: GridStackNode): void {
   const el = node.el as GridItemHTMLElement | undefined
-  el?._gridItemRef?.gridComp?.requestUpdate?.()
+  const ref = el?._gridItemRef
+  if (!ref) return
+  const { id, gridComp } = ref
+  const w = node as GridStackWidget
+  if (w.props) gridComp.deserializeWidget(id, w)
+  gridComp.requestUpdate()
 }

--- a/vue/projects/lib/src/types.ts
+++ b/vue/projects/lib/src/types.ts
@@ -16,9 +16,15 @@ export interface GridStackHostApi {
   unregisterSyntheticItemId(id: string): void
   /** Notify Vue to re-read node props after GS `update()` / `updateCB`. */
   requestUpdate(): void
-  registerWidgetSerializer(id: string, fn: () => Record<string, unknown> | undefined): () => void
+  registerWidgetSerializer(
+    id: string,
+    serialize: () => Record<string, unknown> | undefined,
+    deserialize?: (data: Record<string, unknown>) => void,
+  ): () => void
   /** Merge `useWidgetSerializer` results into `w.props` during `grid.save()`. */
   mergeWidgetPropsForSave(id: string, w: GridStackWidget): void
+  /** Call widget's deserialize callback with updated props (invoked by `updateCB`). */
+  deserializeWidget(id: string, w: GridStackWidget): void
 }
 
 export type GridStackWidgetProps = Record<string, unknown>


### PR DESCRIPTION
### Description

Bug fixes:
- Cross-grid DnD serializer loss: unregisterSyntheticItemId now defers via Promise microtask + pendingRemoval Set; register cancels it so serializer survives a same-tick remove+add (Vue reactive batching already prevented component unmount, but serializersRef.delete still fired synchronously)
- GridStackItem serializer cleanup leak: ctx.registerWidgetSerializer cleanup was discarded in setup(); now stored and called in onBeforeUnmount
- useGridStackItem searched only flat engine.nodes — items dragged to sub-grids returned undefined; now uses Utils.findInGrid(g, id, true)
- deserialize in useWidgetSerializer was wired up to nothing: gsUpdateVueComponents now calls deserializeWidget(id, w) before requestUpdate(); deserialize callback flows through registerSerializer → registerWidgetSerializer → deserializersRef

Angular/React parity:
- enable/disable events added to emits + hookEvents/unhookEvents
- isEmpty tracking + #empty named slot: renders above the grid when no items (mirrors Angular [empty-content] / React emptyContent prop)

Performance:
- change event no longer bumps layoutVersion (position/resize doesn't affect Teleport targets; only added/removed are structural)
- watch(options) drops deep:true and no longer bumps layoutVersion on prop changes — structural version bumps come exclusively from added/removed events

Internals:
- Both local findNodeInGrid copies removed; all call sites use Utils.findInGrid from core (same cleanup done for React wrapper)
- GridStackItem serializer layer simplified: local Map replaced with two plain let variables (serializeFn/deserializeFn); delegate closures registered with parent once, updated in-place by child registerSerializer calls

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
