### PR TITLE
dynamically created nested grid disappeared when dragging out

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -140,7 +140,7 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 12.6.0-dev (TBD)
-* NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, memory leak, empty content, etc...
+* NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, fix memory leak, empty content, etc...
 * NEW: vue wrapper: brand new wrapper follow same pattern as well
 * feat: [#662](https://github.com/gridstack/gridstack.js/issues/662) added grid-lines.html demo (just CSS)
 * fix: [#3154](https://github.com/gridstack/gridstack.js/issues/3154) Esc key doesn't restore subgrid
@@ -148,6 +148,7 @@ Change log
 * fix: [#3291](https://github.com/gridstack/gridstack.js/pull/3291) flicker nested grid demo when dragging between sub-grids
 * fix: [#3085](https://github.com/gridstack/gridstack.js/issues/3085) Changing rows after init relays out if smaller
 * fix: [#2823](https://github.com/gridstack/gridstack.js/issues/2823) Scrollbar appears prevents onChange being called
+* fix: [#2948](https://github.com/gridstack/gridstack.js/issues/2948) dynamically created nested grid disappeared when dragging out
 
 ## 12.6.0 (2026-04-08)
 * feat: [#3250](https://github.com/gridstack/gridstack.js/pull/3250) full RTL support - thank you [Daniel Cohen Gindi](https://github.com/danielgindi)

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -606,6 +606,11 @@ export class GridStack {
       // migrate any children over and offsetting by our location
       n.x += this.parentGridNode.x;
       n.y += this.parentGridNode.y;
+      // n.el is still inside the (now-detached) subgrid DOM and has el.gridstackNode set,
+      // so makeWidget would bail out without these steps.
+      this._removeDD(n.el);      // destroy subgrid D&D and clear n._initDD so pGrid re-registers it
+      n.el.remove();             // detach from subgrid DOM so makeWidget can append to pGrid
+      delete n.el.gridstackNode; // clear stale ref so makeWidget won't return early
       pGrid.makeWidget(n.el, n);
     });
     pGrid.batchUpdate(false);
@@ -614,7 +619,17 @@ export class GridStack {
 
     // create an artificial event for the original grid now that this one is gone (got a leave, but won't get enter)
     if (nodeThatRemoved) {
-      window.setTimeout(() => Utils.simulateMouseEvent(nodeThatRemoved._event, 'mouseenter', pGrid.el), 0);
+      // _leave() already restored el.gridstackNode to the original pGrid node (via _gridstackNodeOrig), but that
+      // original node has grid===pGrid and no _temporaryRemoved, so pGrid's dropover would silently skip it.
+      // Mark it so the simulated mouseenter is actually processed and the item gets a placeholder in pGrid.
+      const origNode = nodeThatRemoved.el?.gridstackNode as GridStackNode;
+      if (origNode && origNode !== nodeThatRemoved) origNode._temporaryRemoved = true;
+      // nodeThatRemoved._event was cleared by cleanupNode() when the item entered the subgrid, so use the
+      // always-current lastDrag from the active DDDraggable instead.
+      window.setTimeout(() => {
+        const dragEvent = DDManager.dragElement?.lastDrag || nodeThatRemoved._event;
+        if (dragEvent) Utils.simulateMouseEvent(dragEvent, 'mouseenter', pGrid.el);
+      }, 0);
     }
   }
 


### PR DESCRIPTION
### Description
* fix #2948 that is the correct fix, not the one recommended in teh bug

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
