### PR TITLE
Angular wrapper using component+props (instead of selector+input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Join us on Slack: [https://gridstackjs.slack.com](https://join.slack.com/t/grids
   - [Migrating to v10](#migrating-to-v10)
   - [Migrating to v11](#migrating-to-v11)
   - [Migrating to v12](#migrating-to-v12)
+  - [Migrating to v13](#migrating-to-v13)
 - [jQuery Application](#jquery-application)
 - [Changes](#changes)
 - [Usage Trend](#usage-trend)
@@ -508,6 +509,28 @@ this fixes a long standing issue where people forget to include the right CSS fo
 * `gridstack-extra.min.css` no longer exist, nor is custom column CSS classes needed. API/options hasn't changed.
 * (v12.1) `ES5` folder content has been removed - was for IE support, which has been dropped.
 * (v12.1) nested grid events are now sent to the main grid. You might have to adjust your workaround of this missing feature. nested.html demo has been adjusted.
+
+## Migrating to v13
+
+No breaking changes in the base library, but NEW React and Vue wrapper now being shipped!
+
+**Breaking changes: Angular wrapper only** (`gridstack/dist/angular`)
+
+Widget JSON fields are renamed to match the React/Vue convention, making layouts portable across all three frameworks:
+
+```diff
+- { selector: 'app-chart', input: { title: 'Revenue' } }
++ { component: 'app-chart', props: { title: 'Revenue' } }
+```
+
+The registration call is also renamed:
+
+```diff
+- GridstackComponent.addComponentToSelectorType([ChartComponent, TableComponent]);
++ GridstackComponent.registerComponents([ChartComponent, TableComponent]);
+```
+
+The static map and its type are renamed accordingly (`selectorToType` → `componentMap`, `SelectorToType` → `ComponentMap`). If you subclass `BaseWidget` and override `deserialize()`, replace any direct reads of `w.input` with `w.props`.
 
 # jQuery Application
 

--- a/angular/angular.json
+++ b/angular/angular.json
@@ -54,7 +54,7 @@
               "projects/demo/src/assets"
             ],
             "styles": [
-              "node_modules/gridstack/dist/gridstack.min.css",
+              "../dist/gridstack.min.css",
               "projects/demo/src/styles.css"
             ],
             "scripts": []
@@ -119,7 +119,7 @@
               "projects/demo/src/assets"
             ],
             "styles": [
-              "node_modules/gridstack/dist/gridstack.min.css",
+              "../dist/gridstack.min.css",
               "projects/demo/src/styles.css"
             ],
             "scripts": []

--- a/angular/doc/api/base-widget.md
+++ b/angular/doc/api/base-widget.md
@@ -4,7 +4,7 @@
 
 ### `abstract` BaseWidget
 
-Defined in: [angular/projects/lib/src/lib/base-widget.ts:39](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L39)
+Defined in: [angular/projects/lib/src/lib/base-widget.ts:41](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L41)
 
 Base widget class for GridStack Angular integration.
 
@@ -28,7 +28,7 @@ new BaseWidget(): BaseWidget;
 serialize(): undefined | NgCompInputs;
 ```
 
-Defined in: [angular/projects/lib/src/lib/base-widget.ts:69](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L69)
+Defined in: [angular/projects/lib/src/lib/base-widget.ts:71](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L71)
 
 Override this method to return serializable data for this widget.
 
@@ -59,7 +59,7 @@ serialize() {
 deserialize(w): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/base-widget.ts:91](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L91)
+Defined in: [angular/projects/lib/src/lib/base-widget.ts:93](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L93)
 
 Override this method to handle widget restoration from saved data.
 
@@ -79,12 +79,12 @@ The default implementation automatically assigns input data to component propert
 ###### Example
 
 ```typescript
-deserialize(w: NgGridStackWidget) {
+override deserialize(w: NgGridStackWidget) {
   super.deserialize(w); // Call parent for basic setup
 
   // Custom initialization logic
-  if (w.input?.complexData) {
-    this.processComplexData(w.input.complexData);
+  if (w.props?.complexData) {
+    this.processComplexData(w.props.complexData);
   }
 }
 ```
@@ -93,4 +93,4 @@ deserialize(w: NgGridStackWidget) {
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| <a id="widgetitem"></a> `widgetItem?` | `public` | [`NgGridStackWidget`](types.md#nggridstackwidget) | Complete widget definition including position, size, and Angular-specific data. Populated automatically when the widget is loaded or saved. | [angular/projects/lib/src/lib/base-widget.ts:45](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L45) |
+| <a id="widgetitem"></a> `widgetItem?` | `public` | [`NgGridStackWidget`](types.md#nggridstackwidget) | Complete widget definition including position, size, and Angular-specific data. Populated automatically when the widget is loaded or saved. | [angular/projects/lib/src/lib/base-widget.ts:47](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/base-widget.ts#L47) |

--- a/angular/doc/api/gridstack.component.md
+++ b/angular/doc/api/gridstack.component.md
@@ -4,7 +4,7 @@
 
 ### GridstackComponent
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:85](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L85)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:86](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L86)
 
 Angular component wrapper for GridStack.
 
@@ -40,7 +40,7 @@ Use in combination with GridstackItemComponent for individual grid items.
 get options(): GridStackOptions;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:120](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L120)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:121](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L121)
 
 Get the current running grid options
 
@@ -54,7 +54,7 @@ Get the current running grid options
 set options(o): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:112](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L112)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:113](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L113)
 
 Grid configuration options.
 Can be set before grid initialization or updated after grid is created.
@@ -87,7 +87,7 @@ gridOptions: GridStackOptions = {
 get el(): GridCompHTMLElement;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:190](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L190)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:191](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L191)
 
 Get the native DOM element that contains grid-specific fields.
 This element has GridStack properties attached to it.
@@ -104,7 +104,7 @@ This element has GridStack properties attached to it.
 get grid(): undefined | GridStack;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:201](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L201)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:202](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L202)
 
 Get the underlying GridStack instance.
 Use this to access GridStack API methods directly.
@@ -127,7 +127,7 @@ this.gridComponent.grid.addWidget({x: 0, y: 0, w: 2, h: 1});
 new GridstackComponent(elementRef): GridstackComponent;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:253](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L253)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:248](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L248)
 
 ###### Parameters
 
@@ -141,15 +141,18 @@ Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:253](https://gi
 
 #### Methods
 
-##### addComponentToSelectorType()
+##### registerComponents()
 
 ```ts
-static addComponentToSelectorType(typeList): void;
+static registerComponents(typeList): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:234](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L234)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:230](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L230)
 
-Register a list of Angular components for dynamic creation.
+Register Angular components for dynamic creation.
+
+Each component is keyed by its `@Component.selector` string, which becomes
+the `component` field value in widget JSON (same role as `component` in React/Vue).
 
 ###### Parameters
 
@@ -164,10 +167,7 @@ Register a list of Angular components for dynamic creation.
 ###### Example
 
 ```typescript
-GridstackComponent.addComponentToSelectorType([
-  MyWidgetComponent,
-  AnotherWidgetComponent
-]);
+GridstackComponent.registerComponents([MyWidgetComponent, AnotherWidgetComponent]);
 ```
 
 ##### getSelector()
@@ -176,21 +176,20 @@ GridstackComponent.addComponentToSelectorType([
 static getSelector(type): string;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:243](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L243)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:238](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L238)
 
-Extract the selector string from an Angular component type.
+Extract the Angular selector string from a component type.
+This is used as the default `component` key in widget JSON.
 
 ###### Parameters
 
-| Parameter | Type | Description |
-| ------ | ------ | ------ |
-| `type` | `Type`\<`object`\> | The component type to get selector from |
+| Parameter | Type |
+| ------ | ------ |
+| `type` | `Type`\<`object`\> |
 
 ###### Returns
 
 `string`
-
-The component's selector string
 
 ##### ngOnInit()
 
@@ -198,7 +197,7 @@ The component's selector string
 ngOnInit(): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:267](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L267)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:262](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L262)
 
 A callback method that is invoked immediately after the
 default change detector has checked the directive's
@@ -222,7 +221,7 @@ OnInit.ngOnInit
 ngAfterContentInit(): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:277](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L277)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:272](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L272)
 
 wait until after all DOM is ready to init gridstack children (after angular ngFor and sub-components run first)
 
@@ -242,7 +241,7 @@ AfterContentInit.ngAfterContentInit
 ngOnDestroy(): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:285](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L285)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:280](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L280)
 
 A callback method that performs custom clean-up, invoked immediately
 before a directive, pipe, or service instance is destroyed.
@@ -263,7 +262,7 @@ OnDestroy.ngOnDestroy
 updateAll(): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:299](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L299)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:294](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L294)
 
 called when the TEMPLATE (not recommended) list of items changes - get a list of nodes and
 update the layout accordingly (which will take care of adding/removing items changed by Angular)
@@ -278,7 +277,7 @@ update the layout accordingly (which will take care of adding/removing items cha
 checkEmpty(): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:310](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L310)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:305](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L305)
 
 check if the grid is empty, if so show alternative content
 
@@ -292,7 +291,7 @@ check if the grid is empty, if so show alternative content
 protected hookEvents(grid?): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:316](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L316)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:311](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L311)
 
 get all known events as easy to use Outputs for convenience
 
@@ -312,7 +311,7 @@ get all known events as easy to use Outputs for convenience
 protected unhookEvents(grid?): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:343](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L343)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:338](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L338)
 
 ###### Parameters
 
@@ -328,28 +327,28 @@ Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:343](https://gi
 
 | Property | Modifier | Type | Default value | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ |
-| <a id="gridstackitems"></a> `gridstackItems?` | `public` | `QueryList`\<[`GridstackItemComponent`](gridstack-item.component.md#gridstackitemcomponent)\> | `undefined` | List of template-based grid items (not recommended approach). Used to sync between DOM and GridStack internals when items are defined in templates. Prefer dynamic component creation instead. | [angular/projects/lib/src/lib/gridstack.component.ts:92](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L92) |
-| <a id="container"></a> `container?` | `public` | `ViewContainerRef` | `undefined` | Container for dynamic component creation (recommended approach). Used to append grid items programmatically at runtime. | [angular/projects/lib/src/lib/gridstack.component.ts:97](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L97) |
-| <a id="isempty"></a> `isEmpty?` | `public` | `boolean` | `undefined` | Controls whether empty content should be displayed. Set to true to show ng-content with 'empty-content' selector when grid has no items. **Example** `<gridstack [isEmpty]="gridItems.length === 0"> <div empty-content>Drag widgets here to get started</div> </gridstack>` | [angular/projects/lib/src/lib/gridstack.component.ts:133](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L133) |
-| <a id="addedcb"></a> `addedCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when widgets are added to the grid | [angular/projects/lib/src/lib/gridstack.component.ts:151](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L151) |
-| <a id="changecb"></a> `changeCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when grid layout changes | [angular/projects/lib/src/lib/gridstack.component.ts:154](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L154) |
-| <a id="disablecb"></a> `disableCB` | `public` | `EventEmitter`\<[`eventCB`](#eventcb)\> | `undefined` | Emitted when grid is disabled | [angular/projects/lib/src/lib/gridstack.component.ts:157](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L157) |
-| <a id="dragcb"></a> `dragCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted during widget drag operations | [angular/projects/lib/src/lib/gridstack.component.ts:160](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L160) |
-| <a id="dragstartcb"></a> `dragStartCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget drag starts | [angular/projects/lib/src/lib/gridstack.component.ts:163](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L163) |
-| <a id="dragstopcb"></a> `dragStopCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget drag stops | [angular/projects/lib/src/lib/gridstack.component.ts:166](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L166) |
-| <a id="droppedcb-1"></a> `droppedCB` | `public` | `EventEmitter`\<[`droppedCB`](#droppedcb)\> | `undefined` | Emitted when widget is dropped | [angular/projects/lib/src/lib/gridstack.component.ts:169](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L169) |
-| <a id="enablecb"></a> `enableCB` | `public` | `EventEmitter`\<[`eventCB`](#eventcb)\> | `undefined` | Emitted when grid is enabled | [angular/projects/lib/src/lib/gridstack.component.ts:172](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L172) |
-| <a id="removedcb"></a> `removedCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when widgets are removed from the grid | [angular/projects/lib/src/lib/gridstack.component.ts:175](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L175) |
-| <a id="resizecb"></a> `resizeCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted during widget resize operations | [angular/projects/lib/src/lib/gridstack.component.ts:178](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L178) |
-| <a id="resizestartcb"></a> `resizeStartCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget resize starts | [angular/projects/lib/src/lib/gridstack.component.ts:181](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L181) |
-| <a id="resizestopcb"></a> `resizeStopCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget resize stops | [angular/projects/lib/src/lib/gridstack.component.ts:184](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L184) |
-| <a id="ref"></a> `ref` | `public` | \| `undefined` \| `ComponentRef`\<[`GridstackComponent`](#gridstackcomponent)\> | `undefined` | Component reference for dynamic component removal. Used internally when this component is created dynamically. | [angular/projects/lib/src/lib/gridstack.component.ts:207](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L207) |
-| <a id="selectortotype-1"></a> `selectorToType` | `static` | [`SelectorToType`](#selectortotype) | `{}` | Mapping of component selectors to their types for dynamic creation. This enables dynamic component instantiation from string selectors. Angular doesn't provide public access to this mapping, so we maintain our own. **Example** `GridstackComponent.addComponentToSelectorType([MyWidgetComponent]);` | [angular/projects/lib/src/lib/gridstack.component.ts:220](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L220) |
-| <a id="_options"></a> `_options?` | `protected` | `GridStackOptions` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:248](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L248) |
-| <a id="_grid"></a> `_grid?` | `protected` | `GridStack` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:249](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L249) |
-| <a id="_sub"></a> `_sub` | `protected` | `undefined` \| `Subscription` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:250](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L250) |
-| <a id="loaded"></a> `loaded?` | `protected` | `boolean` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:251](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L251) |
-| <a id="elementref"></a> `elementRef` | `readonly` | `ElementRef`\<[`GridCompHTMLElement`](#gridcomphtmlelement)\> | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:253](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L253) |
+| <a id="gridstackitems"></a> `gridstackItems?` | `public` | `QueryList`\<[`GridstackItemComponent`](gridstack-item.component.md#gridstackitemcomponent)\> | `undefined` | List of template-based grid items (not recommended approach). Used to sync between DOM and GridStack internals when items are defined in templates. Prefer dynamic component creation instead. | [angular/projects/lib/src/lib/gridstack.component.ts:93](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L93) |
+| <a id="container"></a> `container?` | `public` | `ViewContainerRef` | `undefined` | Container for dynamic component creation (recommended approach). Used to append grid items programmatically at runtime. | [angular/projects/lib/src/lib/gridstack.component.ts:98](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L98) |
+| <a id="isempty"></a> `isEmpty?` | `public` | `boolean` | `undefined` | Controls whether empty content should be displayed. Set to true to show ng-content with 'empty-content' selector when grid has no items. **Example** `<gridstack [isEmpty]="gridItems.length === 0"> <div empty-content>Drag widgets here to get started</div> </gridstack>` | [angular/projects/lib/src/lib/gridstack.component.ts:134](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L134) |
+| <a id="addedcb"></a> `addedCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when widgets are added to the grid | [angular/projects/lib/src/lib/gridstack.component.ts:152](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L152) |
+| <a id="changecb"></a> `changeCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when grid layout changes | [angular/projects/lib/src/lib/gridstack.component.ts:155](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L155) |
+| <a id="disablecb"></a> `disableCB` | `public` | `EventEmitter`\<[`eventCB`](#eventcb)\> | `undefined` | Emitted when grid is disabled | [angular/projects/lib/src/lib/gridstack.component.ts:158](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L158) |
+| <a id="dragcb"></a> `dragCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted during widget drag operations | [angular/projects/lib/src/lib/gridstack.component.ts:161](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L161) |
+| <a id="dragstartcb"></a> `dragStartCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget drag starts | [angular/projects/lib/src/lib/gridstack.component.ts:164](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L164) |
+| <a id="dragstopcb"></a> `dragStopCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget drag stops | [angular/projects/lib/src/lib/gridstack.component.ts:167](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L167) |
+| <a id="droppedcb-1"></a> `droppedCB` | `public` | `EventEmitter`\<[`droppedCB`](#droppedcb)\> | `undefined` | Emitted when widget is dropped | [angular/projects/lib/src/lib/gridstack.component.ts:170](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L170) |
+| <a id="enablecb"></a> `enableCB` | `public` | `EventEmitter`\<[`eventCB`](#eventcb)\> | `undefined` | Emitted when grid is enabled | [angular/projects/lib/src/lib/gridstack.component.ts:173](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L173) |
+| <a id="removedcb"></a> `removedCB` | `public` | `EventEmitter`\<[`nodesCB`](#nodescb)\> | `undefined` | Emitted when widgets are removed from the grid | [angular/projects/lib/src/lib/gridstack.component.ts:176](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L176) |
+| <a id="resizecb"></a> `resizeCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted during widget resize operations | [angular/projects/lib/src/lib/gridstack.component.ts:179](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L179) |
+| <a id="resizestartcb"></a> `resizeStartCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget resize starts | [angular/projects/lib/src/lib/gridstack.component.ts:182](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L182) |
+| <a id="resizestopcb"></a> `resizeStopCB` | `public` | `EventEmitter`\<[`elementCB`](#elementcb)\> | `undefined` | Emitted when widget resize stops | [angular/projects/lib/src/lib/gridstack.component.ts:185](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L185) |
+| <a id="ref"></a> `ref` | `public` | \| `undefined` \| `ComponentRef`\<[`GridstackComponent`](#gridstackcomponent)\> | `undefined` | Component reference for dynamic component removal. Used internally when this component is created dynamically. | [angular/projects/lib/src/lib/gridstack.component.ts:208](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L208) |
+| <a id="componentmap-1"></a> `componentMap` | `static` | [`ComponentMap`](#componentmap) | `{}` | Map of component keys to Angular component types used for dynamic creation. Keys default to the component's `@Component.selector` string when registered via `registerComponents()`. | [angular/projects/lib/src/lib/gridstack.component.ts:215](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L215) |
+| <a id="_options"></a> `_options?` | `protected` | `GridStackOptions` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:243](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L243) |
+| <a id="_grid"></a> `_grid?` | `protected` | `GridStack` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:244](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L244) |
+| <a id="_sub"></a> `_sub` | `protected` | `undefined` \| `Subscription` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:245](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L245) |
+| <a id="loaded"></a> `loaded?` | `protected` | `boolean` | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:246](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L246) |
+| <a id="elementref"></a> `elementRef` | `readonly` | `ElementRef`\<[`GridCompHTMLElement`](#gridcomphtmlelement)\> | `undefined` | - | [angular/projects/lib/src/lib/gridstack.component.ts:248](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L248) |
 
 ## Interfaces
 
@@ -3096,7 +3095,7 @@ function gsCreateNgComponents(
    isGrid): undefined | HTMLElement;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:354](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L354)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:349](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L349)
 
 can be used when a new item needs to be created, which we do as a Angular component, or deleted (skip)
 
@@ -3121,7 +3120,7 @@ can be used when a new item needs to be created, which we do as a Angular compon
 function gsSaveAdditionalNgInfo(n, w): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:449](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L449)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:444](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L444)
 
 called for each item in the grid - check if additional information needs to be saved.
 Note: since this is options minus gridstack protected members using Utils.removeInternalForSave(),
@@ -3147,7 +3146,7 @@ using BaseWidget.serialize()
 function gsUpdateNgComponents(n): void;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:468](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L468)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:463](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L463)
 
 track when widgeta re updated (rather than created) to make sure we de-serialize them as well
 
@@ -3283,16 +3282,17 @@ Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:33](https://git
 
 ***
 
-### SelectorToType
+### ComponentMap
 
 ```ts
-type SelectorToType = object;
+type ComponentMap = object;
 ```
 
-Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:48](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L48)
+Defined in: [angular/projects/lib/src/lib/gridstack.component.ts:49](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/gridstack.component.ts#L49)
 
-Mapping of selector strings to Angular component types.
-Used for dynamic component creation based on widget selectors.
+Mapping of component keys to Angular component types.
+Keys are the `component` field values stored in widget JSON
+(by default the component's `@Component.selector` string).
 
 #### Index Signature
 

--- a/angular/doc/api/types.md
+++ b/angular/doc/api/types.md
@@ -4,10 +4,11 @@
 
 ### NgGridStackWidget
 
-Defined in: [angular/projects/lib/src/lib/types.ts:12](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L12)
+Defined in: [angular/projects/lib/src/lib/types.ts:13](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L13)
 
 Extended GridStackWidget interface for Angular integration.
-Adds Angular-specific properties for dynamic component creation.
+Matches the React/Vue convention: `component` identifies the widget type,
+`props` carries the data passed to it (via ComponentRef.setInput()).
 
 #### Extends
 
@@ -34,18 +35,18 @@ Adds Angular-specific properties for dynamic component creation.
 | <a id="lazyload"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | - | `GridStackWidget.lazyLoad` | dist/types.d.ts:354 |
 | <a id="sizetocontent"></a> `sizeToContent?` | `number` \| `boolean` | local (vs grid) override - see GridStackOptions. Note: This also allow you to set a maximum h value (but user changeable during normal resizing) to prevent unlimited content from taking too much space (get scrollbar) | - | `GridStackWidget.sizeToContent` | dist/types.d.ts:357 |
 | <a id="resizetocontentparent"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | - | `GridStackWidget.resizeToContentParent` | dist/types.d.ts:359 |
-| <a id="selector"></a> `selector?` | `string` | Angular component selector for dynamic creation (e.g., 'my-widget') | - | - | [angular/projects/lib/src/lib/types.ts:14](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L14) |
-| <a id="input"></a> `input?` | [`NgCompInputs`](#ngcompinputs) | Serialized data for component @Input() properties | - | - | [angular/projects/lib/src/lib/types.ts:16](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L16) |
-| <a id="subgridopts"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids | `GridStackWidget.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:18](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L18) |
+| <a id="component"></a> `component?` | `string` | Key used to look up the Angular component in the `componentMap` (defaults to the component's `@Component.selector`, e.g. `'app-chart'`). | - | - | [angular/projects/lib/src/lib/types.ts:18](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L18) |
+| <a id="props"></a> `props?` | [`NgCompInputs`](#ngcompinputs) | Serialized props forwarded to the component via `ComponentRef.setInput()`. | - | - | [angular/projects/lib/src/lib/types.ts:20](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L20) |
+| <a id="subgridopts"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids | `GridStackWidget.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:22](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L22) |
 
 ***
 
 ### NgGridStackNode
 
-Defined in: [angular/projects/lib/src/lib/types.ts:25](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L25)
+Defined in: [angular/projects/lib/src/lib/types.ts:29](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L29)
 
 Extended GridStackNode interface for Angular integration.
-Adds component selector for dynamic content creation.
+Adds component key for dynamic content creation.
 
 #### Extends
 
@@ -77,13 +78,13 @@ Adds component selector for dynamic content creation.
 | <a id="grid"></a> `grid?` | `GridStack` | pointer back to parent Grid instance | `GridStackNode.grid` | dist/types.d.ts:433 |
 | <a id="subgrid"></a> `subGrid?` | `GridStack` | actual sub-grid instance | `GridStackNode.subGrid` | dist/types.d.ts:435 |
 | <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | `GridStackNode.visibleObservable` | dist/types.d.ts:437 |
-| <a id="selector-1"></a> `selector?` | `string` | Angular component selector for this node's content | - | [angular/projects/lib/src/lib/types.ts:27](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L27) |
+| <a id="component-1"></a> `component?` | `string` | Key used to look up the Angular component in the `componentMap`. | - | [angular/projects/lib/src/lib/types.ts:31](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L31) |
 
 ***
 
 ### NgGridStackOptions
 
-Defined in: [angular/projects/lib/src/lib/types.ts:34](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L34)
+Defined in: [angular/projects/lib/src/lib/types.ts:38](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L38)
 
 Extended GridStackOptions interface for Angular integration.
 Supports Angular-specific widget definitions and nested grids.
@@ -136,8 +137,8 @@ Supports Angular-specific widget definitions and nested grids.
 | <a id="staticgrid"></a> `staticGrid?` | `boolean` | makes grid static (default?: false). If `true` widgets are not movable/resizable. You don't even need draggable/resizable. A CSS class 'grid-stack-static' is also added to the element. | - | `GridStackOptions.staticGrid` | dist/types.d.ts:284 |
 | <a id="styleinhead"></a> ~~`styleInHead?`~~ | `boolean` | **Deprecated** Not used anymore, styles are now implemented with local CSS variables | - | `GridStackOptions.styleInHead` | dist/types.d.ts:288 |
 | <a id="subgriddynamic"></a> `subGridDynamic?` | `boolean` | enable/disable the creation of sub-grids on the fly by dragging items completely over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that. | - | `GridStackOptions.subGridDynamic` | dist/types.d.ts:293 |
-| <a id="children"></a> `children?` | [`NgGridStackWidget`](#nggridstackwidget)[] | Array of Angular widget definitions for initial grid setup | `GridStackOptions.children` | - | [angular/projects/lib/src/lib/types.ts:36](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L36) |
-| <a id="subgridopts-2"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids (Angular-aware) | `GridStackOptions.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:38](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L38) |
+| <a id="children"></a> `children?` | [`NgGridStackWidget`](#nggridstackwidget)[] | Array of Angular widget definitions for initial grid setup | `GridStackOptions.children` | - | [angular/projects/lib/src/lib/types.ts:40](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L40) |
+| <a id="subgridopts-2"></a> `subGridOpts?` | [`NgGridStackOptions`](#nggridstackoptions) | Configuration for nested sub-grids (Angular-aware) | `GridStackOptions.subGridOpts` | - | [angular/projects/lib/src/lib/types.ts:42](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L42) |
 
 ## Type Aliases
 
@@ -147,7 +148,7 @@ Supports Angular-specific widget definitions and nested grids.
 type NgCompInputs = object;
 ```
 
-Defined in: [angular/projects/lib/src/lib/types.ts:55](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L55)
+Defined in: [angular/projects/lib/src/lib/types.ts:59](https://github.com/adumesny/gridstack.js/blob/master/angular/projects/lib/src/lib/types.ts#L59)
 
 Type for component input data serialization.
 Maps @Input() property names to their values for widget persistence.

--- a/angular/projects/demo/src/app/app.component.ts
+++ b/angular/projects/demo/src/app/app.component.ts
@@ -4,8 +4,6 @@ import { AngularSimpleComponent } from './simple';
 import { AngularNgForTestComponent } from './ngFor';
 import { AngularNgForCmdTestComponent } from './ngFor_cmd';
 
-// TEST: local testing of file
-// import { GridstackComponent, NgGridStackOptions, NgGridStackWidget, elementCB, gsCreateNgComponents, nodesCB } from './gridstack.component';
 import { GridstackComponent, NgGridStackOptions, NgGridStackWidget, elementCB, gsCreateNgComponents, nodesCB } from 'gridstack/dist/angular';
 
 // unique ids sets for each item for correct ngFor updating
@@ -21,8 +19,8 @@ export class AppComponent implements OnInit {
   @ViewChild(AngularNgForTestComponent) case1Comp?: AngularNgForTestComponent;
   @ViewChild(AngularNgForCmdTestComponent) case2Comp?: AngularNgForCmdTestComponent;
   @ViewChild(GridstackComponent) gridComp?: GridstackComponent;
-  @ViewChild('origTextArea', {static: true}) origTextEl?: ElementRef<HTMLTextAreaElement>;
-  @ViewChild('textArea', {static: true}) textEl?: ElementRef<HTMLTextAreaElement>;
+  @ViewChild('origTextArea') origTextEl?: ElementRef<HTMLTextAreaElement>;
+  @ViewChild('textArea') textEl?: ElementRef<HTMLTextAreaElement>;
 
   // which sample to show
   public show = 5;
@@ -40,7 +38,7 @@ export class AppComponent implements OnInit {
     cellHeight: 70,
     columnOpts: { breakpoints: [{w:768, c:1}] },
   }
-  public sub0: NgGridStackWidget[] = [{x:0, y:0, selector:'app-a'}, {x:1, y:0, selector:'app-a', input: {text: 'bar'}}, {x:1, y:1, content:'plain html'}, {x:0, y:1, selector:'app-b'} ];
+  public sub0: NgGridStackWidget[] = [{x:0, y:0, component:'app-a'}, {x:1, y:0, component:'app-a', props: {text: 'bar'}}, {x:1, y:1, content:'plain html'}, {x:0, y:1, component:'app-b'} ];
   public gridOptionsFull: NgGridStackOptions = {
     ...this.gridOptions,
     children: this.sub0,
@@ -60,9 +58,9 @@ export class AppComponent implements OnInit {
     acceptWidgets: true, // will accept .grid-stack-item by default
     margin: 5,
   };
-  public sub1: NgGridStackWidget[] = [ {x:0, y:0, selector:'app-a'}, {x:1, y:0, selector:'app-b'}, {x:2, y:0, selector:'app-c'}, {x:3, y:0}, {x:0, y:1}, {x:1, y:1}];
+  public sub1: NgGridStackWidget[] = [ {x:0, y:0, component:'app-a'}, {x:1, y:0, component:'app-b'}, {x:2, y:0, component:'app-c'}, {x:3, y:0}, {x:0, y:1}, {x:1, y:1}];
   public sub2: NgGridStackWidget[] = [ {x:0, y:0}, {x:0, y:1, w:2}];
-  public sub3: NgGridStackWidget = { selector: 'app-n', w:2, h:2, subGridOpts: { children: [{selector: 'app-a'}, {selector: 'app-b', y:0, x:1}]}};
+  public sub3: NgGridStackWidget = { component: 'app-n', w:2, h:2, subGridOpts: { children: [{component: 'app-a'}, {component: 'app-b', y:0, x:1}]}};
   private subChildren: NgGridStackWidget[] = [
     {x:0, y:0, content: 'regular item'},
     {x:1, y:0, w:4, h:4, subGridOpts: {children: this.sub1}},
@@ -86,8 +84,8 @@ export class AppComponent implements OnInit {
     acceptWidgets: true,
     float: true,
     children: [
-      {x: 0, y: 0, w: 2, h: 2, selector: 'app-a'},
-      {x: 3, y: 1, h: 2, selector: 'app-b'},
+      {x: 0, y: 0, w: 2, h: 2, component: 'app-a'},
+      {x: 3, y: 1, h: 2, component: 'app-b'},
       {x: 4, y: 1},
       {x: 2, y: 3, w: 3, maxW: 3, id: 'special', content: 'has maxW=3'},
     ]
@@ -101,16 +99,16 @@ export class AppComponent implements OnInit {
     this.sub3,
   ];
   public sidebarContent7: NgGridStackWidget[] = [
-    {selector: 'app-a'},
-    {selector: 'app-b', w:2, maxW: 3},
+    {component: 'app-a'},
+    {component: 'app-b', w:2, maxW: 3},
   ];
 
   constructor() {
-    for (let y = 0; y <= 5; y++) this.lazyChildren.push({x:0, y, id:String(y), selector: y%2 ? 'app-b' : 'app-a'});
+    for (let y = 0; y <= 5; y++) this.lazyChildren.push({x:0, y, id:String(y), component: y%2 ? 'app-b' : 'app-a'});
 
     // give them content and unique id to make sure we track them during changes below...
     [...this.items, ...this.subChildren, ...this.sub1, ...this.sub2, ...this.sub0].forEach((w: NgGridStackWidget) => {
-      if (!w.selector && !w.content && !w.subGridOpts) w.content = `item ${ids++}`;
+      if (!w.component && !w.content && !w.subGridOpts) w.content = `item ${ids++}`;
     });
   }
 

--- a/angular/projects/demo/src/app/app.config.ts
+++ b/angular/projects/demo/src/app/app.config.ts
@@ -1,7 +1,5 @@
 import { ApplicationConfig, provideEnvironmentInitializer } from '@angular/core';
 
-// TEST local testing
-// import { GridstackComponent } from './gridstack.component';
 import { GridstackComponent } from 'gridstack/dist/angular';
 import { AComponent, BComponent, CComponent, NComponent } from './dummy.component';
 
@@ -9,7 +7,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideEnvironmentInitializer(() => {
       // register all our dynamic components created in the grid
-      GridstackComponent.addComponentToSelectorType([AComponent, BComponent, CComponent, NComponent]);
+      GridstackComponent.registerComponents([AComponent, BComponent, CComponent, NComponent]);
     })
   ]
 };

--- a/angular/projects/demo/src/app/app.module.ts
+++ b/angular/projects/demo/src/app/app.module.ts
@@ -7,9 +7,6 @@ import { AngularNgForCmdTestComponent } from './ngFor_cmd';
 import { AngularSimpleComponent } from './simple';
 import { AComponent, BComponent, CComponent, NComponent } from './dummy.component';
 
-// TEST local testing
-// import { GridstackModule } from './gridstack.module';
-// import { GridstackComponent } from './gridstack.component';
 import { GridstackModule, GridstackComponent } from 'gridstack/dist/angular';
 
 @NgModule({
@@ -35,6 +32,6 @@ import { GridstackModule, GridstackComponent } from 'gridstack/dist/angular';
 export class AppModule {
   constructor() {
     // register all our dynamic components created in the grid
-    GridstackComponent.addComponentToSelectorType([AComponent, BComponent, CComponent, NComponent]);
+    GridstackComponent.registerComponents([AComponent, BComponent, CComponent, NComponent]);
   }
 }

--- a/angular/projects/demo/src/app/dummy.component.ts
+++ b/angular/projects/demo/src/app/dummy.component.ts
@@ -7,9 +7,6 @@
 
 import { Component, OnDestroy, Input, ViewChild, ViewContainerRef } from '@angular/core';
 
-// TEST local testing
-// import { BaseWidget } from './base-widget';
-// import { NgCompInputs } from './gridstack.component';
 import { BaseWidget, NgCompInputs } from 'gridstack/dist/angular';
 
 @Component({

--- a/angular/projects/demo/src/app/ngFor.ts
+++ b/angular/projects/demo/src/app/ngFor.ts
@@ -62,7 +62,7 @@ export class AngularNgForTestComponent implements AfterViewInit {
     this.grid = GridStack.init({
       margin: 5,
       float: true,
-    })
+    })!
     .on('change added', (event: Event, nodes: GridStackNode[]) => this.onChange(nodes));
 
     // sync initial actual valued rendered (in case init() had to merge conflicts)

--- a/angular/projects/demo/src/app/ngFor_cmd.ts
+++ b/angular/projects/demo/src/app/ngFor_cmd.ts
@@ -57,7 +57,7 @@ export class AngularNgForCmdTestComponent implements AfterViewInit {
     this.grid = GridStack.init({
       margin: 5,
       float: true,
-    });
+    })!;
 
     // To sync dom manipulation done by Angular and widget manipulation done by gridstack we need to zip the observables
     zip(this.gridstackItems.changes, this.widgetToMake).subscribe(

--- a/angular/projects/demo/src/app/simple.ts
+++ b/angular/projects/demo/src/app/simple.ts
@@ -28,9 +28,9 @@
 
    // simple div above doesn't require Angular to run, so init gridstack here
    public ngOnInit() {
-     this.grid = GridStack.init({
-       cellHeight: 70,
-     })
+    this.grid = GridStack.init({
+      cellHeight: 70,
+    })!
      .load(this.items); // and load our content directly (will create DOM)
    }
 

--- a/angular/projects/lib/src/lib/base-widget.ts
+++ b/angular/projects/lib/src/lib/base-widget.ts
@@ -16,16 +16,18 @@
  * @example
  * ```typescript
  * @Component({
- *   selector: 'my-custom-widget',
+ *   selector: 'app-my-widget',
  *   template: '<div>{{data}}</div>'
  * })
- * export class MyCustomWidget extends BaseWidget {
- *   @Input() data: string = '';
+ * export class MyWidget extends BaseWidget {
+ *   data = input(''); // signal input (Angular 17+) — or @Input() data = ''
  *
- *   serialize() {
- *     return { data: this.data };
+ *   override serialize() {
+ *     return { data: this.data() };
  *   }
  * }
+ * // Register so the widget JSON { component: 'app-my-widget', props: { data: 'hello' } } works:
+ * GridstackComponent.registerComponents([MyWidget]);
  * ```
  */
 
@@ -76,29 +78,29 @@ export abstract class BaseWidget {
    *
    * @param w The saved widget data including input properties
    *
-   * @example
-   * ```typescript
-   * deserialize(w: NgGridStackWidget) {
-   *   super.deserialize(w); // Call parent for basic setup
-   *
-   *   // Custom initialization logic
-   *   if (w.input?.complexData) {
-   *     this.processComplexData(w.input.complexData);
-   *   }
-   * }
-   * ```
+ * @example
+ * ```typescript
+ * override deserialize(w: NgGridStackWidget) {
+ *   super.deserialize(w); // Call parent for basic setup
+ *
+ *   // Custom initialization logic
+ *   if (w.props?.complexData) {
+ *     this.processComplexData(w.props.complexData);
+ *   }
+ * }
+ * ```
    */
   public deserialize(w: NgGridStackWidget)  {
     // save full description for meta data
     this.widgetItem = w;
-    if (!w?.input) return;
+    if (!w?.props) return;
 
     if (this._compRef) {
       // Use setInput() to correctly handle both @Input() decorator and signal-based inputs (Angular 17+).
       // Direct Object.assign overwrites signal functions with plain values, breaking signal inputs.
-      Object.keys(w.input).forEach(key => this._compRef!.setInput(key, (w.input as any)[key]));
+      Object.keys(w.props).forEach(key => this._compRef!.setInput(key, (w.props as any)[key]));
     } else {
-      Object.assign(this, w.input);
+      Object.assign(this, w.props);
     }
   }
 }

--- a/angular/projects/lib/src/lib/gridstack.component.ts
+++ b/angular/projects/lib/src/lib/gridstack.component.ts
@@ -42,10 +42,11 @@ export interface GridCompHTMLElement extends GridHTMLElement {
 }
 
 /**
- * Mapping of selector strings to Angular component types.
- * Used for dynamic component creation based on widget selectors.
+ * Mapping of component keys to Angular component types.
+ * Keys are the `component` field values stored in widget JSON
+ * (by default the component's `@Component.selector` string).
  */
-export type SelectorToType = {[key: string]: Type<object>};
+export type ComponentMap = {[key: string]: Type<object>};
 
 /**
  * Angular component wrapper for GridStack.
@@ -207,38 +208,32 @@ export class GridstackComponent implements OnInit, AfterContentInit, OnDestroy {
   public ref: ComponentRef<GridstackComponent> | undefined;
 
   /**
-   * Mapping of component selectors to their types for dynamic creation.
-   *
-   * This enables dynamic component instantiation from string selectors.
-   * Angular doesn't provide public access to this mapping, so we maintain our own.
-   *
-   * @example
-   * ```typescript
-   * GridstackComponent.addComponentToSelectorType([MyWidgetComponent]);
-   * ```
+   * Map of component keys to Angular component types used for dynamic creation.
+   * Keys default to the component's `@Component.selector` string when registered
+   * via `registerComponents()`.
    */
-  public static selectorToType: SelectorToType = {};
+  public static componentMap: ComponentMap = {};
+
   /**
-   * Register a list of Angular components for dynamic creation.
+   * Register Angular components for dynamic creation.
+   *
+   * Each component is keyed by its `@Component.selector` string, which becomes
+   * the `component` field value in widget JSON (same role as `component` in React/Vue).
    *
    * @param typeList Array of component types to register
    *
    * @example
    * ```typescript
-   * GridstackComponent.addComponentToSelectorType([
-   *   MyWidgetComponent,
-   *   AnotherWidgetComponent
-   * ]);
+   * GridstackComponent.registerComponents([MyWidgetComponent, AnotherWidgetComponent]);
    * ```
    */
-  public static addComponentToSelectorType(typeList: Array<Type<object>>) {
-    typeList.forEach(type => GridstackComponent.selectorToType[ GridstackComponent.getSelector(type) ] = type);
+  public static registerComponents(typeList: Array<Type<object>>) {
+    typeList.forEach(type => GridstackComponent.componentMap[GridstackComponent.getSelector(type)] = type);
   }
+
   /**
-   * Extract the selector string from an Angular component type.
-   *
-   * @param type The component type to get selector from
-   * @returns The component's selector string
+   * Extract the Angular selector string from a component type.
+   * This is used as the default `component` key in widget JSON.
    */
   public static getSelector(type: Type<object>): string {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -384,8 +379,8 @@ export function gsCreateNgComponents(host: GridCompHTMLElement | HTMLElement, n:
       gridItem.ref = gridItemRef
 
       // define what type of component to create as child, OR you can do it GridstackItemComponent template, but this is more generic
-      const selector = n.selector;
-      const type = selector ? GridstackComponent.selectorToType[selector] : undefined;
+      const component = n.component;
+      const type = component ? GridstackComponent.componentMap[component] : undefined;
       if (type) {
         // shared code to create our selector component
         const createComp = () => {
@@ -449,9 +444,9 @@ export function gsCreateNgComponents(host: GridCompHTMLElement | HTMLElement, n:
 export function gsSaveAdditionalNgInfo(n: NgGridStackNode, w: NgGridStackWidget) {
   const gridItem = (n.el as GridItemCompHTMLElement)?._gridItemComp;
   if (gridItem) {
-    const input = gridItem.childWidget?.serialize();
-    if (input) {
-      w.input = input;
+    const props = gridItem.childWidget?.serialize();
+    if (props) {
+      w.props = props;
     }
     return;
   }
@@ -468,5 +463,5 @@ export function gsSaveAdditionalNgInfo(n: NgGridStackNode, w: NgGridStackWidget)
 export function gsUpdateNgComponents(n: NgGridStackNode) {
   const w: NgGridStackWidget = n;
   const gridItem = (n.el as GridItemCompHTMLElement)?._gridItemComp;
-  if (gridItem?.childWidget && w.input) gridItem.childWidget.deserialize(w);
+  if (gridItem?.childWidget && w.props) gridItem.childWidget.deserialize(w);
 }

--- a/angular/projects/lib/src/lib/types.ts
+++ b/angular/projects/lib/src/lib/types.ts
@@ -7,24 +7,28 @@ import { GridStackNode, GridStackOptions, GridStackWidget } from "gridstack";
 
 /**
  * Extended GridStackWidget interface for Angular integration.
- * Adds Angular-specific properties for dynamic component creation.
+ * Matches the React/Vue convention: `component` identifies the widget type,
+ * `props` carries the data passed to it (via ComponentRef.setInput()).
  */
 export interface NgGridStackWidget extends GridStackWidget {
-  /** Angular component selector for dynamic creation (e.g., 'my-widget') */
-  selector?: string;
-  /** Serialized data for component @Input() properties */
-  input?: NgCompInputs;
+  /**
+   * Key used to look up the Angular component in the `componentMap`
+   * (defaults to the component's `@Component.selector`, e.g. `'app-chart'`).
+   */
+  component?: string;
+  /** Serialized props forwarded to the component via `ComponentRef.setInput()`. */
+  props?: NgCompInputs;
   /** Configuration for nested sub-grids */
   subGridOpts?: NgGridStackOptions;
 }
 
 /**
  * Extended GridStackNode interface for Angular integration.
- * Adds component selector for dynamic content creation.
+ * Adds component key for dynamic content creation.
  */
 export interface NgGridStackNode extends GridStackNode {
-  /** Angular component selector for this node's content */
-  selector?: string;
+  /** Key used to look up the Angular component in the `componentMap`. */
+  component?: string;
 }
 
 /**

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -13,6 +13,9 @@
       ],
       "gridstack": [
         "../dist/gridstack"
+      ],
+      "gridstack/dist/angular": [
+        "projects/lib/src/index"
       ]
     },
     "noPropertyAccessFromIndexSignature": true,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -142,6 +142,7 @@ Change log
 ## 12.6.0-dev (TBD)
 * NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, fix memory leak, empty content, etc...
 * NEW: vue wrapper: brand new wrapper follow same pattern as well
+* break: [#3302](https://github.com/gridstack/gridstack.js/pull/3303) Angular wrapper using component+props (instead of selector+input)
 * feat: [#662](https://github.com/gridstack/gridstack.js/issues/662) added grid-lines.html demo (just CSS)
 * fix: [#3154](https://github.com/gridstack/gridstack.js/issues/3154) Esc key doesn't restore subgrid
 * fix: [#3231](https://github.com/gridstack/gridstack.js/issues/3231) drag broken in Firefox 147.0.4+ and Chrome 144+ due to `navigator.maxTouchPoints > 0` now returning true on desktop (macOS trackpad)

--- a/react/projects/lib/src/types.ts
+++ b/react/projects/lib/src/types.ts
@@ -1,6 +1,6 @@
 /**
  * React wrapper type extensions — same identifiers as core `gridstack`, extended when imported from `gridstack/dist/react`.
- * Angular parity: `component`/`props` ⇄ `selector`/`input`.
+ * All three framework wrappers (React, Vue, Angular) use the same `component`/`props` field names for widget JSON.
  */
 import type {
   GridStackOptions as CoreGridStackOptions,

--- a/vue/projects/lib/src/types.ts
+++ b/vue/projects/lib/src/types.ts
@@ -1,6 +1,6 @@
 /**
  * Vue wrapper type extensions — same identifiers as core `gridstack`, extended when imported from `gridstack/dist/vue`.
- * React parity: `component`/`props` ⇄ Angular `selector`/`input`.
+ * All three framework wrappers (Vue, React, Angular) use the same `component`/`props` field names for widget JSON.
  */
 import type {
   GridStackOptions as CoreGridStackOptions,


### PR DESCRIPTION
**Breaking changes: Angular wrapper only** (`gridstack/dist/angular`)

Widget JSON fields are renamed to match the React/Vue convention, making layouts portable across all three frameworks:

```diff
- { selector: 'app-chart', input: { title: 'Revenue' } }
+ { component: 'app-chart', props: { title: 'Revenue' } }
```

The registration call is also renamed:

```diff
- GridstackComponent.addComponentToSelectorType([ChartComponent, TableComponent]);
+ GridstackComponent.registerComponents([ChartComponent, TableComponent]);
```

The static map and its type are renamed accordingly (`selectorToType` → `componentMap`, `SelectorToType` → `ComponentMap`). If you subclass `BaseWidget` and override `deserialize()`, replace any direct reads of `w.input` with `w.props`.

### Description
Please explain the changes you made here. Include an example of what your changes fix or how to use the changes.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
