### PR TITLE
isTouch fix for trackpads

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [12.6.0-dev (TBD)](#1260-dev-tbd)
 - [12.6.0 (2026-04-08)](#1260-2026-04-08)
 - [12.5.0 (2026-04-05)](#1250-2026-04-05)
 - [12.4.2 (2025-12-26)](#1242-2025-12-26)
@@ -137,6 +138,13 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 12.6.0-dev (TBD)
+* NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, memory leak, empty content, etc...
+* NEW: vue wrapper: brand new wrapper follow same pattern as well
+* fix: [#3154](https://github.com/gridstack/gridstack.js/issues/3154) Esc key doesn't restore subgrid
+* fix: [#3231](https://github.com/gridstack/gridstack.js/issues/3231) drag broken in Firefox 147.0.4+ and Chrome 144+ due to `navigator.maxTouchPoints > 0` now returning true on desktop (macOS trackpad)
+
 ## 12.6.0 (2026-04-08)
 * feat: [#3250](https://github.com/gridstack/gridstack.js/pull/3250) full RTL support - thank you [Daniel Cohen Gindi](https://github.com/danielgindi)
 * fix: [#3261](https://github.com/gridstack/gridstack.js/pull/3261) prepareDragDrop() returns for disable after deletion

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -167,8 +167,11 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
 
   /** @internal call when mouse goes down before a dragstart happens */
   protected _mouseDown(e: MouseEvent): boolean {
-    // if real brower event (trusted:true vs false for our simulated ones) and we didn't correctly clear the last touch event, clear things up
-    if (DDTouch.touchHandled && e.isTrusted) DDTouch.touchHandled = false;
+    // if real browser event (trusted:true vs false for our simulated ones) and prior touch/mouse state didn't clean up, reset it
+    if (e.isTrusted) {
+      if (DDTouch.touchHandled) DDTouch.touchHandled = false;
+      if (DDManager.mouseHandled) delete DDManager.mouseHandled; // stuck from an incomplete prior drag
+    }
 
     // don't let more than one widget handle mouseStart
     if (DDManager.mouseHandled) return;

--- a/src/dd-touch.ts
+++ b/src/dd-touch.ts
@@ -17,7 +17,7 @@ export const isTouch: boolean = typeof window !== 'undefined' && typeof document
     // || !!window.TouchEvent // true on Windows 10 Chrome desktop so don't use this
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     || ((window as any).DocumentTouch && document instanceof (window as any).DocumentTouch)
-    || navigator.maxTouchPoints > 0
+    || (navigator.maxTouchPoints > 0 && window.matchMedia('(any-pointer: coarse)').matches)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     || (navigator as any).msMaxTouchPoints > 0
   );


### PR DESCRIPTION
### Description
* fix #3231 which I cannot reproduce on macBook Pro with latest browser. Claude though ti found issue, but maybe Windows 11 only ?

* drag broken in Firefox 147.0.4+ and Chrome 144+ due to `navigator.maxTouchPoints > 0` now returning true on desktop (macOS trackpad). Use `(any-pointer: coarse)` media query to correctly identify real touch devices. Also safety-reset stuck `mouseHandled` state on new trusted mousedown.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
