### PR TITLE
preinstall script error fix

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -141,7 +141,8 @@ Change log
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## 13.0.0-dev (TBD)
-* feat: [#701](https://github.com/gridstack/gridstack.js/issues/701) pageBreak printing support for grids !
+* feat: [#701](https://github.com/gridstack/gridstack.js/issues/701) major printing support for grids using PrintOptions (pageBreak, hide, orientation, ...)
+* fix: [#3325](https://github.com/gridstack/gridstack.js/issues/3325) preinstall script
 
 ## 13.0.0 (2026-07-18)
 * NEW: react wrapper: re-did to follow the Angular pattern (drag&Drop between grid doesn't destroy content), events, lazyLoad support, fix memory leak, empty content, etc...

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "test:e2e:headed": "playwright test --headed",
     "lint": "tsc --project tsconfig.build.json --noEmit && eslint src/*.ts angular/projects/lib/src/**/*.ts react/projects/lib/src/**/*.{ts,tsx}",
     "reset": "rm -rf dist node_modules",
-    "prepublishOnly": "yarn build",
-    "preinstall": "npx only-allow yarn"
+    "prepublishOnly": "yarn build"
   },
   "keywords": [
     "Typescript",


### PR DESCRIPTION
*fix #3325

### Description
Cursor:

Why is this a bug?
When a user installs gridstack as a dependency (e.g., npm install gridstack), npm automatically executes the library's preinstall, install, and postinstall scripts on the consumer's machine.

Because gridstack.js had "preinstall": "npx only-allow yarn" in its package.json, this script runs during the consumer's installation process. This breaks things in two ways:

It attempts to download only-allow dynamically via npx over the network. For users with a private registry or restricted network (like the Nexus registry returning a 401 error in the issue description), this completely halts the installation. Even if it could download, it forces the consumer of the library to use yarn for their own app! If they are trying to build an app with npm or pnpm, our preinstall script will throw an error and refuse to let them install our library. Scripts like only-allow are meant to ensure contributors to the gridstack.js codebase use yarn, but binding it to the preinstall hook in a published library inappropriately enforces this on end-users.

Suggestion / Fix
The only-allow package itself is actually deprecated for exactly these kinds of reasons.

The modern and native way to enforce a package manager for repository contributors is using the "packageManager" field in package.json. Node's built-in corepack reads this and will automatically ensure contributors use the correct package manager. Since gridstack.js already includes "packageManager": "yarn@1.22.22..." in its package.json, the only-allow script is completely redundant anyway.

I have gone ahead and removed the "preinstall": "npx only-allow yarn" script from the package.json.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
