### PR TITLE
use `moveBefore()` instead of `appendChild()` in `_sortDom()`

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -148,6 +148,7 @@ Change log
 
 ## 13.2.0-dev (TBD)
 * feat: [#2781](https://github.com/gridstack/gridstack.js/issues/3177) [#2781](https://github.com/gridstack/gridstack.js/issues/3177) mobile: pause to drag/reszie vs scroll behavior
+* fix: [#3374](https://github.com/gridstack/gridstack.js/issues/3374) use `moveBefore()` (when supported) instead of `appendChild()` in `_sortDom()` so reordering doesn't reload iframes / lose element state
 
 ## 13.2.0 (2026-08-19)
 * feat: [#701](https://github.com/gridstack/gridstack.js/issues/701) removed printMode as we support much better printing now that doesn't compromise.

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -1867,10 +1867,12 @@ export class GridStack {
     nodes = this.engine.nodes; // new sorted array
     const children = this.el.children;
     if (nodes.some((n, i) => n.el !== children[i])) {
-      // order doesn't match, re-order DOM
+      // order doesn't match, re-order DOM. Use moveBefore() to preserve element state (ex: iframe) #3374
+      const moveBefore = (this.el as { moveBefore?: (node: Node, ref: Node | null) => void }).moveBefore?.bind(this.el);
       nodes.forEach(n => {
         if (n.el && n.el.parentElement === this.el) {
-          this.el.appendChild(n.el);
+          if (moveBefore) moveBefore(n.el, null);
+          else this.el.appendChild(n.el);
         }
       });
     }


### PR DESCRIPTION
### Description

use `moveBefore()` instead of `appendChild()` in `_sortDom()`
* fix #3374 fix #585

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
