### PR TITLE
better print support (no need for printMode trade-off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,9 @@ See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html).
 
 ## Printing Support
 
-GridStack v13.1+ introduces native printing support with two distinct layout modes to handle the complexities of browser print engines (like Chrome's Flexbox/Grid pagination bug).
-
-- **Flow Mode (Default):** Items auto-size their height and flow naturally across pages without slicing. Best for dashboards with tall widgets that span multiple pages.
-- **Exact Mode (`printMode: 'exact'`):** Uses CSS Grid to perfectly respect visual coordinates and dimensions, but may slice tall items or push entire rows to the next page. Best for single-page dashboards.
+GridStack v13.1+ introduces native printing support. Widgets auto-size to their content and flow naturally
+across pages without being sliced in half, and a hidden widget (`print.hide`) leaves no gap behind. Per-widget
+`PrintOptions` let you force a page break or switch a widget's page to landscape/portrait.
 
 See [print_README.md](./print_README.md) for full details, examples, and how to use widget `PrintOptions` (like `pageBreak` and `orientation`).
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,8 +22,8 @@
     <li><a href="nested.html">Nested grids</a></li>
     <li><a href="nested_advanced.html">Nested Advanced grids</a></li>
     <li><a href="nested_constraint.html">Nested Constraint grids</a></li>
-    <li><a href="print.html">Print grid (default flow)</a></li>
-    <li><a href="print_exact.html">Print grid (exact mode)</a></li>
+    <li><a href="print.html">Print grid</a></li>
+    <li><a href="print_advanced.html">Print grid (advanced PrintOptions)</a></li>
     <li><a href="react-hooks-controlled-multiple.html">ReactJS (Hooks), multiple grid, controlled (NOT Ideal)</a></li>
     <li><a href="react-hooks.html">ReactJS (Hooks)</a></li>
     <li><a href="react.html">ReactJS</a></li>

--- a/demo/print.html
+++ b/demo/print.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Print Grid Demo (Default Flow Mode)</title>
+  <title>Print Grid Demo</title>
 
   <link rel="stylesheet" href="demo.css"/>
   <script src="../dist/gridstack-all.js"></script>
@@ -14,19 +14,19 @@
   <div class="container-fluid">
     <h1>Print Grid Demo</h1>
     <p>
-      Default v13.1+ Print Behavior (Flow Mode), 6 column. Notice how large items span across multiple printed pages automatically without being sliced.<br/>
-      <strong>Drawback:</strong> Cannot force exact layout, and manual page breaks/orientations may not work well.
+      v13.1+ printing support, 6 column. Widgets auto-size to their content and flow naturally across
+      pages - notice how the large items span multiple printed pages automatically without being sliced
+      in half, and without showing a scrollbar.<br/>
+      See <a href="print_exact.html">Print grid (advanced PrintOptions)</a> for per-widget <code>hide</code>,
+      <code>pageBreak</code> and <code>orientation</code> examples.
     </p>
     <div class="gs-print-hide">
       <a class="btn btn-primary" onClick="window.print()" href="#">Print Page</a>
-      <label style="margin-left: 15px;">
-        <input type="checkbox" id="printModeToggle" onchange="togglePrintMode()"> Exact Print Mode
-      </label>
     </div>
     <br><br>
     <div class="grid-stack" id="grid2"></div>
   </div>
-  
+
   <script type="text/javascript">
     // NOTE: REAL apps would sanitize-html or DOMPurify before blinding setting innerHTML. see #2736
     GridStack.renderCB = function(el, w) {
@@ -38,7 +38,7 @@
       cellHeight: 100,
       margin: 10,
     };
-    
+
     let grid2 = GridStack.init({...options, column: 6}, '#grid2');
     let items2 = [];
     for (let i = 0; i < 15; i++) {
@@ -55,16 +55,6 @@
       });
     }
     grid2.load(items2);
-
-    function togglePrintMode() {
-      let isExact = document.getElementById('printModeToggle').checked;
-      let el = document.getElementById('grid2');
-      if (isExact) {
-        el.classList.add('gs-print-exact');
-      } else {
-        el.classList.remove('gs-print-exact');
-      }
-    }
   </script>
 </body>
 </html>

--- a/demo/print_advanced.html
+++ b/demo/print_advanced.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Print Grid Exact Mode Demo</title>
+  <title>Print Grid Advanced PrintOptions Demo</title>
 
   <link rel="stylesheet" href="demo.css"/>
   <script src="../dist/gridstack-all.js"></script>
@@ -12,22 +12,23 @@
 </head>
 <body>
   <div class="container-fluid">
-    <h1>Print Grid Exact Mode Demo</h1>
+    <h1>Print Grid Advanced PrintOptions Demo</h1>
     <p>
-      New v13.1+ printing support with <code>printMode: 'exact'</code> and widget <code>PrintOptions</code> to control how items are printed. <br/>
-      This mode perfectly respects visual coordinates, dimensions, page breaks, and orientations using CSS Grid. <br/>
-      <strong>Drawbacks:</strong> Chrome's print engine may slice tall items, and widgets will show scrollbars instead of expanding to fit content.
+      v13.1+ printing support with per-widget <code>PrintOptions</code>: <code>hide</code>, <code>pageBreak</code>
+      and <code>orientation</code>, combined with the same content-sized, non-slicing layout from
+      <a href="print.html">Print grid</a>.<br/>
+      Notes: a hidden widget (Item 4) leaves no gap - the next widget reflows up to take its place. An
+      <code>orientation</code> section stays in effect until something else forces a new page, so the widget
+      that should resume portrait after a landscape section (Item 8) sets <code>orientation: 'portrait'</code>
+      explicitly rather than relying on it reverting on its own.
     </p>
     <div class="gs-print-hide">
       <a class="btn btn-primary" onClick="window.print()" href="#">Print Page</a>
-      <label style="margin-left: 15px;">
-        <input type="checkbox" id="printModeToggle" checked onchange="togglePrintMode()"> Exact Print Mode
-      </label>
     </div>
     <br><br>
     <div class="grid-stack" id="grid1"></div>
   </div>
-  
+
   <script type="text/javascript">
     // NOTE: REAL apps would sanitize-html or DOMPurify before blinding setting innerHTML. see #2736
     GridStack.renderCB = function(el, w) {
@@ -38,9 +39,8 @@
       float: true,
       cellHeight: 100,
       margin: 10,
-      printMode: 'exact'
     };
-    
+
     let items = [
       {x: 6, y: 1, w: 4, h: 1, content: 'Item 2<br>(Page 1)'}, // test floating (due to hidden:true support to reclaim space, will move upwards)
       {x: 1, y: 0, w: 4, h: 2, content: 'Item 1<br>(Page 1)'}, // verify domSort is working
@@ -51,21 +51,11 @@
       {x: 0, y: 6, w: 6, h: 1, content: 'Item 7'},
       {x: 0, y: 6, w: 12, h: 2, content: 'Item 8<br>(Starts on Portrait Page)' + 'Line<br>'.repeat(4), print: { pageBreak: true, orientation: 'portrait' } },
       {x: 0, y: 8, w: 6, h: 1, content: 'Item 9' + 'Line<br>'.repeat(10)},
-      {x: 0, y: 9, w: 12, h: 14, content: 'Item 10<br>(Very tall widget to test clipping and page breaks)<br>' + 'Line<br>'.repeat(40) }
+      {x: 0, y: 9, w: 12, h: 14, content: 'Item 10<br>(Very tall widget - auto-sizes to content, never sliced)<br>' + 'Line<br>'.repeat(40) }
     ];
 
     let grid1 = GridStack.init(options, '#grid1');
     grid1.load(items);
-
-    function togglePrintMode() {
-      let isExact = document.getElementById('printModeToggle').checked;
-      let el = document.getElementById('grid1');
-      if (isExact) {
-        el.classList.add('gs-print-exact');
-      } else {
-        el.classList.remove('gs-print-exact');
-      }
-    }
   </script>
 </body>
 </html>

--- a/doc/API.md
+++ b/doc/API.md
@@ -115,7 +115,7 @@ Construct a grid item from the given element and options
 protected _updateResizeEvent(forceRemove): GridStack;
 ```
 
-Defined in: [gridstack.ts:2190](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2190)
+Defined in: [gridstack.ts:2184](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2184)
 
 add or remove the grid element size event handler
 
@@ -135,7 +135,7 @@ add or remove the grid element size event handler
 protected _widthOrContainer(forBreakpoint): number;
 ```
 
-Defined in: [gridstack.ts:986](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L986)
+Defined in: [gridstack.ts:980](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L980)
 
 return our expected width (or parent) , and optionally of window for dynamic column check
 
@@ -178,7 +178,7 @@ JSON serialized data, including options.
 addWidget(w): undefined | GridItemHTMLElement;
 ```
 
-Defined in: [gridstack.ts:448](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L448)
+Defined in: [gridstack.ts:442](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L442)
 
 add a new widget and returns it.
 
@@ -209,7 +209,7 @@ grid.addWidget({w: 3, content: 'hello'});
 batchUpdate(flag): GridStack;
 ```
 
-Defined in: [gridstack.ts:864](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L864)
+Defined in: [gridstack.ts:858](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L858)
 
 use before calling a bunch of `addWidget()` to prevent un-necessary relayouts in between (more efficient)
 and get a single event callback. You will see no changes until `batchUpdate(false)` is called.
@@ -230,7 +230,7 @@ and get a single event callback. You will see no changes until `batchUpdate(fals
 cellHeight(val?): GridStack;
 ```
 
-Defined in: [gridstack.ts:935](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L935)
+Defined in: [gridstack.ts:929](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L929)
 
 Update current cell height - see `GridStackOptions.cellHeight` for format by updating eh Browser CSS variable.
 
@@ -262,7 +262,7 @@ grid.cellHeight('auto');  // auto-size based on content
 cellWidth(): number;
 ```
 
-Defined in: [gridstack.ts:981](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L981)
+Defined in: [gridstack.ts:975](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L975)
 
 Gets the current cell width in pixels. This is calculated based on the grid container width divided by the number of columns.
 
@@ -288,7 +288,7 @@ const widgetWidth = width * 3; // For a 3-column wide widget
 protected checkDynamicColumn(): boolean;
 ```
 
-Defined in: [gridstack.ts:993](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L993)
+Defined in: [gridstack.ts:987](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L987)
 
 checks for dynamic column count for our current size, returning true if changed
 
@@ -302,7 +302,7 @@ checks for dynamic column count for our current size, returning true if changed
 column(column, layout): GridStack;
 ```
 
-Defined in: [gridstack.ts:1072](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1072)
+Defined in: [gridstack.ts:1066](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1066)
 
 Set the number of columns in the grid. Will update existing widgets to conform to new number of columns,
 as well as cache the original layout so you can revert back to previous positions without loss.
@@ -343,7 +343,7 @@ grid.column(1);
 compact(layout, doSort): GridStack;
 ```
 
-Defined in: [gridstack.ts:1038](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1038)
+Defined in: [gridstack.ts:1032](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1032)
 
 Re-layout grid items to reclaim any empty space. This is useful after removing widgets
 or when you want to optimize the layout.
@@ -381,7 +381,7 @@ grid.compact('compact', false);
 createWidgetDivs(n): HTMLElement;
 ```
 
-Defined in: [gridstack.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L494)
+Defined in: [gridstack.ts:488](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L488)
 
 Create the default grid item divs and content (possibly lazy loaded) by using GridStack.renderCB().
 
@@ -409,7 +409,7 @@ const element = grid.createWidgetDivs({ w: 2, h: 1, content: 'Hello World' });
 destroy(removeDOM): GridStack;
 ```
 
-Defined in: [gridstack.ts:1146](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1146)
+Defined in: [gridstack.ts:1140](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1140)
 
 Destroys a grid instance. DO NOT CALL any methods or access any vars after this as it will free up members.
 
@@ -429,7 +429,7 @@ Destroys a grid instance. DO NOT CALL any methods or access any vars after this 
 disable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2392](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2392)
+Defined in: [gridstack.ts:2386](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2386)
 
 Temporarily disables widgets moving/resizing.
 If you want a more permanent way (which freezes up resources) use `setStatic(true)` instead.
@@ -470,7 +470,7 @@ grid.disable(false);
 enable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2419](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2419)
+Defined in: [gridstack.ts:2413](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2413)
 
 Re-enables widgets moving/resizing - see disable().
 Note: This is a no-op for static grids.
@@ -509,7 +509,7 @@ grid.enable(false);
 enableMove(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2445](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2445)
+Defined in: [gridstack.ts:2439](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2439)
 
 Enables/disables widget moving for all widgets. No-op for static grids.
 Note: locally defined items (with noMove property) still override this setting.
@@ -546,7 +546,7 @@ grid.enableMove(true, false);
 enableResize(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2473](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2473)
+Defined in: [gridstack.ts:2467](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2467)
 
 Enables/disables widget resizing for all widgets. No-op for static grids.
 Note: locally defined items (with noResize property) still override this setting.
@@ -583,7 +583,7 @@ grid.enableResize(true, false);
 float(val): GridStack;
 ```
 
-Defined in: [gridstack.ts:1180](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1180)
+Defined in: [gridstack.ts:1174](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1174)
 
 Enable/disable floating widgets (default: `false`). When enabled, widgets can float up to fill empty spaces.
 See [example](http://gridstackjs.com/demo/float.html)
@@ -613,7 +613,7 @@ grid.float(false); // Disable floating (default)
 getCellFromPixel(position, useDocRelative): CellPosition;
 ```
 
-Defined in: [gridstack.ts:1210](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1210)
+Defined in: [gridstack.ts:1204](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1204)
 
 Get the position of the cell under a pixel on screen.
 
@@ -634,7 +634,7 @@ Get the position of the cell under a pixel on screen.
 getCellHeight(forcePixel): number;
 ```
 
-Defined in: [gridstack.ts:888](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L888)
+Defined in: [gridstack.ts:882](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L882)
 
 Gets the current cell height in pixels. This takes into account the unit type and converts to pixels if necessary.
 
@@ -666,7 +666,7 @@ const pixelHeight = grid.getCellHeight(true);
 getColumn(): number;
 ```
 
-Defined in: [gridstack.ts:1109](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1109)
+Defined in: [gridstack.ts:1103](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1103)
 
 Get the number of columns in the grid (default 12).
 
@@ -688,7 +688,7 @@ const columnCount = grid.getColumn(); // returns 12 by default
 static getDD(): DDGridStack;
 ```
 
-Defined in: [gridstack.ts:2289](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2289)
+Defined in: [gridstack.ts:2283](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2283)
 
 Get the global drag & drop implementation instance.
 This provides access to the underlying drag & drop functionality.
@@ -712,7 +712,7 @@ const dd = GridStack.getDD();
 getFloat(): boolean;
 ```
 
-Defined in: [gridstack.ts:1197](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1197)
+Defined in: [gridstack.ts:1191](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1191)
 
 Get the current float mode setting.
 
@@ -735,7 +735,7 @@ console.log('Floating enabled:', isFloating);
 getGridItems(): GridItemHTMLElement[];
 ```
 
-Defined in: [gridstack.ts:1123](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1123)
+Defined in: [gridstack.ts:1117](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1117)
 
 Returns an array of grid HTML elements (no placeholder) - used to iterate through our children in DOM order.
 This method excludes placeholder elements and returns only actual grid items.
@@ -761,7 +761,7 @@ items.forEach(item => {
 getMargin(): number;
 ```
 
-Defined in: [gridstack.ts:1832](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1832)
+Defined in: [gridstack.ts:1826](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1826)
 
 Returns the current margin value as a number (undefined if the 4 sides don't match).
 This only returns a number if all sides have the same margin value.
@@ -789,7 +789,7 @@ if (margin !== undefined) {
 getRow(): number;
 ```
 
-Defined in: [gridstack.ts:1240](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1240)
+Defined in: [gridstack.ts:1234](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1234)
 
 Returns the current number of rows, which will be at least `minRow` if set.
 The row count is based on the highest positioned widget in the grid.
@@ -877,7 +877,7 @@ isAreaEmpty(
    h): boolean;
 ```
 
-Defined in: [gridstack.ts:1259](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1259)
+Defined in: [gridstack.ts:1253](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1253)
 
 Checks if the specified rectangular area is empty (no widgets occupy any part of it).
 
@@ -911,7 +911,7 @@ if (grid.isAreaEmpty(1, 1, 2, 2)) {
 isIgnoreChangeCB(): boolean;
 ```
 
-Defined in: [gridstack.ts:1140](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1140)
+Defined in: [gridstack.ts:1134](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1134)
 
 Returns true if change callbacks should be ignored due to column change, sizeToContent, loading, etc.
 This is useful for callers who want to implement dirty flag functionality.
@@ -937,7 +937,7 @@ if (!grid.isIgnoreChangeCB()) {
 load(items, addRemove): GridStack;
 ```
 
-Defined in: [gridstack.ts:753](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L753)
+Defined in: [gridstack.ts:747](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L747)
 
 Load widgets from a list. This will call update() on each (matching by id) or add/remove widgets that are not there.
 Used to restore a grid layout for a saved layout list (see `save()`).
@@ -996,7 +996,7 @@ makeSubGrid(
    saveContent?): GridStack;
 ```
 
-Defined in: [gridstack.ts:522](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L522)
+Defined in: [gridstack.ts:516](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L516)
 
 Convert an existing gridItem element into a sub-grid with the given (optional) options, else inherit them
 from the parent's subGrid options.
@@ -1022,7 +1022,7 @@ newly created grid
 makeWidget(els, options?): GridItemHTMLElement;
 ```
 
-Defined in: [gridstack.ts:1287](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1287)
+Defined in: [gridstack.ts:1281](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1281)
 
 If you add elements to your grid by hand (or have some framework creating DOM), you have to tell gridstack afterwards to make them widgets.
 If you want gridstack to add the elements for you, use `addWidget()` instead.
@@ -1065,7 +1065,7 @@ grid.makeWidget(element, {x: 0, y: 1, w: 4, h: 2});
 margin(value): GridStack;
 ```
 
-Defined in: [gridstack.ts:1803](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1803)
+Defined in: [gridstack.ts:1797](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1797)
 
 Updates the margins which will set all 4 sides at once - see `GridStackOptions.margin` for format options.
 Supports CSS string format of 1, 2, or 4 values or a single number.
@@ -1096,7 +1096,7 @@ grid.margin('5px 10px 15px 20px'); // Different for each side
 movable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2333](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2333)
+Defined in: [gridstack.ts:2327](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2327)
 
 Enables/Disables dragging by the user for specific grid elements.
 For all items and future items, use enableMove() instead. No-op for static grids.
@@ -1133,7 +1133,7 @@ grid.movable('#fixed-widget', false);
 off(name): GridStack;
 ```
 
-Defined in: [gridstack.ts:1383](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1383)
+Defined in: [gridstack.ts:1377](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1377)
 
 unsubscribe from the 'on' event GridStackEvent
 
@@ -1153,7 +1153,7 @@ unsubscribe from the 'on' event GridStackEvent
 offAll(): GridStack;
 ```
 
-Defined in: [gridstack.ts:1410](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1410)
+Defined in: [gridstack.ts:1404](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1404)
 
 Remove all event handlers from the grid. This is useful for cleanup when destroying a grid.
 
@@ -1177,7 +1177,7 @@ grid.offAll(); // Remove all event listeners
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1346](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1346)
+Defined in: [gridstack.ts:1340](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1340)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1228,7 +1228,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1347](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1347)
+Defined in: [gridstack.ts:1341](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1341)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1279,7 +1279,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1348](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1348)
+Defined in: [gridstack.ts:1342](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1342)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1330,7 +1330,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1349](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1349)
+Defined in: [gridstack.ts:1343](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1343)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1381,7 +1381,7 @@ grid.on('added', (event, items) => {
 on(name, callback): GridStack;
 ```
 
-Defined in: [gridstack.ts:1350](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1350)
+Defined in: [gridstack.ts:1344](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1344)
 
 Register event handler for grid events. You can call this on a single event name, or space separated list.
 
@@ -1432,7 +1432,7 @@ grid.on('added', (event, items) => {
 onResize(clientWidth): GridStack;
 ```
 
-Defined in: [gridstack.ts:2128](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2128)
+Defined in: [gridstack.ts:2122](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2122)
 
 called when we are being resized - check if the one Column Mode needs to be turned on/off
 and remember the prev columns we used, or get our count from parent, as well as check for cellHeight==='auto' (square)
@@ -1454,7 +1454,7 @@ or `sizeToContent` gridItem options.
 prepareDragDrop(el, force?): GridStack;
 ```
 
-Defined in: [gridstack.ts:2862](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2862)
+Defined in: [gridstack.ts:2856](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2856)
 
 prepares the element for drag&drop - this is normally called by makeWidget() unless are are delay loading
 
@@ -1475,7 +1475,7 @@ prepares the element for drag&drop - this is normally called by makeWidget() unl
 refreshDragHandles(els): GridStack;
 ```
 
-Defined in: [gridstack.ts:2850](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2850)
+Defined in: [gridstack.ts:2844](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2844)
 
 Re-scans one or more widget elements for drag handle elements after delayed content
 (React portal, Angular component, etc.) has been rendered inside the item.
@@ -1529,7 +1529,7 @@ replace just one instance.
 removeAll(removeDOM, triggerEvent): GridStack;
 ```
 
-Defined in: [gridstack.ts:1459](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1459)
+Defined in: [gridstack.ts:1453](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1453)
 
 Removes all widgets from the grid.
 
@@ -1550,7 +1550,7 @@ Removes all widgets from the grid.
 removeAsSubGrid(nodeThatRemoved?): void;
 ```
 
-Defined in: [gridstack.ts:615](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L615)
+Defined in: [gridstack.ts:609](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L609)
 
 called when an item was converted into a nested grid to accommodate a dragged over item, but then item leaves - return back
 to the original grid-item. Also called to remove empty sub-grids when last item is dragged out (since re-creating is simple)
@@ -1574,7 +1574,7 @@ removeWidget(
    triggerEvent): GridStack;
 ```
 
-Defined in: [gridstack.ts:1421](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1421)
+Defined in: [gridstack.ts:1415](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1415)
 
 Removes widget from the grid.
 
@@ -1596,7 +1596,7 @@ Removes widget from the grid.
 resizable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2359](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2359)
+Defined in: [gridstack.ts:2353](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2353)
 
 Enables/Disables user resizing for specific grid elements.
 For all items and future items, use enableResize() instead. No-op for static grids.
@@ -1630,7 +1630,7 @@ grid.resizable('#fixed-size-widget', false);
 resizeToContent(el): void;
 ```
 
-Defined in: [gridstack.ts:1692](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1692)
+Defined in: [gridstack.ts:1686](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1686)
 
 Updates widget height to match the content height to avoid vertical scrollbars or dead space.
 This automatically adjusts the widget height based on its content size.
@@ -1666,7 +1666,7 @@ grid.resizeToContent(widget);
 rotate(els, relative?): GridStack;
 ```
 
-Defined in: [gridstack.ts:1767](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1767)
+Defined in: [gridstack.ts:1761](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1761)
 
 Rotate widgets by swapping their width and height. This is typically called when the user presses 'r' during dragging.
 The rotation swaps the w/h dimensions and adjusts min/max constraints accordingly.
@@ -1706,7 +1706,7 @@ save(
   | GridStackWidget[];
 ```
 
-Defined in: [gridstack.ts:665](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L665)
+Defined in: [gridstack.ts:659](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L659)
 
 saves the current layout returning a list of widgets for serialization which might include any nested grids.
 
@@ -1732,7 +1732,7 @@ list of widgets or full grid option, including .children list of widgets
 setAnimation(doAnimate, delay?): GridStack;
 ```
 
-Defined in: [gridstack.ts:1478](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1478)
+Defined in: [gridstack.ts:1472](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1472)
 
 Toggle the grid animation state.  Toggles the `grid-stack-animate` class.
 
@@ -1756,7 +1756,7 @@ setStatic(
    recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:1501](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1501)
+Defined in: [gridstack.ts:1495](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1495)
 
 Toggle the grid static state, which permanently removes/add Drag&Drop support, unlike disable()/enable() that just turns it off/on.
 Also toggle the grid-stack-static class.
@@ -1783,7 +1783,7 @@ static setupDragIn(
    root?): void;
 ```
 
-Defined in: [gridstack.ts:2302](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2302)
+Defined in: [gridstack.ts:2296](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2296)
 
 call to setup dragging in from the outside (say toolbar), by specifying the class selection and options.
 Called during GridStack.init() as options, but can also be called directly (last param are used) in case the toolbar
@@ -1808,7 +1808,7 @@ is dynamically create and needs to be set later.
 protected triggerEvent(event, target): void;
 ```
 
-Defined in: [gridstack.ts:3124](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3124)
+Defined in: [gridstack.ts:3118](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3118)
 
 call given event callback on our main top-most grid (if we're nested)
 
@@ -1829,7 +1829,7 @@ call given event callback on our main top-most grid (if we're nested)
 update(els, opt): GridStack;
 ```
 
-Defined in: [gridstack.ts:1585](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1585)
+Defined in: [gridstack.ts:1579](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1579)
 
 Updates widget position/size and other info. This is used to change widget properties after creation.
 Can update position, size, content, and other widget properties.
@@ -1874,7 +1874,7 @@ grid.update('#my-widget', {
 updateOptions(o): GridStack;
 ```
 
-Defined in: [gridstack.ts:1519](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1519)
+Defined in: [gridstack.ts:1513](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1513)
 
 Updates the passed in options on the grid (similar to update(widget) for for the grid options).
 
@@ -1894,7 +1894,7 @@ Updates the passed in options on the grid (similar to update(widget) for for the
 willItFit(node): boolean;
 ```
 
-Defined in: [gridstack.ts:1846](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1846)
+Defined in: [gridstack.ts:1840](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L1840)
 
 Returns true if the height of the grid will be less than the vertical
 constraint. Always returns true if grid doesn't have height constraint.
@@ -3824,17 +3824,16 @@ Defines the options for a Grid
 | <a id="nonce"></a> `nonce?` | `string` | If you are using a nonce-based Content Security Policy, pass your nonce here and GridStack will add it to the `<style>` elements it creates. | [types.ts:332](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L332) |
 | <a id="placeholderclass"></a> `placeholderClass?` | `string` | class for placeholder (default?: 'grid-stack-placeholder') | [types.ts:335](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L335) |
 | <a id="placeholdertext"></a> `placeholderText?` | `string` | placeholder default content (default?: '') | [types.ts:338](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L338) |
-| <a id="printmode"></a> `printMode?` | `"flow"` \| `"exact"` | Print mode for the grid (default?: 'flow'). - 'flow': items auto-size their height and flow naturally across pages without slicing. - 'exact': uses CSS grid to perfectly respect visual coordinates and dimensions, but may slice tall items or push entire rows to the next page. See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) for more details. | [types.ts:362](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L362) |
 | <a id="removable"></a> `removable?` | `string` \| `boolean` | if true widgets could be removed by dragging outside of the grid. It could also be a selector string (ex: ".trash"), in this case widgets will be removed by dropping them there (default?: false) See example (http://gridstack.github.io/gridstack.js/demo/two.html) | [types.ts:348](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L348) |
 | <a id="removableoptions"></a> `removableOptions?` | [`DDRemoveOpt`](#ddremoveopt) | allows to override UI removable options. (default?: { accept: '.grid-stack-item' }) | [types.ts:351](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L351) |
 | <a id="resizable-4"></a> `resizable?` | [`DDResizeOpt`](#ddresizeopt) | allows to override UI resizable options. default is { handles: 'se', autoHide: true on desktop, false on mobile } | [types.ts:341](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L341) |
 | <a id="row"></a> `row?` | `number` | fix grid number of rows. This is a shortcut of writing `minRow:N, maxRow:N`. (default `0` no constrain) | [types.ts:354](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L354) |
-| <a id="rtl-2"></a> `rtl?` | `boolean` \| `"auto"` | if true turns grid to RTL, and applies the `grid-stack-rtl class`. Possible values are true, false, 'auto' (default?: 'auto') See [example](http://gridstack.github.io/gridstack.js/demo/right-to-left(rtl).html) | [types.ts:368](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L368) |
-| <a id="sizetocontent-1"></a> `sizeToContent?` | `boolean` | set to true if all grid items (by default, but item can also override) height should be based on content size instead of WidgetItem.h to avoid v-scrollbars. Note: this is still row based, not pixels, so it will use ceil(getBoundingClientRect().height / getCellHeight()) | [types.ts:373](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L373) |
-| <a id="staticgrid"></a> `staticGrid?` | `boolean` | makes grid static (default?: false). If `true` widgets are not movable/resizable. You don't even need draggable/resizable. A CSS class 'grid-stack-static' is also added to the element. | [types.ts:380](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L380) |
-| <a id="styleinhead"></a> ~~`styleInHead?`~~ | `boolean` | **Deprecated** Not used anymore, styles are now implemented with local CSS variables | [types.ts:385](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L385) |
-| <a id="subgriddynamic"></a> `subGridDynamic?` | `boolean` | enable/disable the creation of sub-grids on the fly by dragging items completely over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that. | [types.ts:392](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L392) |
-| <a id="subgridopts-1"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | list of differences in options for automatically created sub-grids under us (inside our grid-items) | [types.ts:388](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L388) |
+| <a id="rtl-2"></a> `rtl?` | `boolean` \| `"auto"` | if true turns grid to RTL, and applies the `grid-stack-rtl class`. Possible values are true, false, 'auto' (default?: 'auto') See [example](http://gridstack.github.io/gridstack.js/demo/right-to-left(rtl).html) | [types.ts:360](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L360) |
+| <a id="sizetocontent-1"></a> `sizeToContent?` | `boolean` | set to true if all grid items (by default, but item can also override) height should be based on content size instead of WidgetItem.h to avoid v-scrollbars. Note: this is still row based, not pixels, so it will use ceil(getBoundingClientRect().height / getCellHeight()) | [types.ts:365](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L365) |
+| <a id="staticgrid"></a> `staticGrid?` | `boolean` | makes grid static (default?: false). If `true` widgets are not movable/resizable. You don't even need draggable/resizable. A CSS class 'grid-stack-static' is also added to the element. | [types.ts:372](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L372) |
+| <a id="styleinhead"></a> ~~`styleInHead?`~~ | `boolean` | **Deprecated** Not used anymore, styles are now implemented with local CSS variables | [types.ts:377](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L377) |
+| <a id="subgriddynamic"></a> `subGridDynamic?` | `boolean` | enable/disable the creation of sub-grids on the fly by dragging items completely over others (nest) vs partially (push). Forces `DDDragOpt.pause=true` to accomplish that. | [types.ts:384](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L384) |
+| <a id="subgridopts-1"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | list of differences in options for automatically created sub-grids under us (inside our grid-items) | [types.ts:380](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L380) |
 
 ***
 
@@ -5317,7 +5316,7 @@ Defines the position of a cell inside the grid
 <a id="dddragopt"></a>
 ### DDDragOpt
 
-Defined in: [types.ts:506](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L506)
+Defined in: [types.ts:498](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L498)
 
 Drag&Drop dragging options
 
@@ -5325,16 +5324,16 @@ Drag&Drop dragging options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:510](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L510) |
-| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:516](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L516) |
-| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:522](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L522) |
-| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L508) |
-| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:518](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L518) |
-| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L512) |
-| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:523](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L523) |
-| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:514](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L514) |
-| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L520) |
-| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521) |
+| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:502](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L502) |
+| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L508) |
+| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:514](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L514) |
+| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:500](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L500) |
+| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:510](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L510) |
+| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:504](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L504) |
+| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:515](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L515) |
+| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:506](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L506) |
+| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L512) |
+| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:513](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L513) |
 
 ***
 
@@ -5377,7 +5376,7 @@ All grid item DOM elements implement this interface to provide access to their g
 <a id="ddremoveopt"></a>
 ### DDRemoveOpt
 
-Defined in: [types.ts:498](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L498)
+Defined in: [types.ts:490](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L490)
 
 Drag&Drop remove options
 
@@ -5385,8 +5384,8 @@ Drag&Drop remove options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:500](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L500) |
-| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:502](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L502) |
+| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:492](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L492) |
+| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L494) |
 
 ***
 
@@ -5437,7 +5436,7 @@ Drag&Drop resize options
 <a id="ddresizeopt"></a>
 ### DDResizeOpt
 
-Defined in: [types.ts:482](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L482)
+Defined in: [types.ts:474](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L474)
 
 Drag&Drop resize options
 
@@ -5449,16 +5448,16 @@ Drag&Drop resize options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:484](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L484) |
-| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L494) |
-| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:489](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L489) |
+| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:476](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L476) |
+| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:486](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L486) |
+| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:481](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L481) |
 
 ***
 
 <a id="dduidata"></a>
 ### DDUIData
 
-Defined in: [types.ts:541](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L541)
+Defined in: [types.ts:533](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L533)
 
 data that is passed during drag and resizing callbacks
 
@@ -5466,9 +5465,9 @@ data that is passed during drag and resizing callbacks
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:544](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L544) |
-| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:542](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L542) |
-| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:543](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L543) |
+| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:536](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L536) |
+| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:534](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L534) |
+| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:535](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L535) |
 
 ***
 
@@ -5551,7 +5550,7 @@ options used during creation - similar to GridStackOptions
 <a id="gridstackmouseevent"></a>
 ### GridStackMouseEvent
 
-Defined in: [types.ts:608](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L608)
+Defined in: [types.ts:600](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L600)
 
 #### Extends
 
@@ -5561,16 +5560,16 @@ Defined in: [types.ts:608](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:610](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L610) |
-| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:611](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L611) |
-| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:609](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L609) |
+| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:602](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L602) |
+| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:603](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L603) |
+| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:601](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L601) |
 
 ***
 
 <a id="gridstackmoveopts"></a>
 ### GridStackMoveOpts
 
-Defined in: [types.ts:396](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L396)
+Defined in: [types.ts:388](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L388)
 
 options used during GridStackEngine.moveNode()
 
@@ -5582,26 +5581,26 @@ options used during GridStackEngine.moveNode()
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="cellheight-2"></a> `cellHeight?` | `number` | - | [types.ts:405](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L405) |
-| <a id="cellwidth-2"></a> `cellWidth?` | `number` | vars to calculate other cells coordinates | [types.ts:404](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L404) |
-| <a id="collide-2"></a> `collide?` | [`GridStackNode`](#gridstacknode-2) | best node (most coverage) we collied with | [types.ts:415](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L415) |
-| <a id="forcecollide"></a> `forceCollide?` | `boolean` | for collision check even if we don't move | [types.ts:417](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L417) |
-| <a id="marginbottom"></a> `marginBottom?` | `number` | - | [types.ts:407](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L407) |
-| <a id="marginleft"></a> `marginLeft?` | `number` | - | [types.ts:408](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L408) |
-| <a id="marginright"></a> `marginRight?` | `number` | - | [types.ts:409](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L409) |
-| <a id="margintop"></a> `marginTop?` | `number` | - | [types.ts:406](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L406) |
-| <a id="nested"></a> `nested?` | `boolean` | true if we are calling this recursively to prevent simple swap or coverage collision - default false | [types.ts:402](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L402) |
-| <a id="pack"></a> `pack?` | `boolean` | do we pack (default true) | [types.ts:400](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L400) |
-| <a id="rect"></a> `rect?` | [`GridStackPosition`](#gridstackposition) | position in pixels of the currently dragged items (for overlap check) | [types.ts:411](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L411) |
-| <a id="resizing"></a> `resizing?` | `boolean` | true if we're live resizing | [types.ts:413](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L413) |
-| <a id="skip"></a> `skip?` | [`GridStackNode`](#gridstacknode-2) | node to skip collision | [types.ts:398](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L398) |
+| <a id="cellheight-2"></a> `cellHeight?` | `number` | - | [types.ts:397](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L397) |
+| <a id="cellwidth-2"></a> `cellWidth?` | `number` | vars to calculate other cells coordinates | [types.ts:396](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L396) |
+| <a id="collide-2"></a> `collide?` | [`GridStackNode`](#gridstacknode-2) | best node (most coverage) we collied with | [types.ts:407](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L407) |
+| <a id="forcecollide"></a> `forceCollide?` | `boolean` | for collision check even if we don't move | [types.ts:409](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L409) |
+| <a id="marginbottom"></a> `marginBottom?` | `number` | - | [types.ts:399](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L399) |
+| <a id="marginleft"></a> `marginLeft?` | `number` | - | [types.ts:400](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L400) |
+| <a id="marginright"></a> `marginRight?` | `number` | - | [types.ts:401](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L401) |
+| <a id="margintop"></a> `marginTop?` | `number` | - | [types.ts:398](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L398) |
+| <a id="nested"></a> `nested?` | `boolean` | true if we are calling this recursively to prevent simple swap or coverage collision - default false | [types.ts:394](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L394) |
+| <a id="pack"></a> `pack?` | `boolean` | do we pack (default true) | [types.ts:392](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L392) |
+| <a id="rect"></a> `rect?` | [`GridStackPosition`](#gridstackposition) | position in pixels of the currently dragged items (for overlap check) | [types.ts:403](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L403) |
+| <a id="resizing"></a> `resizing?` | `boolean` | true if we're live resizing | [types.ts:405](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L405) |
+| <a id="skip"></a> `skip?` | [`GridStackNode`](#gridstacknode-2) | node to skip collision | [types.ts:390](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L390) |
 
 ***
 
 <a id="gridstacknode-2"></a>
 ### GridStackNode
 
-Defined in: [types.ts:558](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L558)
+Defined in: [types.ts:550](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L550)
 
 internal runtime descriptions describing the widgets in the grid
 
@@ -5613,17 +5612,17 @@ internal runtime descriptions describing the widgets in the grid
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:560](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L560) |
-| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:562](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L562) |
-| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:564](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L564) |
-| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:566](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L566) |
+| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:552](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L552) |
+| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:554](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L554) |
+| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:556](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L556) |
+| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:558](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L558) |
 
 ***
 
 <a id="gridstackposition"></a>
 ### GridStackPosition
 
-Defined in: [types.ts:420](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L420)
+Defined in: [types.ts:412](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L412)
 
 #### Extended by
 
@@ -5634,17 +5633,17 @@ Defined in: [types.ts:420](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="h-2"></a> `h?` | `number` | widget dimension height (default?: 1) | [types.ts:428](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L428) |
-| <a id="w-3"></a> `w?` | `number` | widget dimension width (default?: 1) | [types.ts:426](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L426) |
-| <a id="x-3"></a> `x?` | `number` | widget position x (default?: 0) | [types.ts:422](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L422) |
-| <a id="y-3"></a> `y?` | `number` | widget position y (default?: 0) | [types.ts:424](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L424) |
+| <a id="h-2"></a> `h?` | `number` | widget dimension height (default?: 1) | [types.ts:420](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L420) |
+| <a id="w-3"></a> `w?` | `number` | widget dimension width (default?: 1) | [types.ts:418](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L418) |
+| <a id="x-3"></a> `x?` | `number` | widget position x (default?: 0) | [types.ts:414](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L414) |
+| <a id="y-3"></a> `y?` | `number` | widget position y (default?: 0) | [types.ts:416](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L416) |
 
 ***
 
 <a id="gridstackwidget"></a>
 ### GridStackWidget
 
-Defined in: [types.ts:447](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L447)
+Defined in: [types.ts:439](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L439)
 
 GridStack Widget creation options
 
@@ -5660,20 +5659,20 @@ GridStack Widget creation options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:449](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L449) |
-| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:467](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L467) |
-| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:465](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L465) |
-| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:471](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L471) |
-| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:463](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L463) |
-| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L457) |
-| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:453](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L453) |
-| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:455](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L455) |
-| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:451](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L451) |
-| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:461](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L461) |
-| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:459](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L459) |
-| <a id="print-1"></a> `print?` | [`PrintOptions`](#printoptions) | print options | [types.ts:469](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L469) |
-| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:476](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L476) |
-| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:478](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L478) |
+| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:441](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L441) |
+| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:459](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L459) |
+| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L457) |
+| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:463](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L463) |
+| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:455](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L455) |
+| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:449](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L449) |
+| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:445](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L445) |
+| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:447](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L447) |
+| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:443](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L443) |
+| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:453](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L453) |
+| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:451](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L451) |
+| <a id="print-1"></a> `print?` | [`PrintOptions`](#printoptions) | print options | [types.ts:461](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L461) |
+| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:468](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L468) |
+| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:470](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L470) |
 
 ***
 
@@ -5755,7 +5754,7 @@ Defines the coordinates of an object
 <a id="position-1"></a>
 ### Position
 
-Defined in: [types.ts:529](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L529)
+Defined in: [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521)
 
 #### Extended by
 
@@ -5765,15 +5764,15 @@ Defined in: [types.ts:529](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:536](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L536) |
-| <a id="top-1"></a> `top` | `number` | - | [types.ts:530](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L530) |
+| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:528](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L528) |
+| <a id="top-1"></a> `top` | `number` | - | [types.ts:522](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L522) |
 
 ***
 
 <a id="printoptions"></a>
 ### PrintOptions
 
-Defined in: [types.ts:435](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L435)
+Defined in: [types.ts:427](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L427)
 
 Print options for a widget.
 See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) for more details.
@@ -5782,16 +5781,16 @@ See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/prin
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="hide"></a> `hide?` | `boolean` | prevent this widget from printing (default?: undefined). Applies to both print modes. | [types.ts:437](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L437) |
-| <a id="orientation"></a> `orientation?` | `"portrait"` \| `"landscape"` | set the orientation of the printed page (default?: 'portrait'). Note: Only works in exact mode (`printMode: 'exact'`). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:441](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L441) |
-| <a id="pagebreak"></a> `pageBreak?` | `boolean` | add a page break before this widget (default?: undefined). Note: Only works in exact mode (`printMode: 'exact'`). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:439](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L439) |
+| <a id="hide"></a> `hide?` | `boolean` | prevent this widget from printing (default?: undefined) | [types.ts:429](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L429) |
+| <a id="orientation"></a> `orientation?` | `"portrait"` \| `"landscape"` | set the orientation of the printed page (default?: 'portrait'). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:433](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L433) |
+| <a id="pagebreak"></a> `pageBreak?` | `boolean` | add a page break before this widget (default?: undefined). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:431](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L431) |
 
 ***
 
 <a id="rect-1"></a>
 ### Rect
 
-Defined in: [types.ts:538](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L538)
+Defined in: [types.ts:530](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L530)
 
 #### Extends
 
@@ -5825,7 +5824,7 @@ NOTE: Make sure to include the appropriate CSS (gridstack-extra.css) to support 
 <a id="size-1"></a>
 ### Size
 
-Defined in: [types.ts:525](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L525)
+Defined in: [types.ts:517](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L517)
 
 #### Extended by
 
@@ -5835,8 +5834,8 @@ Defined in: [types.ts:525](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="height-1"></a> `height` | `number` | [types.ts:527](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L527) |
-| <a id="width-1"></a> `width` | `number` | [types.ts:526](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L526) |
+| <a id="height-1"></a> `height` | `number` | [types.ts:519](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L519) |
+| <a id="width-1"></a> `width` | `number` | [types.ts:518](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L518) |
 
 ## Variables
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [13.2.0 (TBD)](#1320-tbd)
 - [13.1.2 (2026-07-26)](#1312-2026-07-26)
 - [13.1.1 (2026-07-25)](#1311-2026-07-25)
 - [13.1.0 (2026-07-22)](#1310-2026-07-22)
@@ -143,6 +144,11 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 13.2.0 (TBD)
+* feat: [#701](https://github.com/gridstack/gridstack.js/issues/701) removed printMode as we support much better printing now that doesn't compromises.
+* fix: [#3357](https://github.com/gridstack/gridstack.js/pull/3357) (react): drop type assertions on useGridStack add/remove helpers
+* fix: [#3358](https://github.com/gridstack/gridstack.js/pull/3358) (react): use wrapper widget types in registry callbacks
 
 ## 13.1.2 (2026-07-26)
 * reg: [#3340](https://github.com/gridstack/gridstack.js/pull/3340) regression: strict mode (v13.0.0) fails columnWidth without .breakpoints - thank you [Daniel Cohen Gindi](https://github.com/danielgindi)

--- a/print_README.md
+++ b/print_README.md
@@ -1,61 +1,35 @@
 # GridStack Printing Support
 
-GridStack v13.1+ introduces native printing support with two distinct layout modes to handle the complexities of browser print engines.
+GridStack v13.1+ introduces native printing support.
 
-## The Problem: The Flexbox Pagination Bug
+## The Problem
 
-Chrome's print engine has a notorious, long-standing bug where it **cannot calculate page breaks inside CSS Grid or Flexbox containers**. 
+GridStack normally positions widgets with `position: absolute` and inline `top`/`left` coordinates. Browsers
+cannot paginate absolutely-positioned content at all - it's removed from the normal document flow, so a
+printed grid would either get clipped at the page edge or overlap across pages.
 
-If a widget is too tall to fit on the remainder of a printed page, instead of cleanly breaking the widget across two pages (or moving it to the next page), Chrome will literally slice your widgets in half across physical pieces of paper, or push entire rows to the next page, leaving massive blank gaps.
+## The Solution
 
-To solve this, GridStack offers two print modes:
+For `@media print`, GridStack switches widgets to `display: block` with `float: left` instead. This puts them
+back in the normal document flow, which browsers know how to paginate correctly:
 
----
+- Items auto-size their height to fit their content (no scrollbars, no clipping - nothing on a printed page
+  is interactive anyway).
+- Items flow left to right and wrap to the next line based on their width, in the same order they appear
+  visually on screen.
+- A widget that doesn't fit in the remaining space on a page is moved to start cleanly on the next page,
+  instead of being sliced in half across the two pages.
+- A hidden widget (`print.hide`) takes no space at all, so the widgets that follow move up to reclaim it -
+  there's no empty gap left behind.
 
-## 1. Flow Mode (Default)
-**Best for:** Dashboards with tall widgets that span multiple pages.
-
-In Flow Mode, GridStack forces the widgets to act like words in a standard Word document (`display: block` with `float: left`). This allows Chrome to cleanly push them to the next page without slicing them in half.
-
-**How it works:**
-- Items auto-size their height to fit their content.
-- Items flow naturally from left to right, wrapping to the next line when they run out of horizontal space.
-- Widgets are never sliced across pages.
-
-**The Trade-off (Gaps):**
-Because they are flowing like a standard document, they wrap line-by-line. If you have a row with one very tall widget and several short widgets, the next row of widgets *cannot start higher than the bottom of the tallest item in the previous row*. This can result in empty vertical space (gaps) under the shorter widgets.
-
----
-
-## 2. Exact Mode (`printMode: 'exact'`)
-**Best for:** Single-page dashboards or strict layouts where visual fidelity is more important than pagination.
-
-In Exact Mode, GridStack uses native CSS Grid to perfectly pack the widgets exactly as they appear on screen.
-
-**How to enable:**
-Pass `printMode: 'exact'` in your `GridStackOptions`:
-```javascript
-let grid = GridStack.init({
-  printMode: 'exact'
-});
-```
-
-**How it works:**
-- Perfectly respects your exact `x`, `y`, `w`, and `h` coordinates.
-- Zero vertical gaps (perfect 2D masonry packing).
-- Honors manual `PrintOptions` like `pageBreak: true` and `orientation: 'landscape'`.
-
-**The Trade-offs:**
-- **Slicing:** Because it uses CSS Grid, Chrome's pagination bug applies. If a tall widget lands on a page boundary, Chrome will likely slice it in half across two pages.
-- **Scrollbars:** Widgets do *not* auto-expand their height to fit content. If a widget has more content than its `h` value allows, it will print with a scrollbar (or clip the content) just like it does on screen, rather than expanding and pushing the widgets below it down.
-
----
+**The one remaining trade-off:** this is a left-to-right/top-to-bottom flow, not a pixel-perfect 2D packing.
+If one widget in a row is much taller than its neighbors, the next row still can't start higher than that
+tall widget's bottom edge (plain CSS has no print-safe masonry layout). Hidden widgets aren't affected by
+this - only different-height *visible* neighbors sharing a row are.
 
 ## Widget PrintOptions
 
 You can customize how individual widgets print by passing a `print` object to the widget options.
-
-*Note: `pageBreak` and `orientation` require **Exact Mode**. In Flow Mode, items use `float: left` to achieve natural wrapping, and Chrome's print engine ignores forced page breaks on floated elements - `pageBreak` and `orientation` will have no effect there.*
 
 ```javascript
 {
@@ -64,17 +38,30 @@ You can customize how individual widgets print by passing a `print` object to th
   print: {
     hide: true,                  // Prevent this widget from printing
     pageBreak: true,             // Force a page break before this widget
-    orientation: 'landscape'     // Force the printed page to be landscape
+    orientation: 'landscape'     // Force the printed page (and this widget's own page) to be landscape
   }
 }
 ```
 
+Note: `pageBreak`/`orientation` pull the widget out of the normal float flow so the browser reliably honors
+the forced break (floated elements are otherwise ignored by Chrome's forced page-break handling) - the
+widget's width is unaffected.
+
+`orientation` stays in effect for that page until something else forces a new page - it doesn't automatically
+revert on the next widget. If you have a landscape section followed by widgets that should go back to
+portrait, set `orientation: 'portrait'` (or `pageBreak: true`) explicitly on the widget that should resume
+portrait, rather than relying on it reverting on its own.
+
 ## Utility Classes
 
-GridStack also provides a utility class to hide specific elements (like buttons or navbars) during printing:
+GridStack also provides a utility class to hide specific elements (like buttons, links, or a navbar) during
+printing - useful for anything interactive that doesn't make sense on paper:
 
 ```html
 <div class="gs-print-hide">
   <button onClick="window.print()">Print Dashboard</button>
 </div>
 ```
+
+This works anywhere in the document, not just on grid items - for example on buttons/links inside a widget's
+own content.

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -159,24 +159,30 @@
   }
 
   /* ========================================================================
-     DEFAULT PRINT MODE: Flow
-     Ignores exact Y/H coordinates and uses block/float flow. 
-     Items auto-size their height and flow naturally across pages without slicing.
-     Drawback: Cannot force exact layout, page breaks/orientations may not work well.
+     PRINT LAYOUT
+     GridStack normally positions items with `position: absolute`, which browsers
+     can't paginate at all (it's removed from the flow). For print we switch to
+     block/float flow instead: items auto-size their height to content and flow
+     left to right, wrapping naturally across pages without being sliced in half.
+     Trade-off: this ignores the exact on-screen Y coordinate, so if one item in
+     a row is much taller than its siblings, shorter siblings in the next row
+     still can't start higher than that tall item's bottom (plain CSS has no
+     print-safe masonry packing) - hidden items don't cause this though, since
+     a display:none item simply takes no space and following items move up.
      ======================================================================== */
-  .grid-stack:not(.gs-print-exact) {
+  .grid-stack {
     display: block !important;
     height: auto !important;
     position: static !important;
   }
-  .grid-stack:not(.gs-print-exact) > .grid-stack-item {
+  .grid-stack > .grid-stack-item {
     display: block !important;
     float: left !important;
     position: static !important;
     height: auto !important; /* Let it grow with content */
     left: auto !important;
     top: auto !important;
-    
+
     /* Proportional width based on grid columns */
     width: calc(100% * var(--gs-w) / var(--gs-columns, 12)) !important;
 
@@ -184,18 +190,18 @@
     break-inside: avoid !important;
     page-break-inside: avoid !important;
   }
-  .grid-stack:not(.gs-print-exact) > .grid-stack-item > .grid-stack-item-content {
+  .grid-stack > .grid-stack-item > .grid-stack-item-content {
     position: relative !important; /* change from absolute to relative to dictate parent height */
     height: auto !important;
     overflow: visible !important;
     white-space: normal !important;
-    
+
     /* Convert absolute positioning offsets to margins to keep the gaps */
     margin-top: var(--gs-item-margin-top) !important;
     margin-right: var(--gs-item-margin-right) !important;
     margin-bottom: var(--gs-item-margin-bottom) !important;
     margin-left: var(--gs-item-margin-left) !important;
-    
+
     top: auto !important;
     right: auto !important;
     bottom: auto !important;
@@ -203,46 +209,32 @@
   }
 
   /* ========================================================================
-     EXACT PRINT MODE: .gs-print-exact (CSS Grid)
-     Perfectly respects visual coordinates, dimensions, page breaks, and orientations.
-     Drawback: Chrome's print engine may slice tall items or push entire rows to the next page.
+     PER-WIDGET PrintOptions
      ======================================================================== */
-  .grid-stack.gs-print-exact {
-    display: grid !important;
-    grid-template-columns: repeat(var(--gs-columns, 12), minmax(0, 1fr)) !important;
-    grid-auto-rows: var(--gs-cell-height) !important;
-    height: auto !important;
+  .gs-print-hide {
+    display: none !important;
   }
-  .grid-stack.gs-print-exact > .grid-stack-item {
-    position: relative !important;
+  /* needs to out-specificity the base item rule above (display: block !important)
+     so a hidden widget actually collapses instead of still reserving its slot */
+  .grid-stack > .grid-stack-item.gs-print-hide {
+    display: none !important;
+  }
+  /* pageBreak/orientation need the item to be a normal block box: Chrome's print
+     engine ignores forced page breaks on floated elements, so pull these out of
+     the float flow (their width is kept as-is - a plain block box already can't
+     have a later float rise up beside it, so nothing else tucks into the row). */
+  .grid-stack > .grid-stack-item[gs-page-break="true"],
+  .grid-stack > .grid-stack-item[gs-print-orientation] {
     float: none !important;
-    width: auto !important;
-    height: auto !important;
-    left: auto !important;
-    top: auto !important;
-    
-    /* Apply GS coordinates natively via the injected CSS vars.
-       We deliberately DO NOT set grid-row-start so that the browser's 
-       CSS Grid engine can natively auto-flow elements upwards, naturally 
-       collapsing any empty rows caused by hidden elements! */
-    grid-column-start: calc(var(--gs-x) + 1) !important;
-    grid-column-end: span var(--gs-w) !important;
-    grid-row-end: span var(--gs-h) !important;
+    clear: both !important;
   }
-
-  /* ========================================================================
-     SHARED PRINT STYLES
-     ======================================================================== */
   .grid-stack > .grid-stack-item[gs-page-break="true"] {
     page-break-before: always !important;
     break-before: page !important;
   }
-  .gs-print-hide {
-    display: none !important;
-  }
   .grid-stack > .grid-stack-item[gs-print-orientation="landscape"] {
     page: gs-landscape;
-    /* Force item to take proper landscape width, overriding portrait grid track sizing.
+    /* Force item to take proper landscape width, overriding portrait-page sizing.
        vmax ensures we get the long edge of the paper regardless of default printer orientation */
     min-width: calc(100vmax * var(--gs-w) / var(--gs-columns, 12)) !important;
   }
@@ -251,7 +243,7 @@
     /* vmin ensures we get the short edge of the paper */
     min-width: calc(100vmin * var(--gs-w) / var(--gs-columns, 12)) !important;
   }
-  
+
   /* Hide interactive elements during print */
   .grid-stack > .grid-stack-item > .ui-resizable-handle {
     display: none !important;

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -340,12 +340,6 @@ export class GridStack {
       this.el.classList.add('grid-stack-rtl');
     }
 
-    if (opts.printMode === 'exact') {
-      this.el.classList.add('gs-print-exact');
-    } else {
-      this.el.classList.add('gs-print-flow');
-    }
-
     // check if we're been nested, and if so update our style and keep pointer around (used during save)
     const parentGridItem: GridItemHTMLElement | null = this.el.closest('.' + gridDefaults.itemClass!);
     const parentNode = parentGridItem?.gridstackNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,14 +354,6 @@ export interface GridStackOptions {
   row?: number;
 
   /**
-   * Print mode for the grid (default?: 'flow').
-   * - 'flow': items auto-size their height and flow naturally across pages without slicing.
-   * - 'exact': uses CSS grid to perfectly respect visual coordinates and dimensions, but may slice tall items or push entire rows to the next page.
-   * See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) for more details.
-   */
-  printMode?: 'flow' | 'exact';
-
-  /**
    * if true turns grid to RTL, and applies the `grid-stack-rtl class`. Possible values are true, false, 'auto' (default?: 'auto')
    * See [example](http://gridstack.github.io/gridstack.js/demo/right-to-left(rtl).html)
    */
@@ -433,11 +425,11 @@ export interface GridStackPosition {
  * See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) for more details.
  */
 export interface PrintOptions {
-  /** prevent this widget from printing (default?: undefined). Applies to both print modes. */
+  /** prevent this widget from printing (default?: undefined) */
   hide?: boolean;
-  /** add a page break before this widget (default?: undefined). Note: Only works in exact mode (`printMode: 'exact'`). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
+  /** add a page break before this widget (default?: undefined). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
   pageBreak?: boolean;
-  /** set the orientation of the printed page (default?: 'portrait'). Note: Only works in exact mode (`printMode: 'exact'`). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
+  /** set the orientation of the printed page (default?: 'portrait'). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
   orientation?: 'portrait' | 'landscape';
 }
 


### PR DESCRIPTION
### Description
* more fix #701
* asked Claude to fix the printMode trade-off, which ahs been removed. We now support per widget pageBreak + orientation WHIEL allowing widgets to size to content (no scrollbar) and reflow when a row is hidden.
* demo now has advanced mode showing options

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
