### PR TITLE
fix: re-export source files and include wrapper READMEs in npm package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,8 @@ module.exports = function(grunt) {
       dist: {
         files: {
           'dist/angular/README.md': ['angular/README.md'],
+          'dist/react/README.md': ['react/README.md'],
+          'dist/vue/README.md': ['vue/README.md'],
           'dist/angular/src/gridstack.component.ts': ['angular/projects/lib/src/lib/gridstack.component.ts'],
           'dist/angular/src/gridstack-item.component.ts': ['angular/projects/lib/src/lib/gridstack-item.component.ts'],
           'dist/angular/src/base-widget.ts': ['angular/projects/lib/src/lib/base-widget.ts'],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/gridstack/gridstack.js/badge.svg?branch=develop)](https://coveralls.io/github/gridstack/gridstack.js?branch=develop)
 [![downloads](https://img.shields.io/npm/dm/gridstack.svg)](https://www.npmjs.com/package/gridstack)
 
-Mobile-friendly modern Typescript library for dashboard layout and creation. Making a drag-and-drop, multi-column responsive dashboard has never been easier. Has multiple bindings and works great with [Angular](https://angular.dev/) (included), [React](https://reactjs.org/) (included), [Vue](https://vuejs.org/) (included), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others (see [frameworks](#specific-frameworks) section).
+Mobile-friendly modern Typescript library for dashboard layout and creation. Making a drag-and-drop, multi-column responsive dashboard has never been easier. Has multiple bindings and works great with [Angular](./angular/README.md) (included), [React](./react/README.md) (included), [Vue](./vue/README.md) (included), [Knockout.js](http://knockoutjs.com), [Ember](https://www.emberjs.com/) and others (see [frameworks](#specific-frameworks) section).
 
 Inspired by no-longer maintained gridster, built with love.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn build:core && yarn build:ng && yarn build:react && yarn build:vue && yarn doc",
     "build:core": "grunt && webpack && tsc --project tsconfig.build.json --stripInternal",
-    "build:ng": "cd angular && yarn build",
+    "build:ng": "cd angular && yarn build && cd .. && grunt copy:dist",
     "build:react": "cd react && yarn build:lib",
     "build:vue": "cd vue && yarn build:lib",
     "w": "webpack --mode development",
@@ -114,6 +114,9 @@
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "files": [
     "dist",
-    "doc/API.md"
+    "doc/API.md",
+    "angular/README.md",
+    "react/README.md",
+    "vue/README.md"
   ]
 }


### PR DESCRIPTION
- Restore the copying of angular source files to dist/angular/src which was broken when the build order was changed (ng-packagr deletes the dist directory, removing the files copied by grunt). Running grunt copy:dist after ng build restores them.
- Include README.md for each wrapper (angular, react, vue) as top-level items in the npm package.
- Update main README.md to link to the included wrapper READMEs instead of external sites.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
