### PR TITLE
OnChange trigger fix when scrollbar show up

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/gridstack/gridstack.js/badge.svg?branch=develop)](https://coveralls.io/github/gridstack/gridstack.js?branch=develop)
 [![downloads](https://img.shields.io/npm/dm/gridstack.svg)](https://www.npmjs.com/package/gridstack)
 
-Mobile-friendly modern Typescript library for dashboard layout and creation. Making a drag-and-drop, multi-column responsive dashboard has never been easier. Has multiple bindings and works great with [Angular](https://angular.io/) (included), [React](https://reactjs.org/) (included), [Vue](https://vuejs.org/) (included), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others (see [frameworks](#specific-frameworks) section).
+Mobile-friendly modern Typescript library for dashboard layout and creation. Making a drag-and-drop, multi-column responsive dashboard has never been easier. Has multiple bindings and works great with [Angular](https://angular.dev/) (included), [React](https://reactjs.org/) (included), [Vue](https://vuejs.org/) (included), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others (see [frameworks](#specific-frameworks) section).
 
 Inspired by no-longer maintained gridster, built with love.
 

--- a/angular/README_build.md
+++ b/angular/README_build.md
@@ -24,4 +24,4 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/cli) page.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -142,11 +142,12 @@ Change log
 ## 12.6.0-dev (TBD)
 * NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, memory leak, empty content, etc...
 * NEW: vue wrapper: brand new wrapper follow same pattern as well
+* feat: [#662](https://github.com/gridstack/gridstack.js/issues/662) added grid-lines.html demo (just CSS)
 * fix: [#3154](https://github.com/gridstack/gridstack.js/issues/3154) Esc key doesn't restore subgrid
 * fix: [#3231](https://github.com/gridstack/gridstack.js/issues/3231) drag broken in Firefox 147.0.4+ and Chrome 144+ due to `navigator.maxTouchPoints > 0` now returning true on desktop (macOS trackpad)
 * fix: [#3291](https://github.com/gridstack/gridstack.js/pull/3291) flicker nested grid demo when dragging between sub-grids
 * fix: [#3085](https://github.com/gridstack/gridstack.js/issues/3085) Changing rows after init relays out if smaller
-* feat: [#662](https://github.com/gridstack/gridstack.js/issues/662) added grid-lines.html demo (just CSS)
+* fix: [#2823](https://github.com/gridstack/gridstack.js/issues/2823) Scrollbar appears prevents onChange being called
 
 ## 12.6.0 (2026-04-08)
 * feat: [#3250](https://github.com/gridstack/gridstack.js/pull/3250) full RTL support - thank you [Daniel Cohen Gindi](https://github.com/danielgindi)

--- a/src/gridstack-engine.ts
+++ b/src/gridstack-engine.ts
@@ -89,7 +89,9 @@ export class GridStackEngine {
       this._prevFloat = this._float;
       this._float = true; // let things go anywhere for now... will restore and possibly reposition later
       this.cleanNodes();
-      this.saveInitial(); // since begin update (which is called multiple times) won't do this
+      // skip saveInitial() if a drag/resize is in progress - it would overwrite _orig with mid-drag
+      // positions and corrupt change detection, causing onChange not to fire (see #2823)
+      if (!this.nodes.some(n => n._updating)) this.saveInitial();
     } else {
       this._float = this._prevFloat;
       delete this._prevFloat;


### PR DESCRIPTION
### Description
* fix #2823
* skip saveInitial() when a drag/resize is already in progress (i.e., any node has _updating=true). Scrollbar appears (grid grows taller) → clientWidth decreases → ResizeObserver fires onResize()

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
