### PR TITLE
mobile: pause to drag/reszie vs scroll behavior

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -4068,7 +4068,7 @@ Defined in: [dd-draggable.ts:70](https://github.com/adumesny/gridstack.js/blob/m
 destroy(): void;
 ```
 
-Defined in: [dd-draggable.ts:132](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L132)
+Defined in: [dd-draggable.ts:133](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L133)
 
 Destroy this drag & drop implementation and clean up resources.
 Removes all event handlers and clears internal state.
@@ -4194,7 +4194,7 @@ Register an event callback for the specified event.
 refreshHandles(): void;
 ```
 
-Defined in: [dd-draggable.ts:153](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L153)
+Defined in: [dd-draggable.ts:154](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L154)
 
 Re-scans the item element for drag-handle elements after delayed content (React portal,
 Angular component, etc.) has been rendered into the item.  Removes listeners from the
@@ -4238,7 +4238,7 @@ Result from the callback function, if any
 updateOption(opts): DDDraggable;
 ```
 
-Defined in: [dd-draggable.ts:142](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L142)
+Defined in: [dd-draggable.ts:143](https://github.com/adumesny/gridstack.js/blob/master/src/dd-draggable.ts#L143)
 
 Method to update the options and return the DD implementation
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@ Change log
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+- [13.2.0-dev (TBD)](#1320-dev-tbd)
 - [13.2.0 (2026-08-19)](#1320-2026-08-19)
 - [13.1.2 (2026-07-26)](#1312-2026-07-26)
 - [13.1.1 (2026-07-25)](#1311-2026-07-25)
@@ -144,6 +145,9 @@ Change log
 - [v0.1.0 (2014-11-18)](#v010-2014-11-18)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 13.2.0-dev (TBD)
+* feat: [#2781](https://github.com/gridstack/gridstack.js/issues/3177) [#2781](https://github.com/gridstack/gridstack.js/issues/3177) mobile: pause to drag/reszie vs scroll behavior
 
 ## 13.2.0 (2026-08-19)
 * feat: [#701](https://github.com/gridstack/gridstack.js/issues/701) removed printMode as we support much better printing now that doesn't compromise.

--- a/src/dd-draggable.ts
+++ b/src/dd-draggable.ts
@@ -8,7 +8,7 @@ import { DragTransform, Utils } from './utils';
 import { DDBaseImplement, HTMLElementExtendOpt } from './dd-base-impl';
 import { GridItemHTMLElement, DDUIData, GridStackNode, GridStackPosition, DDDragOpt } from './types';
 import { DDElementHost } from './dd-element';
-import { isTouch, touchend, touchmove, touchstart, pointerdown, DDTouch } from './dd-touch';
+import { isTouch, touchend, touchmove, touchstart, pointerdown, cancelPendingTouchDrag, DDTouch } from './dd-touch';
 import { GridHTMLElement } from './gridstack';
 
 interface DragOffset {
@@ -119,6 +119,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   public override disable(forDestroy = false): void {
     if (this.disabled === true) return;
     super.disable();
+    cancelPendingTouchDrag();
     this.dragEls.forEach(dragEl => {
       dragEl.removeEventListener('mousedown', this._mouseDown);
       if (isTouch) {
@@ -198,6 +199,11 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
     if (isTouch && e.currentTarget) {
       (e.currentTarget as HTMLElement).addEventListener('touchmove', touchmove);
       (e.currentTarget as HTMLElement).addEventListener('touchend', touchend);
+      (e.currentTarget as HTMLElement).addEventListener('touchcancel', touchend); // browser aborting on us, clean up too
+    }
+    if (DDTouch.wasDelayed) {
+      // the long-press wait just elapsed - signal the item is now armed & ready to drag
+      this.el.classList.add('ui-draggable-armed');
     }
 
     e.preventDefault();
@@ -241,6 +247,7 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
        * don't start unless we've moved at least 3 pixels
        */
       this.dragging = true;
+      this.el.classList.remove('ui-draggable-armed');
       DDManager.dragElement = this;
       // if we're dragging an actual grid item, set the current drop as the grid (to detect enter/leave)
       const grid = this.el.gridstackNode?.grid;
@@ -270,11 +277,13 @@ export class DDDraggable extends DDBaseImplement implements HTMLElementExtendOpt
   /** @internal call when the mouse gets released to drop the item at current location */
   protected _mouseUp(e: MouseEvent): void {
     this._stopScrolling();
+    this.el.classList.remove('ui-draggable-armed');
     document.removeEventListener('mousemove', this._mouseMove, true);
     document.removeEventListener('mouseup', this._mouseUp as EventListener, true);
     if (isTouch && e.currentTarget) { // destroy() during nested grid call us again wit fake _mouseUp
       e.currentTarget.removeEventListener('touchmove', touchmove as EventListener, true);
       e.currentTarget.removeEventListener('touchend', touchend as EventListener, true);
+      e.currentTarget.removeEventListener('touchcancel', touchend as EventListener, true);
     }
     if (this.dragging) {
       delete this.dragging;

--- a/src/dd-resizable-handle.ts
+++ b/src/dd-resizable-handle.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2025  Alain Dumesny - see GridStack root license
  */
 
-import { isTouch, pointerdown, touchend, touchmove, touchstart } from './dd-touch';
+import { isTouch, pointerdown, touchend, touchmove, touchstart, cancelPendingTouchDrag, DDTouch } from './dd-touch';
 import { GridItemHTMLElement } from './gridstack';
 
 export interface DDResizableHandleOpt {
@@ -69,6 +69,7 @@ export class DDResizableHandle {
     // Clean up whenever a gesture is armed (mousedown), not only after the
     // 3px threshold flips `moving`. Mirrors DDDraggable.destroy(). See #3345.
     if (this.mouseDownEvent) this._mouseUp(this.mouseDownEvent);
+    cancelPendingTouchDrag();
     this.el.removeEventListener('mousedown', this._mouseDown);
     if (isTouch) {
       this.el.removeEventListener('touchstart', touchstart);
@@ -88,6 +89,11 @@ export class DDResizableHandle {
     if (isTouch) {
       this.el.addEventListener('touchmove', touchmove);
       this.el.addEventListener('touchend', touchend);
+      this.el.addEventListener('touchcancel', touchend); // browser aborting on us, clean up too
+    }
+    if (DDTouch.wasDelayed) {
+      // the long-press wait just elapsed - signal the handle is now armed & ready to resize
+      this.el.classList.add('ui-resizable-armed');
     }
     e.stopPropagation();
     e.preventDefault();
@@ -101,6 +107,7 @@ export class DDResizableHandle {
     } else if (Math.abs(e.x - s.x) + Math.abs(e.y - s.y) > 2) {
       // don't start unless we've moved at least 3 pixels
       this.moving = true;
+      this.el.classList.remove('ui-resizable-armed');
       this._triggerEvent('start', this.mouseDownEvent!);
       this._triggerEvent('move', e);
       // now track keyboard events to cancel
@@ -116,11 +123,13 @@ export class DDResizableHandle {
       this._triggerEvent('stop', e);
       document.removeEventListener('keydown', this._keyEvent);
     }
+    this.el.classList.remove('ui-resizable-armed');
     document.removeEventListener('mousemove', this._mouseMove, true);
     document.removeEventListener('mouseup', this._mouseUp, true);
     if (isTouch) {
       this.el.removeEventListener('touchmove', touchmove);
       this.el.removeEventListener('touchend', touchend);
+      this.el.removeEventListener('touchcancel', touchend);
     }
     delete this.moving;
     delete this.mouseDownEvent;

--- a/src/dd-touch.ts
+++ b/src/dd-touch.ts
@@ -22,10 +22,61 @@ export const isTouch: boolean = typeof window !== 'undefined' && typeof document
     || (navigator as any).msMaxTouchPoints > 0
   );
 
+/** ms to wait, while touching an item, before starting a drag - lets a quick swipe scroll the
+ * page normally instead of always moving the widget (touch only, no mouse ambiguity - see #2781).
+ * Keep this well under the browser's own long-press threshold (~500ms) so we arm - and start
+ * swallowing `contextmenu` - before it tries to pop its context menu / selection callout. */
+const touchDragDelay = 300;
+/** max distance (px, added over x+y) a finger can move while we wait out `touchDragDelay` before we consider it a scroll instead */
+const touchDelayMoveThreshold = 10;
+
 export class DDTouch {
   /** set to true while we are handling touch dragging, to prevent accepting browser real mouse events (trusted:true) vs our simulated ones (trusted:false) */
   public static touchHandled?: boolean;
   public static pointerLeaveTimeout?: number;
+  /** @internal timer waiting to see if the user pauses (drag) or moves/releases (scroll/tap) */
+  public static touchDelayTimer?: number;
+  /** @internal true right before we simulate the delayed mousedown, so DDDraggable knows to show the 'armed' drag feedback */
+  public static wasDelayed?: boolean;
+}
+
+/** @internal used to swallow the browser long-press context menu once we've armed a touch drag */
+function preventDefaultEvent(e: Event): void {
+  e.preventDefault();
+}
+
+/**
+ * @internal from the moment we arm (start wiggling) until the touch ends, swallow `contextmenu` so a
+ * user holding longer than `touchDragDelay` doesn't lose the drag to the browser's long-press menu.
+ * Note we can't just preventDefault() the touchstart: that is only allowed synchronously during its
+ * dispatch, and doing it there would also kill the page scrolling we're trying to preserve.
+ */
+function suppressContextMenu(): void {
+  // capture=true so we get a first crack at it
+  document.addEventListener('contextmenu', preventDefaultEvent, true);
+  document.addEventListener('selectstart', preventDefaultEvent, true); // what Safari long-press does instead
+}
+
+function restoreContextMenu(): void {
+  document.removeEventListener('contextmenu', preventDefaultEvent, true);
+  document.removeEventListener('selectstart', preventDefaultEvent, true);
+}
+
+/** cancels a pending delayed touch-drag (called on move/end/cancel while waiting) */
+function cancelDelayedTouchStart(target: HTMLElement, onMove: (e: TouchEvent) => void, onEnd: (e: TouchEvent) => void): void {
+  target.removeEventListener('touchmove', onMove);
+  target.removeEventListener('touchend', onEnd);
+  target.removeEventListener('touchcancel', onEnd);
+  cancelPendingTouchDrag();
+}
+
+/** defensively clears any pending delayed touch-drag timer, e.g. when a draggable is disabled/destroyed mid-wait */
+export function cancelPendingTouchDrag(): void {
+  if (DDTouch.touchDelayTimer) {
+    window.clearTimeout(DDTouch.touchDelayTimer);
+    delete DDTouch.touchDelayTimer;
+  }
+  restoreContextMenu();
 }
 
 /**
@@ -61,15 +112,37 @@ function simulatePointerMouseEvent(e: PointerEvent, simulatedType: string) {
 
 
 /**
- * Handle the touchstart events
+ * Handle the touchstart events - waits for `touchDragDelay` (a pause/long-press) before starting
+ * the drag, so a quick swipe scrolls the page instead - see issue #2781
  * @param {Object} e The widget element's touchstart event
  */
 export function touchstart(e: TouchEvent): void {
   // Ignore the event if another widget is already being handled
   if (DDTouch.touchHandled) return;
-  DDTouch.touchHandled = true;
 
-  simulateMouseEvent(e, 'mousedown');
+  // wait for the user to pause before treating this as a drag - bail out (letting the browser
+  // scroll normally) if they release or move too far before the delay elapses.
+  const target = e.currentTarget as HTMLElement;
+  const startX = e.touches[0].clientX;
+  const startY = e.touches[0].clientY;
+
+  const onEnd = () => cancelDelayedTouchStart(target, onMove, onEnd);
+  const onMove = (ev: TouchEvent) => {
+    const t = ev.touches[0];
+    if (Math.abs(t.clientX - startX) + Math.abs(t.clientY - startY) > touchDelayMoveThreshold) onEnd();
+  };
+  target.addEventListener('touchmove', onMove, { passive: true });
+  target.addEventListener('touchend', onEnd, { passive: true });
+  target.addEventListener('touchcancel', onEnd, { passive: true });
+
+  DDTouch.touchDelayTimer = window.setTimeout(() => {
+    cancelDelayedTouchStart(target, onMove, onEnd); // NOTE: also restores contextmenu, so suppress AFTER
+    DDTouch.touchHandled = true;
+    DDTouch.wasDelayed = true;
+    suppressContextMenu();
+    simulateMouseEvent(e, 'mousedown');
+    delete DDTouch.wasDelayed; // consumed synchronously above - don't leak into the next gesture
+  }, touchDragDelay);
 }
 
 /**
@@ -84,13 +157,16 @@ export function touchmove(e: TouchEvent): void {
 }
 
 /**
- * Handle the touchend events
+ * Handle the touchend events - also used for `touchcancel` (browser aborting the gesture, which is
+ * what we get if something still manages to pop a long-press menu over us) so we always clean up.
  * @param {Object} e The document's touchend event
  */
 export function touchend(e: TouchEvent): void {
 
   // Ignore event if not handled
   if (!DDTouch.touchHandled) return;
+
+  restoreContextMenu();
 
   // cancel delayed leave event when we release on ourself which happens BEFORE we get this!
   if (DDTouch.pointerLeaveTimeout) {
@@ -102,8 +178,9 @@ export function touchend(e: TouchEvent): void {
 
   simulateMouseEvent(e, 'mouseup');
 
-  // If the touch interaction did not move, it should trigger a click
-  if (!wasDragging) {
+  // If the touch interaction did not move, it should trigger a click - but not when the browser
+  // aborted the gesture on us (touchcancel), where no click is intended.
+  if (!wasDragging && e.type !== 'touchcancel') {
     simulateMouseEvent(e, 'click');
   }
 

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -59,8 +59,10 @@
      position: absolute;
      font-size: 0.1px;
      display: block;
-     -ms-touch-action: none;
-     touch-action: none;
+     // not 'none': let a touch swipe over a handle scroll the page normally during the long-press
+     // delay below (JS preventDefault takes over once armed) - see #2781
+     -ms-touch-action: manipulation;
+     touch-action: manipulation;
      user-select: none;
      z-index: 100;
    }
@@ -115,6 +117,31 @@
    &.ui-resizable-resizing {
      will-change: width, height;
    }
+
+   // shown on touch once the long-press pause has been detected, signaling the item is now
+   // ready to be picked up and dragged - see #2781
+   &.ui-draggable-armed {
+     cursor: move;
+     animation: gs-armed-wiggle 0.25s ease-in-out infinite;
+   }
+
+   // same long-press feedback for resize handles, but they keep their own nw/n/ne/... cursor instead
+   // of 'move', and pulse rather than wiggle since the corner ones already use transform:rotate(45deg)
+   // for their arrow - animating transform here would fight that.
+   > .ui-resizable-handle.ui-resizable-armed {
+     animation: gs-armed-pulse 0.5s ease-in-out infinite;
+   }
+ }
+
+ @keyframes gs-armed-wiggle {
+   0%, 100% { transform: rotate(0deg); }
+   25% { transform: rotate(-1.5deg); }
+   75% { transform: rotate(1.5deg); }
+ }
+
+ @keyframes gs-armed-pulse {
+   0%, 100% { opacity: 1; }
+   50% { opacity: 0.3; }
  }
 
  // not .grid-stack-item specific to also affect dragIn regions


### PR DESCRIPTION
### Description
* fix #2781 #3177
* on mobile/touch you now need to pause 300msec (get wiggle feedback for move, translucent on resize) before action happens so you can also scroll vs drag on same touch gesture

[recording-2026-08-30-08-37-25.webm](https://github.com/user-attachments/assets/fb6b90bf-7d7a-4133-8b5d-896163effa73)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
