### PR TITLE
more print support with GridStackWidget.PrintOptions

### DIFF
--- a/demo/print.html
+++ b/demo/print.html
@@ -14,9 +14,7 @@
   <div class="container-fluid">
     <h1>Print Grid Demo</h1>
     <p>
-      This example demonstrates how to use the <code>pageBreak</code> widget option (or the <code>gs-page-break</code> attribute) 
-      to force a new page when printing a grid. <br/>
-      Notice how Item 3 has <code>pageBreak: true</code> and prints on a new page.
+      New v13.1+ printing support and widget <code>PrintOptions</code> to control how items are printed. <br/>
     </p>
     <div>
       <a class="btn btn-primary" onClick="window.print()" href="#">Print Page</a>
@@ -38,11 +36,13 @@
     };
     
     let items = [
-      {x: 0, y: 0, w: 4, h: 2, content: 'Item 1<br>(Page 1)'},
-      {x: 4, y: 0, w: 4, h: 1, content: 'Item 2<br>(Page 1)'},
-      {x: 0, y: 2, w: 12, h: 1, content: 'Item 3<br><strong>(Starts on Page 2)</strong>', pageBreak: true},
-      {x: 0, y: 3, w: 6, h: 1, content: 'Item 4<br>(Page 2)'},
-      {x: 6, y: 3, w: 6, h: 1, content: 'Item 5<br>(Page 2)'}
+      {x: 6, y: 0, w: 4, h: 1, content: 'Item 2<br>(Page 1)'},
+      {x: 1, y: 0, w: 4, h: 2, content: 'Item 1<br>(Page 1)'}, // verify domSort is working
+      {x: 0, y: 2, w: 12, h: 1, content: 'Item 3<br><strong>(Starts on Page 2)</strong>', print: { pageBreak: true } },
+      {x: 0, y: 3, w: 6, h: 1, content: 'Item 4<br>(Not Printed)', print: { hide: true } },
+      {x: 6, y: 3, w: 6, h: 1, content: 'Item 5'},
+      {x: 0, y: 4, w: 12, h: 2, content: 'Item 6<br>(Starts on Landscape Page)', print: { pageBreak: true, orientation: 'landscape' } },
+      {x: 0, y: 6, w: 12, h: 2, content: 'Item 7<br>(Starts on Portrait Page)', print: { pageBreak: true, orientation: 'portrait' } }
     ];
 
     let grid = GridStack.init(options);

--- a/doc/API.md
+++ b/doc/API.md
@@ -40,6 +40,7 @@
 - [HTMLElementExtendOpt\<T\>](#htmlelementextendoptt)
 - [MousePosition](#mouseposition)
 - [Position](#position-1)
+- [PrintOptions](#printoptions)
 - [Rect](#rect-1)
 - [Responsive](#responsive)
 - [Size](#size-1)
@@ -114,7 +115,7 @@ Construct a grid item from the given element and options
 protected _updateResizeEvent(forceRemove): GridStack;
 ```
 
-Defined in: [gridstack.ts:2126](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2126)
+Defined in: [gridstack.ts:2169](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2169)
 
 add or remove the grid element size event handler
 
@@ -134,7 +135,7 @@ add or remove the grid element size event handler
 protected _widthOrContainer(forBreakpoint): number;
 ```
 
-Defined in: [gridstack.ts:973](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L973)
+Defined in: [gridstack.ts:976](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L976)
 
 return our expected width (or parent) , and optionally of window for dynamic column check
 
@@ -177,7 +178,7 @@ JSON serialized data, including options.
 addWidget(w): undefined | GridItemHTMLElement;
 ```
 
-Defined in: [gridstack.ts:435](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L435)
+Defined in: [gridstack.ts:438](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L438)
 
 add a new widget and returns it.
 
@@ -208,7 +209,7 @@ grid.addWidget({w: 3, content: 'hello'});
 batchUpdate(flag): GridStack;
 ```
 
-Defined in: [gridstack.ts:851](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L851)
+Defined in: [gridstack.ts:854](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L854)
 
 use before calling a bunch of `addWidget()` to prevent un-necessary relayouts in between (more efficient)
 and get a single event callback. You will see no changes until `batchUpdate(false)` is called.
@@ -229,7 +230,7 @@ and get a single event callback. You will see no changes until `batchUpdate(fals
 cellHeight(val?): GridStack;
 ```
 
-Defined in: [gridstack.ts:922](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L922)
+Defined in: [gridstack.ts:925](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L925)
 
 Update current cell height - see `GridStackOptions.cellHeight` for format by updating eh Browser CSS variable.
 
@@ -261,7 +262,7 @@ grid.cellHeight('auto');  // auto-size based on content
 cellWidth(): number;
 ```
 
-Defined in: [gridstack.ts:968](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L968)
+Defined in: [gridstack.ts:971](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L971)
 
 Gets the current cell width in pixels. This is calculated based on the grid container width divided by the number of columns.
 
@@ -287,7 +288,7 @@ const widgetWidth = width * 3; // For a 3-column wide widget
 protected checkDynamicColumn(): boolean;
 ```
 
-Defined in: [gridstack.ts:980](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L980)
+Defined in: [gridstack.ts:983](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L983)
 
 checks for dynamic column count for our current size, returning true if changed
 
@@ -301,7 +302,7 @@ checks for dynamic column count for our current size, returning true if changed
 column(column, layout): GridStack;
 ```
 
-Defined in: [gridstack.ts:1059](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1059)
+Defined in: [gridstack.ts:1062](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1062)
 
 Set the number of columns in the grid. Will update existing widgets to conform to new number of columns,
 as well as cache the original layout so you can revert back to previous positions without loss.
@@ -342,7 +343,7 @@ grid.column(1);
 compact(layout, doSort): GridStack;
 ```
 
-Defined in: [gridstack.ts:1025](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1025)
+Defined in: [gridstack.ts:1028](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1028)
 
 Re-layout grid items to reclaim any empty space. This is useful after removing widgets
 or when you want to optimize the layout.
@@ -380,7 +381,7 @@ grid.compact('compact', false);
 createWidgetDivs(n): HTMLElement;
 ```
 
-Defined in: [gridstack.ts:481](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L481)
+Defined in: [gridstack.ts:484](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L484)
 
 Create the default grid item divs and content (possibly lazy loaded) by using GridStack.renderCB().
 
@@ -408,7 +409,7 @@ const element = grid.createWidgetDivs({ w: 2, h: 1, content: 'Hello World' });
 destroy(removeDOM): GridStack;
 ```
 
-Defined in: [gridstack.ts:1133](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1133)
+Defined in: [gridstack.ts:1136](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1136)
 
 Destroys a grid instance. DO NOT CALL any methods or access any vars after this as it will free up members.
 
@@ -428,7 +429,7 @@ Destroys a grid instance. DO NOT CALL any methods or access any vars after this 
 disable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2328](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2328)
+Defined in: [gridstack.ts:2371](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2371)
 
 Temporarily disables widgets moving/resizing.
 If you want a more permanent way (which freezes up resources) use `setStatic(true)` instead.
@@ -469,7 +470,7 @@ grid.disable(false);
 enable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2355](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2355)
+Defined in: [gridstack.ts:2398](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2398)
 
 Re-enables widgets moving/resizing - see disable().
 Note: This is a no-op for static grids.
@@ -508,7 +509,7 @@ grid.enable(false);
 enableMove(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2381](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2381)
+Defined in: [gridstack.ts:2424](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2424)
 
 Enables/disables widget moving for all widgets. No-op for static grids.
 Note: locally defined items (with noMove property) still override this setting.
@@ -545,7 +546,7 @@ grid.enableMove(true, false);
 enableResize(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2409](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2409)
+Defined in: [gridstack.ts:2452](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2452)
 
 Enables/disables widget resizing for all widgets. No-op for static grids.
 Note: locally defined items (with noResize property) still override this setting.
@@ -582,7 +583,7 @@ grid.enableResize(true, false);
 float(val): GridStack;
 ```
 
-Defined in: [gridstack.ts:1167](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1167)
+Defined in: [gridstack.ts:1170](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1170)
 
 Enable/disable floating widgets (default: `false`). When enabled, widgets can float up to fill empty spaces.
 See [example](http://gridstackjs.com/demo/float.html)
@@ -612,7 +613,7 @@ grid.float(false); // Disable floating (default)
 getCellFromPixel(position, useDocRelative): CellPosition;
 ```
 
-Defined in: [gridstack.ts:1197](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1197)
+Defined in: [gridstack.ts:1200](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1200)
 
 Get the position of the cell under a pixel on screen.
 
@@ -633,7 +634,7 @@ Get the position of the cell under a pixel on screen.
 getCellHeight(forcePixel): number;
 ```
 
-Defined in: [gridstack.ts:875](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L875)
+Defined in: [gridstack.ts:878](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L878)
 
 Gets the current cell height in pixels. This takes into account the unit type and converts to pixels if necessary.
 
@@ -665,7 +666,7 @@ const pixelHeight = grid.getCellHeight(true);
 getColumn(): number;
 ```
 
-Defined in: [gridstack.ts:1096](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1096)
+Defined in: [gridstack.ts:1099](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1099)
 
 Get the number of columns in the grid (default 12).
 
@@ -687,7 +688,7 @@ const columnCount = grid.getColumn(); // returns 12 by default
 static getDD(): DDGridStack;
 ```
 
-Defined in: [gridstack.ts:2225](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2225)
+Defined in: [gridstack.ts:2268](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2268)
 
 Get the global drag & drop implementation instance.
 This provides access to the underlying drag & drop functionality.
@@ -711,7 +712,7 @@ const dd = GridStack.getDD();
 getFloat(): boolean;
 ```
 
-Defined in: [gridstack.ts:1184](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1184)
+Defined in: [gridstack.ts:1187](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1187)
 
 Get the current float mode setting.
 
@@ -734,7 +735,7 @@ console.log('Floating enabled:', isFloating);
 getGridItems(): GridItemHTMLElement[];
 ```
 
-Defined in: [gridstack.ts:1110](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1110)
+Defined in: [gridstack.ts:1113](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1113)
 
 Returns an array of grid HTML elements (no placeholder) - used to iterate through our children in DOM order.
 This method excludes placeholder elements and returns only actual grid items.
@@ -760,7 +761,7 @@ items.forEach(item => {
 getMargin(): number;
 ```
 
-Defined in: [gridstack.ts:1819](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1819)
+Defined in: [gridstack.ts:1822](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1822)
 
 Returns the current margin value as a number (undefined if the 4 sides don't match).
 This only returns a number if all sides have the same margin value.
@@ -788,7 +789,7 @@ if (margin !== undefined) {
 getRow(): number;
 ```
 
-Defined in: [gridstack.ts:1227](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1227)
+Defined in: [gridstack.ts:1230](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1230)
 
 Returns the current number of rows, which will be at least `minRow` if set.
 The row count is based on the highest positioned widget in the grid.
@@ -876,7 +877,7 @@ isAreaEmpty(
    h): boolean;
 ```
 
-Defined in: [gridstack.ts:1246](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1246)
+Defined in: [gridstack.ts:1249](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1249)
 
 Checks if the specified rectangular area is empty (no widgets occupy any part of it).
 
@@ -910,7 +911,7 @@ if (grid.isAreaEmpty(1, 1, 2, 2)) {
 isIgnoreChangeCB(): boolean;
 ```
 
-Defined in: [gridstack.ts:1127](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1127)
+Defined in: [gridstack.ts:1130](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1130)
 
 Returns true if change callbacks should be ignored due to column change, sizeToContent, loading, etc.
 This is useful for callers who want to implement dirty flag functionality.
@@ -936,7 +937,7 @@ if (!grid.isIgnoreChangeCB()) {
 load(items, addRemove): GridStack;
 ```
 
-Defined in: [gridstack.ts:740](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L740)
+Defined in: [gridstack.ts:743](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L743)
 
 Load widgets from a list. This will call update() on each (matching by id) or add/remove widgets that are not there.
 Used to restore a grid layout for a saved layout list (see `save()`).
@@ -995,7 +996,7 @@ makeSubGrid(
    saveContent?): GridStack;
 ```
 
-Defined in: [gridstack.ts:509](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L509)
+Defined in: [gridstack.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L512)
 
 Convert an existing gridItem element into a sub-grid with the given (optional) options, else inherit them
 from the parent's subGrid options.
@@ -1021,7 +1022,7 @@ newly created grid
 makeWidget(els, options?): GridItemHTMLElement;
 ```
 
-Defined in: [gridstack.ts:1274](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1274)
+Defined in: [gridstack.ts:1277](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1277)
 
 If you add elements to your grid by hand (or have some framework creating DOM), you have to tell gridstack afterwards to make them widgets.
 If you want gridstack to add the elements for you, use `addWidget()` instead.
@@ -1064,7 +1065,7 @@ grid.makeWidget(element, {x: 0, y: 1, w: 4, h: 2});
 margin(value): GridStack;
 ```
 
-Defined in: [gridstack.ts:1790](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1790)
+Defined in: [gridstack.ts:1793](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1793)
 
 Updates the margins which will set all 4 sides at once - see `GridStackOptions.margin` for format options.
 Supports CSS string format of 1, 2, or 4 values or a single number.
@@ -1095,7 +1096,7 @@ grid.margin('5px 10px 15px 20px'); // Different for each side
 movable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2269](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2269)
+Defined in: [gridstack.ts:2312](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2312)
 
 Enables/Disables dragging by the user for specific grid elements.
 For all items and future items, use enableMove() instead. No-op for static grids.
@@ -1132,7 +1133,7 @@ grid.movable('#fixed-widget', false);
 off(name): GridStack;
 ```
 
-Defined in: [gridstack.ts:1370](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1370)
+Defined in: [gridstack.ts:1373](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1373)
 
 unsubscribe from the 'on' event GridStackEvent
 
@@ -1152,7 +1153,7 @@ unsubscribe from the 'on' event GridStackEvent
 offAll(): GridStack;
 ```
 
-Defined in: [gridstack.ts:1397](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1397)
+Defined in: [gridstack.ts:1400](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1400)
 
 Remove all event handlers from the grid. This is useful for cleanup when destroying a grid.
 
@@ -1176,7 +1177,7 @@ grid.offAll(); // Remove all event listeners
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1333](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1333)
+Defined in: [gridstack.ts:1336](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1336)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1227,7 +1228,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1334](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1334)
+Defined in: [gridstack.ts:1337](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1337)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1278,7 +1279,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1335](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1335)
+Defined in: [gridstack.ts:1338](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1338)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1329,7 +1330,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1336](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1336)
+Defined in: [gridstack.ts:1339](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1339)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1380,7 +1381,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1337](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1337)
+Defined in: [gridstack.ts:1340](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1340)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1431,7 +1432,7 @@ grid.on('added', (event, items) => {
 onResize(clientWidth): GridStack;
 ```
 
-Defined in: [gridstack.ts:2064](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2064)
+Defined in: [gridstack.ts:2107](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2107)
 
 called when we are being resized - check if the one Column Mode needs to be turned on/off
 and remember the prev columns we used, or get our count from parent, as well as check for cellHeight==='auto' (square)
@@ -1453,7 +1454,7 @@ or `sizeToContent` gridItem options.
 prepareDragDrop(el, force?): GridStack;
 ```
 
-Defined in: [gridstack.ts:2798](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2798)
+Defined in: [gridstack.ts:2841](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2841)
 
 prepares the element for drag&drop - this is normally called by makeWidget() unless are are delay loading
 
@@ -1474,7 +1475,7 @@ prepares the element for drag&drop - this is normally called by makeWidget() unl
 refreshDragHandles(els): GridStack;
 ```
 
-Defined in: [gridstack.ts:2786](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2786)
+Defined in: [gridstack.ts:2829](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2829)
 
 Re-scans one or more widget elements for drag handle elements after delayed content
 (React portal, Angular component, etc.) has been rendered inside the item.
@@ -1528,7 +1529,7 @@ replace just one instance.
 removeAll(removeDOM, triggerEvent): GridStack;
 ```
 
-Defined in: [gridstack.ts:1446](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1446)
+Defined in: [gridstack.ts:1449](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1449)
 
 Removes all widgets from the grid.
 
@@ -1549,7 +1550,7 @@ Removes all widgets from the grid.
 removeAsSubGrid(nodeThatRemoved?): void;
 ```
 
-Defined in: [gridstack.ts:602](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L602)
+Defined in: [gridstack.ts:605](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L605)
 
 called when an item was converted into a nested grid to accommodate a dragged over item, but then item leaves - return back
 to the original grid-item. Also called to remove empty sub-grids when last item is dragged out (since re-creating is simple)
@@ -1573,7 +1574,7 @@ removeWidget(
    triggerEvent): GridStack;
 ```
 
-Defined in: [gridstack.ts:1408](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1408)
+Defined in: [gridstack.ts:1411](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1411)
 
 Removes widget from the grid.
 
@@ -1595,7 +1596,7 @@ Removes widget from the grid.
 resizable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2295](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2295)
+Defined in: [gridstack.ts:2338](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2338)
 
 Enables/Disables user resizing for specific grid elements.
 For all items and future items, use enableResize() instead. No-op for static grids.
@@ -1629,7 +1630,7 @@ grid.resizable('#fixed-size-widget', false);
 resizeToContent(el): void;
 ```
 
-Defined in: [gridstack.ts:1679](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1679)
+Defined in: [gridstack.ts:1682](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1682)
 
 Updates widget height to match the content height to avoid vertical scrollbars or dead space.
 This automatically adjusts the widget height based on its content size.
@@ -1665,7 +1666,7 @@ grid.resizeToContent(widget);
 rotate(els, relative?): GridStack;
 ```
 
-Defined in: [gridstack.ts:1754](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1754)
+Defined in: [gridstack.ts:1757](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1757)
 
 Rotate widgets by swapping their width and height. This is typically called when the user presses 'r' during dragging.
 The rotation swaps the w/h dimensions and adjusts min/max constraints accordingly.
@@ -1705,7 +1706,7 @@ save(
   | GridStackWidget[];
 ```
 
-Defined in: [gridstack.ts:652](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L652)
+Defined in: [gridstack.ts:655](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L655)
 
 saves the current layout returning a list of widgets for serialization which might include any nested grids.
 
@@ -1731,7 +1732,7 @@ list of widgets or full grid option, including .children list of widgets
 setAnimation(doAnimate, delay?): GridStack;
 ```
 
-Defined in: [gridstack.ts:1465](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1465)
+Defined in: [gridstack.ts:1468](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1468)
 
 Toggle the grid animation state.  Toggles the `grid-stack-animate` class.
 
@@ -1755,7 +1756,7 @@ setStatic(
    recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:1488](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1488)
+Defined in: [gridstack.ts:1491](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1491)
 
 Toggle the grid static state, which permanently removes/add Drag&Drop support, unlike disable()/enable() that just turns it off/on.
 Also toggle the grid-stack-static class.
@@ -1782,7 +1783,7 @@ static setupDragIn(
    root?): void;
 ```
 
-Defined in: [gridstack.ts:2238](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2238)
+Defined in: [gridstack.ts:2281](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2281)
 
 call to setup dragging in from the outside (say toolbar), by specifying the class selection and options.
 Called during GridStack.init() as options, but can also be called directly (last param are used) in case the toolbar
@@ -1807,7 +1808,7 @@ is dynamically create and needs to be set later.
 protected triggerEvent(event, target): void;
 ```
 
-Defined in: [gridstack.ts:3060](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3060)
+Defined in: [gridstack.ts:3103](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3103)
 
 call given event callback on our main top-most grid (if we're nested)
 
@@ -1828,7 +1829,7 @@ call given event callback on our main top-most grid (if we're nested)
 update(els, opt): GridStack;
 ```
 
-Defined in: [gridstack.ts:1572](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1572)
+Defined in: [gridstack.ts:1575](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1575)
 
 Updates widget position/size and other info. This is used to change widget properties after creation.
 Can update position, size, content, and other widget properties.
@@ -1873,7 +1874,7 @@ grid.update('#my-widget', {
 updateOptions(o): GridStack;
 ```
 
-Defined in: [gridstack.ts:1506](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1506)
+Defined in: [gridstack.ts:1509](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1509)
 
 Updates the passed in options on the grid (similar to update(widget) for for the grid options).
 
@@ -1893,7 +1894,7 @@ Updates the passed in options on the grid (similar to update(widget) for for the
 willItFit(node): boolean;
 ```
 
-Defined in: [gridstack.ts:1833](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1833)
+Defined in: [gridstack.ts:1836](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1836)
 
 Returns true if the height of the grid will be less than the vertical
 constraint. Always returns true if grid doesn't have height constraint.
@@ -5315,7 +5316,7 @@ Defines the position of a cell inside the grid
 <a id="dddragopt"></a>
 ### DDDragOpt
 
-Defined in: [types.ts:485](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L485)
+Defined in: [types.ts:497](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L497)
 
 Drag&Drop dragging options
 
@@ -5323,16 +5324,16 @@ Drag&Drop dragging options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:489](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L489) |
-| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:495](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L495) |
-| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:501](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L501) |
-| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:487](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L487) |
-| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:497](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L497) |
-| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:491](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L491) |
-| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:502](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L502) |
-| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:493](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L493) |
-| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:499](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L499) |
-| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:500](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L500) |
+| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:501](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L501) |
+| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:507](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L507) |
+| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:513](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L513) |
+| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:499](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L499) |
+| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:509](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L509) |
+| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:503](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L503) |
+| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:514](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L514) |
+| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:505](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L505) |
+| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:511](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L511) |
+| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L512) |
 
 ***
 
@@ -5375,7 +5376,7 @@ All grid item DOM elements implement this interface to provide access to their g
 <a id="ddremoveopt"></a>
 ### DDRemoveOpt
 
-Defined in: [types.ts:477](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L477)
+Defined in: [types.ts:489](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L489)
 
 Drag&Drop remove options
 
@@ -5383,8 +5384,8 @@ Drag&Drop remove options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:479](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L479) |
-| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:481](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L481) |
+| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:491](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L491) |
+| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:493](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L493) |
 
 ***
 
@@ -5435,7 +5436,7 @@ Drag&Drop resize options
 <a id="ddresizeopt"></a>
 ### DDResizeOpt
 
-Defined in: [types.ts:461](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L461)
+Defined in: [types.ts:473](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L473)
 
 Drag&Drop resize options
 
@@ -5447,16 +5448,16 @@ Drag&Drop resize options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:463](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L463) |
-| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:473](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L473) |
-| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:468](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L468) |
+| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:475](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L475) |
+| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:485](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L485) |
+| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:480](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L480) |
 
 ***
 
 <a id="dduidata"></a>
 ### DDUIData
 
-Defined in: [types.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L520)
+Defined in: [types.ts:532](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L532)
 
 data that is passed during drag and resizing callbacks
 
@@ -5464,9 +5465,9 @@ data that is passed during drag and resizing callbacks
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:523](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L523) |
-| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521) |
-| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:522](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L522) |
+| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:535](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L535) |
+| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:533](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L533) |
+| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:534](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L534) |
 
 ***
 
@@ -5549,7 +5550,7 @@ options used during creation - similar to GridStackOptions
 <a id="gridstackmouseevent"></a>
 ### GridStackMouseEvent
 
-Defined in: [types.ts:587](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L587)
+Defined in: [types.ts:599](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L599)
 
 #### Extends
 
@@ -5559,9 +5560,9 @@ Defined in: [types.ts:587](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:589](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L589) |
-| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:590](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L590) |
-| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:588](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L588) |
+| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:601](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L601) |
+| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:602](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L602) |
+| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:600](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L600) |
 
 ***
 
@@ -5599,7 +5600,7 @@ options used during GridStackEngine.moveNode()
 <a id="gridstacknode-2"></a>
 ### GridStackNode
 
-Defined in: [types.ts:537](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L537)
+Defined in: [types.ts:549](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L549)
 
 internal runtime descriptions describing the widgets in the grid
 
@@ -5611,10 +5612,10 @@ internal runtime descriptions describing the widgets in the grid
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:539](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L539) |
-| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:541](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L541) |
-| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:543](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L543) |
-| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:545](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L545) |
+| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:551](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L551) |
+| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:553](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L553) |
+| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:555](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L555) |
+| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:557](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L557) |
 
 ***
 
@@ -5642,7 +5643,7 @@ Defined in: [types.ts:412](https://github.com/adumesny/gridstack.js/blob/master/
 <a id="gridstackwidget"></a>
 ### GridStackWidget
 
-Defined in: [types.ts:426](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L426)
+Defined in: [types.ts:438](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L438)
 
 GridStack Widget creation options
 
@@ -5658,20 +5659,20 @@ GridStack Widget creation options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:428](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L428) |
-| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:446](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L446) |
-| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:444](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L444) |
-| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:450](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L450) |
-| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:442](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L442) |
-| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:436](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L436) |
-| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:432](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L432) |
-| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:434](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L434) |
-| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:430](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L430) |
-| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:440](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L440) |
-| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:438](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L438) |
-| <a id="pagebreak-1"></a> `pageBreak?` | `boolean` | add a page break before this widget (default?: undefined). Useful for printing. | [types.ts:448](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L448) |
-| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:455](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L455) |
-| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L457) |
+| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:440](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L440) |
+| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:458](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L458) |
+| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:456](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L456) |
+| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:462](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L462) |
+| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:454](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L454) |
+| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:448](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L448) |
+| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:444](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L444) |
+| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:446](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L446) |
+| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:442](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L442) |
+| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:452](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L452) |
+| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:450](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L450) |
+| <a id="print-1"></a> `print?` | [`PrintOptions`](#printoptions) | print options | [types.ts:460](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L460) |
+| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:467](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L467) |
+| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:469](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L469) |
 
 ***
 
@@ -5753,7 +5754,7 @@ Defines the coordinates of an object
 <a id="position-1"></a>
 ### Position
 
-Defined in: [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L508)
+Defined in: [types.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L520)
 
 #### Extended by
 
@@ -5763,15 +5764,32 @@ Defined in: [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:515](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L515) |
-| <a id="top-1"></a> `top` | `number` | - | [types.ts:509](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L509) |
+| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:527](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L527) |
+| <a id="top-1"></a> `top` | `number` | - | [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521) |
+
+***
+
+<a id="printoptions"></a>
+### PrintOptions
+
+Defined in: [types.ts:426](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L426)
+
+Print options for a widget
+
+#### Properties
+
+| Property | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ |
+| <a id="hide"></a> `hide?` | `boolean` | prevent this widget from printing (default?: undefined). | [types.ts:430](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L430) |
+| <a id="orientation"></a> `orientation?` | `"portrait"` \| `"landscape"` | set the orientation of the printed page (default?: 'portrait'). | [types.ts:432](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L432) |
+| <a id="pagebreak"></a> `pageBreak?` | `boolean` | add a page break before this widget (default?: undefined). | [types.ts:428](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L428) |
 
 ***
 
 <a id="rect-1"></a>
 ### Rect
 
-Defined in: [types.ts:517](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L517)
+Defined in: [types.ts:529](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L529)
 
 #### Extends
 
@@ -5805,7 +5823,7 @@ NOTE: Make sure to include the appropriate CSS (gridstack-extra.css) to support 
 <a id="size-1"></a>
 ### Size
 
-Defined in: [types.ts:504](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L504)
+Defined in: [types.ts:516](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L516)
 
 #### Extended by
 
@@ -5815,8 +5833,8 @@ Defined in: [types.ts:504](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="height-1"></a> `height` | `number` | [types.ts:506](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L506) |
-| <a id="width-1"></a> `width` | `number` | [types.ts:505](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L505) |
+| <a id="height-1"></a> `height` | `number` | [types.ts:518](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L518) |
+| <a id="width-1"></a> `width` | `number` | [types.ts:517](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L517) |
 
 ## Variables
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -151,19 +151,51 @@
  }
 
 @media print {
+  @page gs-landscape {
+    size: landscape;
+  }
+  @page gs-portrait {
+    size: portrait;
+  }
+
+  /* Use native CSS Grid instead of floats for printing to perfectly respect 
+     visual coordinates and dimensions while maintaining layout flow */
   .grid-stack {
+    display: grid !important;
+    grid-template-columns: repeat(var(--gs-columns, 12), minmax(0, 1fr)) !important;
+    grid-auto-rows: var(--gs-cell-height) !important;
     height: auto !important;
   }
   .grid-stack > .grid-stack-item {
     position: relative !important;
+    float: none !important;
+    width: auto !important;
+    height: auto !important;
     left: auto !important;
     top: auto !important;
-    float: left;
+    
+    /* Apply GS coordinates natively via the injected CSS vars */
+    grid-column-start: calc(var(--gs-x) + 1) !important;
+    grid-column-end: span var(--gs-w) !important;
+    grid-row-start: calc(var(--gs-y) + 1) !important;
+    grid-row-end: span var(--gs-h) !important;
   }
   .grid-stack > .grid-stack-item[gs-page-break="true"] {
     page-break-before: always !important;
     break-before: page !important;
-    float: none !important;
-    clear: both !important;
+  }
+  .grid-stack > .grid-stack-item[gs-print-hide="true"] {
+    display: none !important;
+  }
+  .grid-stack > .grid-stack-item[gs-print-orientation="landscape"] {
+    page: gs-landscape;
+    /* Force item to take proper landscape width, overriding portrait grid track sizing.
+       vmax ensures we get the long edge of the paper regardless of default printer orientation */
+    min-width: calc(100vmax * var(--gs-w) / var(--gs-columns, 12)) !important;
+  }
+  .grid-stack > .grid-stack-item[gs-print-orientation="portrait"] {
+    page: gs-portrait;
+    /* vmin ensures we get the short edge of the paper */
+    min-width: calc(100vmin * var(--gs-w) / var(--gs-columns, 12)) !important;
   }
 }

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -416,7 +416,10 @@ export class GridStack {
 
   private _updateColumnVar(opts: GridStackOptions = this.opts): void {
     this.el.classList.add('gs-' + opts.column);
-    if (typeof opts.column === 'number') this.el.style.setProperty('--gs-column-width', `${100/opts.column}%`);
+    if (typeof opts.column === 'number') {
+      this.el.style.setProperty('--gs-column-width', `${100/opts.column}%`);
+      this.el.style.setProperty('--gs-columns', String(opts.column));
+    }
   }
 
   /**
@@ -1959,6 +1962,13 @@ export class GridStack {
       elStyle.width = n.w! > 1 ? `calc(${n.w} * var(--gs-column-width))` : null;
       elStyle.height = n.h! > 1 ? `calc(${n.h} * var(--gs-cell-height))` : null;
     }
+    
+    // Always inject variables for print CSS grid mapping (since attr() is not fully supported in calc)
+    el.style.setProperty('--gs-x', String(n.x || 0));
+    el.style.setProperty('--gs-y', String(n.y || 0));
+    el.style.setProperty('--gs-w', String(n.w || 1));
+    el.style.setProperty('--gs-h', String(n.h || 1));
+    
     // NOTE: those are technically not needed anymore (v12+) as we have CSS vars for everything, but some users depends on them to render item size using CSS
     // ALways write x,y otherwise it could be autoPositioned incorrectly #3181
     el.setAttribute('gs-x', String(n.x ?? 0));
@@ -1980,17 +1990,26 @@ export class GridStack {
       locked: 'gs-locked',
       id: 'gs-id',
       sizeToContent: 'gs-size-to-content',
-      pageBreak: 'gs-page-break',
     };
     const nodeRec = node as Record<string, unknown>;
     const attrsRec = attrs as Record<string, string>;
     for (const key in attrsRec) {
-      if (nodeRec[key]) { // 0 is valid for x,y only but done above already and not in list anyway
+      if (nodeRec[key] !== undefined && nodeRec[key] !== null && nodeRec[key] !== false) { // 0 is valid for x,y only but done above already and not in list anyway
         el.setAttribute(attrsRec[key], String(nodeRec[key]));
       } else {
         el.removeAttribute(attrsRec[key]);
       }
     }
+    if (node.print) {
+      if (node.print.pageBreak) el.setAttribute('gs-page-break', String(node.print.pageBreak)); else el.removeAttribute('gs-page-break');
+      if (node.print.hide) el.setAttribute('gs-print-hide', String(node.print.hide)); else el.removeAttribute('gs-print-hide');
+      if (node.print.orientation) el.setAttribute('gs-print-orientation', String(node.print.orientation)); else el.removeAttribute('gs-print-orientation');
+    } else {
+      el.removeAttribute('gs-page-break');
+      el.removeAttribute('gs-print-hide');
+      el.removeAttribute('gs-print-orientation');
+    }
+
     return this;
   }
 
@@ -2005,7 +2024,17 @@ export class GridStack {
     n.noResize = Utils.toBool(el.getAttribute('gs-no-resize'));
     n.noMove = Utils.toBool(el.getAttribute('gs-no-move'));
     n.locked = Utils.toBool(el.getAttribute('gs-locked'));
-    n.pageBreak = Utils.toBool(el.getAttribute('gs-page-break'));
+    
+    let pageBreak = el.getAttribute('gs-page-break');
+    let hide = el.getAttribute('gs-print-hide');
+    let orientation = el.getAttribute('gs-print-orientation') as 'portrait' | 'landscape';
+    if (pageBreak || hide || orientation) {
+      n.print = {};
+      if (pageBreak) n.print.pageBreak = Utils.toBool(pageBreak);
+      if (hide) n.print.hide = Utils.toBool(hide);
+      if (orientation) n.print.orientation = orientation;
+    }
+
     const attr = el.getAttribute('gs-size-to-content');
     if (attr) {
       if (attr === 'true' || attr === 'false') n.sizeToContent = Utils.toBool(attr);

--- a/src/types.ts
+++ b/src/types.ts
@@ -421,6 +421,18 @@ export interface GridStackPosition {
 }
 
 /**
+ * Print options for a widget
+ */
+export interface PrintOptions {
+  /** add a page break before this widget (default?: undefined). */
+  pageBreak?: boolean;
+  /** prevent this widget from printing (default?: undefined). */
+  hide?: boolean;
+  /** set the orientation of the printed page (default?: 'portrait'). */
+  orientation?: 'portrait' | 'landscape';
+}
+
+/**
  * GridStack Widget creation options
  */
 export interface GridStackWidget extends GridStackPosition {
@@ -444,8 +456,8 @@ export interface GridStackWidget extends GridStackPosition {
   id?: string;
   /** html to append inside as content */
   content?: string;
-  /** add a page break before this widget (default?: undefined). Useful for printing. */
-  pageBreak?: boolean;
+  /** print options */
+  print?: PrintOptions;
   /** true when widgets are only created when they scroll into view (visible) */
   lazyLoad?: boolean;
   /** local (vs grid) override - see GridStackOptions.


### PR DESCRIPTION
### Description
* more fix https://github.com/gridstack/gridstack.js/issues/701
* we now have print option of pageBreak, hide (don't print) and landscape vs portrait orientation on a  PER widget option
* switched to CSS grid to get correct layout and holes in the layout
* updated print demo with all options

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary

<img width="1291" height="1065" alt="Screenshot 2026-07-21 at 11 42 25 AM" src="https://github.com/user-attachments/assets/de68a9e6-27e7-4bf3-a669-fb1f328837c1" />
<img width="1008" height="666" alt="Screenshot 2026-07-21 at 11 42 45 AM" src="https://github.com/user-attachments/assets/82a9af29-5c64-4db1-96ff-06ead0bdb057" />
<img width="1010" height="668" alt="Screenshot 2026-07-21 at 11 43 01 AM" src="https://github.com/user-attachments/assets/fa8fd70c-09d3-48e4-b3e6-b737ff0fd7be" />
