### PR TITLE
fix: detach resize-handle document listeners on destroy before move threshold

### DIFF
--- a/src/dd-resizable-handle.ts
+++ b/src/dd-resizable-handle.ts
@@ -66,7 +66,9 @@ export class DDResizableHandle {
 
   /** call this when resize handle needs to be removed and cleaned up */
   public destroy(): DDResizableHandle {
-    if (this.moving) this._mouseUp(this.mouseDownEvent!);
+    // Clean up whenever a gesture is armed (mousedown), not only after the
+    // 3px threshold flips `moving`. Mirrors DDDraggable.destroy(). See #3345.
+    if (this.mouseDownEvent) this._mouseUp(this.mouseDownEvent);
     this.el.removeEventListener('mousedown', this._mouseDown);
     if (isTouch) {
       this.el.removeEventListener('touchstart', touchstart);


### PR DESCRIPTION
## Summary

- Fixes a listener leak in `DDResizableHandle.destroy()`: document `mousemove`/`mouseup` listeners attached on `mousedown` were only removed when `this.moving` was true (after the 3px threshold).
- A handle destroyed between `mousedown` and that threshold left orphaned listeners that then threw `Cannot read properties of undefined (reading 'gridstackNode')` on every subsequent mouse event until reload.
- Guard on `this.mouseDownEvent` instead — same pattern as `DDDraggable.destroy()`.

Fixes #3345

## Test plan

- [ ] Init a resizable grid, `mousedown` on a `.ui-resizable-handle` without moving >3px, then call `removeAll()` / `disable()` / `destroy()` while still held
- [ ] Move the mouse — no `gridstackNode` TypeError, no repeating errors on later mouse events
- [ ] Normal resize still works (mousedown → drag past 3px → mouseup)
- [ ] Esc during an in-progress resize still cancels cleanly

Made with [Cursor](https://cursor.com)