### PR TITLE
strict mode (v13.0.0) fails columnWidth without .breakpoints

### DIFF
--- a/angular/projects/lib/package.json
+++ b/angular/projects/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack-angular",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "peerDependencies": {
     "@angular/common": ">=14",
     "@angular/core": ">=14"

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [13.0.2 (2026-07-26)](#1302-2026-07-26)
 - [13.0.1 (2026-07-22)](#1301-2026-07-22)
 - [13.0.0 (2026-07-18)](#1300-2026-07-18)
 - [12.6.0 (2026-04-08)](#1260-2026-04-08)
@@ -139,6 +140,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 13.0.2 (2026-07-26)
+* fix: [#3340](https://github.com/gridstack/gridstack.js/pull/3340) strict mode (v13.0.0) fails columnWidth without .breakpoints
 
 ## 13.0.1 (2026-07-22)
 * fix: [#3325](https://github.com/gridstack/gridstack.js/issues/3325) preinstall script

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridstack",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "license": "MIT",
   "author": "Alain Dumesny <alaind831+github@gmail.com> (https://github.com/adumesny)",
   "contributors": [

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -297,8 +297,12 @@ export class GridStack {
       if (!resp.columnWidth && !bk?.length) {
         delete opts.columnOpts;
       } else {
-        resp.columnMax = resp.columnMax || 12;
-        if (bk!.length > 1) bk!.sort((a, b) => (b.w || 0) - (a.w || 0));
+        if (bk && bk.length > 1) {
+          bk.sort((a, b) => (b.w || 0) - (a.w || 0));
+          delete resp.columnWidth; // breakpoints wins if both set
+        } else {
+          resp.columnMax = resp.columnMax || 12; // set resonable limit ?
+        }
       }
     }
 


### PR DESCRIPTION
### Description
* Cursor changed the meaning when converting to strict mode. manually fixed this logic

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
