### PR TITLE
new PrintOptions.breakInside?: boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,10 @@ See [example](http://gridstack.github.io/gridstack.js/demo/mobile.html).
 
 GridStack v13.1+ introduces native printing support. Widgets auto-size to their content and flow naturally
 across pages without being sliced in half, and a hidden widget (`print.hide`) leaves no gap behind. Per-widget
-`PrintOptions` let you force a page break or switch a widget's page to landscape/portrait.
+`PrintOptions` let you force a page break, switch a widget's page to landscape/portrait, or let a widget taller
+than a page (like a long table) fragment across pages instead of leaving a blank gap.
 
-See [print_README.md](./print_README.md) for full details, examples, and how to use widget `PrintOptions` (like `pageBreak` and `orientation`).
+See [print_README.md](./print_README.md) for full details, examples, and how to use widget `PrintOptions` (like `pageBreak`, `orientation`, and `breakInside`).
 
 # Migrating
 ## Migrating to v0.6

--- a/demo/print_advanced.html
+++ b/demo/print_advanced.html
@@ -20,7 +20,11 @@
       Notes: a hidden widget (Item 4) leaves no gap - the next widget reflows up to take its place. An
       <code>orientation</code> section stays in effect until something else forces a new page, so the widget
       that should resume portrait after a landscape section (Item 8) sets <code>orientation: 'portrait'</code>
-      explicitly rather than relying on it reverting on its own.
+      explicitly rather than relying on it reverting on its own.<br/>
+      <code>breakInside: true</code> (Item 11) lets a widget that's taller than a full page (ex: a long table)
+      fragment across pages instead of being pushed whole to the next one, leaving a blank gap. Item 12 combines
+      it with the <code>gs-print-avoid-break-after</code> utility class to keep a section header attached to
+      the row of widgets right after it - see <a href="../print_README.md">print_README.md</a> for details.
     </p>
     <div class="gs-print-hide">
       <a class="btn btn-primary" onClick="window.print()" href="#">Print Page</a>
@@ -51,7 +55,20 @@
       {x: 0, y: 6, w: 6, h: 1, content: 'Item 7'},
       {x: 0, y: 6, w: 12, h: 2, content: 'Item 8<br>(Starts on Portrait Page)' + 'Line<br>'.repeat(4), print: { pageBreak: true, orientation: 'portrait' } },
       {x: 0, y: 8, w: 6, h: 1, content: 'Item 9' + 'Line<br>'.repeat(10)},
-      {x: 0, y: 9, w: 12, h: 14, content: 'Item 10<br>(Very tall widget - auto-sizes to content, never sliced)<br>' + 'Line<br>'.repeat(40) }
+      {x: 0, y: 9, w: 12, h: 14, content: 'Item 10<br>(Very tall widget - auto-sizes to content, never sliced)<br>' + 'Line<br>'.repeat(40) },
+      {x: 0, y: 23, w: 12, h: 10, print: { pageBreak: true, breakInside: true }, content:
+        'Item 11<br><strong>(breakInside: true - long table fragments across pages instead of jumping whole to the next page)</strong>' +
+        '<table style="width:100%; border-collapse:collapse;">' +
+        Array.from({length: 30}, (_, i) => `<tr><td style="border:1px solid #ccc;">Row ${i + 1}</td><td style="border:1px solid #ccc;">Data ${i + 1}</td></tr>`).join('') +
+        '</table>'
+      },
+      {x: 0, y: 33, w: 12, h: 6, print: { pageBreak: true, breakInside: true }, content:
+        'Item 12<br><strong>(section: header stays with the row that follows it via gs-print-avoid-break-after)</strong>' +
+        '<div class="gs-print-avoid-break-after">' +
+        '<div style="display:flex; justify-content:space-between; background:#eee; padding:4px;"><strong>Section Header</strong><span>...</span></div>' +
+        '</div>' +
+        Array.from({length: 8}, (_, i) => `<div style="padding:4px; border-top:1px solid #ccc;">Nested row ${i + 1}</div>`).join('')
+      }
     ];
 
     let grid1 = GridStack.init(options, '#grid1');

--- a/doc/API.md
+++ b/doc/API.md
@@ -115,7 +115,7 @@ Construct a grid item from the given element and options
 protected _updateResizeEvent(forceRemove): GridStack;
 ```
 
-Defined in: [gridstack.ts:2184](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2184)
+Defined in: [gridstack.ts:2190](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2190)
 
 add or remove the grid element size event handler
 
@@ -429,7 +429,7 @@ Destroys a grid instance. DO NOT CALL any methods or access any vars after this 
 disable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2386](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2386)
+Defined in: [gridstack.ts:2392](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2392)
 
 Temporarily disables widgets moving/resizing.
 If you want a more permanent way (which freezes up resources) use `setStatic(true)` instead.
@@ -470,7 +470,7 @@ grid.disable(false);
 enable(recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2413](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2413)
+Defined in: [gridstack.ts:2419](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2419)
 
 Re-enables widgets moving/resizing - see disable().
 Note: This is a no-op for static grids.
@@ -509,7 +509,7 @@ grid.enable(false);
 enableMove(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2439](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2439)
+Defined in: [gridstack.ts:2445](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2445)
 
 Enables/disables widget moving for all widgets. No-op for static grids.
 Note: locally defined items (with noMove property) still override this setting.
@@ -546,7 +546,7 @@ grid.enableMove(true, false);
 enableResize(doEnable, recurse): GridStack;
 ```
 
-Defined in: [gridstack.ts:2467](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2467)
+Defined in: [gridstack.ts:2473](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2473)
 
 Enables/disables widget resizing for all widgets. No-op for static grids.
 Note: locally defined items (with noResize property) still override this setting.
@@ -688,7 +688,7 @@ const columnCount = grid.getColumn(); // returns 12 by default
 static getDD(): DDGridStack;
 ```
 
-Defined in: [gridstack.ts:2283](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2283)
+Defined in: [gridstack.ts:2289](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2289)
 
 Get the global drag & drop implementation instance.
 This provides access to the underlying drag & drop functionality.
@@ -1096,7 +1096,7 @@ grid.margin('5px 10px 15px 20px'); // Different for each side
 movable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2327](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2327)
+Defined in: [gridstack.ts:2333](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2333)
 
 Enables/Disables dragging by the user for specific grid elements.
 For all items and future items, use enableMove() instead. No-op for static grids.
@@ -1432,7 +1432,7 @@ grid.on('added', (event, items) => {
 onResize(clientWidth): GridStack;
 ```
 
-Defined in: [gridstack.ts:2122](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2122)
+Defined in: [gridstack.ts:2128](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2128)
 
 called when we are being resized - check if the one Column Mode needs to be turned on/off
 and remember the prev columns we used, or get our count from parent, as well as check for cellHeight==='auto' (square)
@@ -1454,7 +1454,7 @@ or `sizeToContent` gridItem options.
 prepareDragDrop(el, force?): GridStack;
 ```
 
-Defined in: [gridstack.ts:2856](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2856)
+Defined in: [gridstack.ts:2862](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2862)
 
 prepares the element for drag&drop - this is normally called by makeWidget() unless are are delay loading
 
@@ -1475,7 +1475,7 @@ prepares the element for drag&drop - this is normally called by makeWidget() unl
 refreshDragHandles(els): GridStack;
 ```
 
-Defined in: [gridstack.ts:2844](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2844)
+Defined in: [gridstack.ts:2850](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2850)
 
 Re-scans one or more widget elements for drag handle elements after delayed content
 (React portal, Angular component, etc.) has been rendered inside the item.
@@ -1596,7 +1596,7 @@ Removes widget from the grid.
 resizable(els, val): GridStack;
 ```
 
-Defined in: [gridstack.ts:2353](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2353)
+Defined in: [gridstack.ts:2359](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2359)
 
 Enables/Disables user resizing for specific grid elements.
 For all items and future items, use enableResize() instead. No-op for static grids.
@@ -1783,7 +1783,7 @@ static setupDragIn(
    root?): void;
 ```
 
-Defined in: [gridstack.ts:2296](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2296)
+Defined in: [gridstack.ts:2302](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L2302)
 
 call to setup dragging in from the outside (say toolbar), by specifying the class selection and options.
 Called during GridStack.init() as options, but can also be called directly (last param are used) in case the toolbar
@@ -1808,7 +1808,7 @@ is dynamically create and needs to be set later.
 protected triggerEvent(event, target): void;
 ```
 
-Defined in: [gridstack.ts:3118](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3118)
+Defined in: [gridstack.ts:3124](https://github.com/adumesny/gridstack.js/blob/master/src/gridstack.ts#L3124)
 
 call given event callback on our main top-most grid (if we're nested)
 
@@ -2865,7 +2865,7 @@ new Utils(): Utils;
 static addElStyles(el, styles): void;
 ```
 
-Defined in: [utils.ts:610](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L610)
+Defined in: [utils.ts:621](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L621)
 
 ###### Parameters
 
@@ -2884,7 +2884,7 @@ Defined in: [utils.ts:610](https://github.com/adumesny/gridstack.js/blob/master/
 static appendTo(el, parent): void;
 ```
 
-Defined in: [utils.ts:598](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L598)
+Defined in: [utils.ts:609](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L609)
 
 ###### Parameters
 
@@ -2963,7 +2963,7 @@ const overlap = Utils.areaIntercept(
 static canBeRotated(n): boolean;
 ```
 
-Defined in: [utils.ts:703](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L703)
+Defined in: [utils.ts:714](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L714)
 
 true if the item can be rotated (checking for prop, not space available)
 
@@ -2983,7 +2983,7 @@ true if the item can be rotated (checking for prop, not space available)
 static clone<T>(obj): T;
 ```
 
-Defined in: [utils.ts:563](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L563)
+Defined in: [utils.ts:574](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L574)
 
 single level clone, returning a new object with same top fields. This will share sub objects and arrays
 
@@ -3009,7 +3009,7 @@ single level clone, returning a new object with same top fields. This will share
 static cloneDeep<T>(obj): T;
 ```
 
-Defined in: [utils.ts:578](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L578)
+Defined in: [utils.ts:589](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L589)
 
 Recursive clone version that returns a full copy, checking for nested objects and arrays ONLY.
 Note: this will use as-is any key starting with double __ (and not copy inside) some lib have circular dependencies.
@@ -3036,7 +3036,7 @@ Note: this will use as-is any key starting with double __ (and not copy inside) 
 static cloneNode(el): HTMLElement;
 ```
 
-Defined in: [utils.ts:592](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L592)
+Defined in: [utils.ts:603](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L603)
 
 deep clone the given HTML node, removing the unique id field
 
@@ -3280,7 +3280,7 @@ const fromShadow = Utils.getElements('.item', shadowRoot);
 static getValuesFromTransformedElement(parent): DragTransform;
 ```
 
-Defined in: [utils.ts:672](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L672)
+Defined in: [utils.ts:683](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L683)
 
 defines an element that is used to get the offset and scale from grid transforms
 returns the scale and offsets from said element
@@ -3301,7 +3301,7 @@ returns the scale and offsets from said element
 static initEvent<T>(e, info): T;
 ```
 
-Defined in: [utils.ts:628](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L628)
+Defined in: [utils.ts:639](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L639)
 
 ###### Type Parameters
 
@@ -3446,6 +3446,28 @@ Utils.parseHeight('100px');  // {h: 100, unit: 'px'}
 Utils.parseHeight('2rem');   // {h: 2, unit: 'rem'}
 Utils.parseHeight(50);       // {h: 50, unit: 'px'}
 ```
+
+##### pauseIframePointerEvents()
+
+```ts
+static pauseIframePointerEvents(pause): void;
+```
+
+Defined in: [utils.ts:567](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L567)
+
+disable/re-enable pointer events on all iframes on the page while dragging/resizing, otherwise
+fast mouse moves over an iframe get swallowed by its own document instead of reaching ours,
+which stalls the drag/resize. See https://github.com/gridstack/gridstack.js/issues/934
+
+###### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `pause` | `boolean` |
+
+###### Returns
+
+`void`
 
 ##### removeInternalAndSame()
 
@@ -3619,7 +3641,7 @@ static simulateMouseEvent(
    target?): void;
 ```
 
-Defined in: [utils.ts:645](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L645)
+Defined in: [utils.ts:656](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L656)
 
 copies the MouseEvent (or convert Touch) properties and sends it as another event to the given target
 
@@ -3674,7 +3696,7 @@ static swap(
    b): void;
 ```
 
-Defined in: [utils.ts:696](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L696)
+Defined in: [utils.ts:707](https://github.com/adumesny/gridstack.js/blob/master/src/utils.ts#L707)
 
 swap the given object 2 field values
 
@@ -5316,7 +5338,7 @@ Defines the position of a cell inside the grid
 <a id="dddragopt"></a>
 ### DDDragOpt
 
-Defined in: [types.ts:500](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L500)
+Defined in: [types.ts:506](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L506)
 
 Drag&Drop dragging options
 
@@ -5324,16 +5346,16 @@ Drag&Drop dragging options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:504](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L504) |
-| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:510](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L510) |
-| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:516](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L516) |
-| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:502](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L502) |
-| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L512) |
-| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:506](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L506) |
-| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:517](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L517) |
-| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L508) |
-| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:514](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L514) |
-| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:515](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L515) |
+| <a id="appendto"></a> `appendTo?` | `string` | default to 'body' | [types.ts:510](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L510) |
+| <a id="cancel"></a> `cancel?` | `string` | prevents dragging from starting on specified elements, listed as comma separated selectors (eg: '.no-drag'). default built in is 'input,textarea,button,select,option' | [types.ts:516](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L516) |
+| <a id="drag"></a> `drag?` | (`event`, `ui`) => `void` | - | [types.ts:522](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L522) |
+| <a id="handle"></a> `handle?` | `string` | class selector of items that can be dragged. default to '.grid-stack-item-content' | [types.ts:508](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L508) |
+| <a id="helper"></a> `helper?` | `"clone"` \| (`el`) => `HTMLElement` | helper function when dropping: 'clone' or your own method | [types.ts:518](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L518) |
+| <a id="pause"></a> `pause?` | `number` \| `boolean` | if set (true | msec), dragging placement (collision) will only happen after a pause by the user. Note: this is Global | [types.ts:512](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L512) |
+| <a id="rtl"></a> `rtl?` | `boolean` | - | [types.ts:523](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L523) |
+| <a id="scroll"></a> `scroll?` | `boolean` | default to `true` | [types.ts:514](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L514) |
+| <a id="start"></a> `start?` | (`event`, `ui`) => `void` | callbacks | [types.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L520) |
+| <a id="stop"></a> `stop?` | (`event`) => `void` | - | [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521) |
 
 ***
 
@@ -5376,7 +5398,7 @@ All grid item DOM elements implement this interface to provide access to their g
 <a id="ddremoveopt"></a>
 ### DDRemoveOpt
 
-Defined in: [types.ts:492](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L492)
+Defined in: [types.ts:498](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L498)
 
 Drag&Drop remove options
 
@@ -5384,8 +5406,8 @@ Drag&Drop remove options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L494) |
-| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:496](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L496) |
+| <a id="accept-3"></a> `accept?` | `string` | class that can be removed (default?: opts.itemClass) | [types.ts:500](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L500) |
+| <a id="decline"></a> `decline?` | `string` | class that cannot be removed (default: 'grid-stack-non-removable') | [types.ts:502](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L502) |
 
 ***
 
@@ -5436,7 +5458,7 @@ Drag&Drop resize options
 <a id="ddresizeopt"></a>
 ### DDResizeOpt
 
-Defined in: [types.ts:476](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L476)
+Defined in: [types.ts:482](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L482)
 
 Drag&Drop resize options
 
@@ -5448,16 +5470,16 @@ Drag&Drop resize options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:478](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L478) |
-| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:488](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L488) |
-| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:483](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L483) |
+| <a id="autohide-1"></a> `autoHide?` | `boolean` | do resize handle hide by default until mouse over. default: true on desktop, false on mobile | [types.ts:484](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L484) |
+| <a id="element-2"></a> `element?` | `string` \| `HTMLElement` | Custom element or query inside the widget node that is used instead of the generated resize handle. | [types.ts:494](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L494) |
+| <a id="handles-1"></a> `handles?` | `string` | sides where you can resize from (ex: 'e, se, s, sw, w') - default 'se' (south-east) Note: it is not recommended to resize from the top sides as weird side effect may occur. | [types.ts:489](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L489) |
 
 ***
 
 <a id="dduidata"></a>
 ### DDUIData
 
-Defined in: [types.ts:535](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L535)
+Defined in: [types.ts:541](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L541)
 
 data that is passed during drag and resizing callbacks
 
@@ -5465,9 +5487,9 @@ data that is passed during drag and resizing callbacks
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:538](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L538) |
-| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:536](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L536) |
-| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:537](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L537) |
+| <a id="draggable-2"></a> `draggable?` | `HTMLElement` | [types.ts:544](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L544) |
+| <a id="position"></a> `position?` | [`Position`](#position-1) | [types.ts:542](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L542) |
+| <a id="size"></a> `size?` | [`Size`](#size-1) | [types.ts:543](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L543) |
 
 ***
 
@@ -5550,7 +5572,7 @@ options used during creation - similar to GridStackOptions
 <a id="gridstackmouseevent"></a>
 ### GridStackMouseEvent
 
-Defined in: [types.ts:602](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L602)
+Defined in: [types.ts:608](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L608)
 
 #### Extends
 
@@ -5560,9 +5582,9 @@ Defined in: [types.ts:602](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:604](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L604) |
-| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:605](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L605) |
-| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:603](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L603) |
+| <a id="hasmovedx"></a> `hasMovedX?` | `boolean` | [types.ts:610](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L610) |
+| <a id="hasmovedy"></a> `hasMovedY?` | `boolean` | [types.ts:611](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L611) |
+| <a id="resizedir"></a> `resizeDir?` | `string` | [types.ts:609](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L609) |
 
 ***
 
@@ -5600,7 +5622,7 @@ options used during GridStackEngine.moveNode()
 <a id="gridstacknode-2"></a>
 ### GridStackNode
 
-Defined in: [types.ts:552](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L552)
+Defined in: [types.ts:558](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L558)
 
 internal runtime descriptions describing the widgets in the grid
 
@@ -5612,10 +5634,10 @@ internal runtime descriptions describing the widgets in the grid
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:554](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L554) |
-| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:556](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L556) |
-| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:558](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L558) |
-| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:560](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L560) |
+| <a id="el-5"></a> `el?` | [`GridItemHTMLElement`](#griditemhtmlelement) | pointer back to HTML element | [types.ts:560](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L560) |
+| <a id="grid"></a> `grid?` | [`GridStack`](#gridstack-1) | pointer back to parent Grid instance | [types.ts:562](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L562) |
+| <a id="subgrid"></a> `subGrid?` | [`GridStack`](#gridstack-1) | actual sub-grid instance | [types.ts:564](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L564) |
+| <a id="visibleobservable"></a> `visibleObservable?` | `IntersectionObserver` | allow delay creation when visible | [types.ts:566](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L566) |
 
 ***
 
@@ -5643,7 +5665,7 @@ Defined in: [types.ts:412](https://github.com/adumesny/gridstack.js/blob/master/
 <a id="gridstackwidget"></a>
 ### GridStackWidget
 
-Defined in: [types.ts:441](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L441)
+Defined in: [types.ts:447](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L447)
 
 GridStack Widget creation options
 
@@ -5659,20 +5681,20 @@ GridStack Widget creation options
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:443](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L443) |
-| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:461](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L461) |
-| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:459](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L459) |
-| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:465](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L465) |
-| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L457) |
-| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:451](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L451) |
-| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:447](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L447) |
-| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:449](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L449) |
-| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:445](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L445) |
-| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:455](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L455) |
-| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:453](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L453) |
-| <a id="print-1"></a> `print?` | [`PrintOptions`](#printoptions) | print options | [types.ts:463](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L463) |
-| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:470](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L470) |
-| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:472](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L472) |
+| <a id="autoposition-1"></a> `autoPosition?` | `boolean` | if true then x, y parameters will be ignored and widget will be places on the first available position (default?: false) | [types.ts:449](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L449) |
+| <a id="content-1"></a> `content?` | `string` | html to append inside as content | [types.ts:467](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L467) |
+| <a id="id-1"></a> `id?` | `string` | value for `gs-id` stored on the widget (default?: undefined) | [types.ts:465](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L465) |
+| <a id="lazyload-2"></a> `lazyLoad?` | `boolean` | true when widgets are only created when they scroll into view (visible) | [types.ts:471](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L471) |
+| <a id="locked-1"></a> `locked?` | `boolean` | prevents being pushed by other widgets or api (default?: undefined = un-constrained), which is different from `noMove` (user action only) | [types.ts:463](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L463) |
+| <a id="maxh-1"></a> `maxH?` | `number` | maximum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:457](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L457) |
+| <a id="maxw-1"></a> `maxW?` | `number` | maximum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:453](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L453) |
+| <a id="minh-1"></a> `minH?` | `number` | minimum height allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:455](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L455) |
+| <a id="minw-1"></a> `minW?` | `number` | minimum width allowed during resize/creation (default?: undefined = un-constrained) | [types.ts:451](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L451) |
+| <a id="nomove-1"></a> `noMove?` | `boolean` | prevents direct moving by the user (default?: undefined = un-constrained) | [types.ts:461](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L461) |
+| <a id="noresize-1"></a> `noResize?` | `boolean` | prevent direct resizing by the user (default?: undefined = un-constrained) | [types.ts:459](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L459) |
+| <a id="print-1"></a> `print?` | [`PrintOptions`](#printoptions) | print options | [types.ts:469](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L469) |
+| <a id="resizetocontentparent-2"></a> `resizeToContentParent?` | `string` | local override of GridStack.resizeToContentParent that specify the class to use for the parent (actual) vs child (wanted) height | [types.ts:476](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L476) |
+| <a id="subgridopts-2"></a> `subGridOpts?` | [`GridStackOptions`](#gridstackoptions) | optional nested grid options and list of children, which then turns into actual instance at runtime to get options from | [types.ts:478](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L478) |
 
 ***
 
@@ -5754,7 +5776,7 @@ Defines the coordinates of an object
 <a id="position-1"></a>
 ### Position
 
-Defined in: [types.ts:523](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L523)
+Defined in: [types.ts:529](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L529)
 
 #### Extended by
 
@@ -5764,8 +5786,8 @@ Defined in: [types.ts:523](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:530](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L530) |
-| <a id="top-1"></a> `top` | `number` | - | [types.ts:524](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L524) |
+| <a id="left-1"></a> `left` | `number` | Start position of the element on the X axis. In LTR mode, this is the coordinate from the left side. In RTL mode it's actually the coordinate from the right side. | [types.ts:536](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L536) |
+| <a id="top-1"></a> `top` | `number` | - | [types.ts:530](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L530) |
 
 ***
 
@@ -5781,8 +5803,9 @@ See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/prin
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
+| <a id="breakinside"></a> `breakInside?` | `boolean` | allow this widget (ex: a tall table/datagrid, or a section with a nested sub-grid) to fragment across multiple printed pages instead of being kept together as one unbreakable block - which otherwise pushes the whole widget to the next page (leaving a blank gap) whenever it doesn't fit in the space remaining on the current page (default?: undefined = kept on one page). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:439](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L439) |
 | <a id="hide"></a> `hide?` | `boolean` | prevent this widget from printing (default?: undefined) | [types.ts:429](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L429) |
-| <a id="mode"></a> `mode?` | `string` | application specific print options for a given widget | [types.ts:435](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L435) |
+| <a id="mode"></a> `mode?` | `string` | application specific print options for a given widget | [types.ts:441](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L441) |
 | <a id="orientation"></a> `orientation?` | `"portrait"` \| `"landscape"` | set the orientation of the printed page (default?: 'portrait'). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:433](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L433) |
 | <a id="pagebreak"></a> `pageBreak?` | `boolean` | add a page break before this widget (default?: undefined). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) | [types.ts:431](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L431) |
 
@@ -5791,7 +5814,7 @@ See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/prin
 <a id="rect-1"></a>
 ### Rect
 
-Defined in: [types.ts:532](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L532)
+Defined in: [types.ts:538](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L538)
 
 #### Extends
 
@@ -5825,7 +5848,7 @@ NOTE: Make sure to include the appropriate CSS (gridstack-extra.css) to support 
 <a id="size-1"></a>
 ### Size
 
-Defined in: [types.ts:519](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L519)
+Defined in: [types.ts:525](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L525)
 
 #### Extended by
 
@@ -5835,8 +5858,8 @@ Defined in: [types.ts:519](https://github.com/adumesny/gridstack.js/blob/master/
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| <a id="height-1"></a> `height` | `number` | [types.ts:521](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L521) |
-| <a id="width-1"></a> `width` | `number` | [types.ts:520](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L520) |
+| <a id="height-1"></a> `height` | `number` | [types.ts:527](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L527) |
+| <a id="width-1"></a> `width` | `number` | [types.ts:526](https://github.com/adumesny/gridstack.js/blob/master/src/types.ts#L526) |
 
 ## Variables
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -148,7 +148,8 @@ Change log
 
 ## 13.2.0-dev (TBD)
 * feat: [#2781](https://github.com/gridstack/gridstack.js/issues/3177) [#2781](https://github.com/gridstack/gridstack.js/issues/3177) mobile: pause to drag/reszie vs scroll behavior
-* fix: [#3374](https://github.com/gridstack/gridstack.js/issues/3374) use `moveBefore()` (when supported) instead of `appendChild()` in `_sortDom()` so reordering doesn't reload iframes / lose element state
+* feat: [#3383](https://github.com/gridstack/gridstack.js/pull/3383) added `PrintOptions.breakInside` and `.gs-print-avoid-break-after` so section (nested grids) and tables can fragment across pages
+* fix: [#3374](https://github.com/gridstack/gridstack.js/issues/3374) Iframe: use `moveBefore()` instead of `appendChild()` in `_sortDom()` so reordering doesn't reload iframes
 * fix: [#934](https://github.com/gridstack/gridstack.js/issues/934) disable pointer events on iframes while dragging/resizing so fast mouse moves aren't swallowed by the iframe's own document
 * fix: [#3371](https://github.com/gridstack/gridstack.js/issues/3371) (vue, react): item content vanished after dragging between 2 grids with `acceptWidgets`
 

--- a/print_README.md
+++ b/print_README.md
@@ -38,19 +38,57 @@ You can customize how individual widgets print by passing a `print` object to th
   print: {
     hide: true,                  // Prevent this widget from printing
     pageBreak: true,             // Force a page break before this widget
-    orientation: 'landscape'     // Force the printed page (and this widget's own page) to be landscape
+    orientation: 'landscape',    // Force the printed page (and this widget's own page) to be landscape
+    breakInside: true            // Allow this widget's content to fragment across pages instead of
+                                  // being kept together as one unbreakable block
   }
 }
 ```
 
-Note: `pageBreak`/`orientation` pull the widget out of the normal float flow so the browser reliably honors
-the forced break (floated elements are otherwise ignored by Chrome's forced page-break handling) - the
-widget's width is unaffected.
+Note: `pageBreak`/`orientation`/`breakInside` all pull the widget out of the normal float flow so the browser
+reliably honors them (floated elements are otherwise ignored/mishandled by Chrome's print pagination) - for
+`pageBreak`/`orientation` the widget's width is unaffected, but `breakInside` also widens the widget to the
+full print width (see below).
 
 `orientation` stays in effect for that page until something else forces a new page - it doesn't automatically
 revert on the next widget. If you have a landscape section followed by widgets that should go back to
 portrait, set `orientation: 'portrait'` (or `pageBreak: true`) explicitly on the widget that should resume
 portrait, rather than relying on it reverting on its own.
+
+### Tall content that doesn't fit on one page
+
+The base layout keeps every widget together with `break-inside: avoid`, so a widget that's taller than the
+remaining space on a page moves whole to the next page - normally the right behavior, but a widget containing
+a long table/datagrid (or a section wrapping a nested sub-grid) can easily be taller than an *entire* page.
+Forcing it to stay in one piece then just leaves the current page mostly blank.
+
+Set `print.breakInside: true` on that widget to opt out: it's allowed to fragment naturally across as many
+pages as it needs, and is widened to the full print width (rather than its on-screen column width) since a
+floated box that's allowed to break across pages can otherwise overlap the next floated sibling in Chrome.
+
+```javascript
+{ x: 0, y: 0, w: 6, h: 20, content: '<table>...many rows...</table>', print: { breakInside: true } }
+```
+
+### Keeping a header with the content that follows it (sections / nested sub-grids)
+
+A "section" widget - typically a header/title bar followed by a nested sub-grid - has the same needs: the
+outer widget should use `breakInside: true` so the section as a whole can span pages, while the header
+itself should never be separated from the row of widgets right after it.
+
+The natural tool for that is `break-after: avoid` on the header, but Chrome's print engine ignores
+`break-after`/`page-break-after` set directly on a `display: flex` (or `grid`) element - a common case for
+headers that lay out a title next to actions/icons. Put the [`gs-print-avoid-break-after`](#utility-classes)
+utility class on a plain block-level wrapper around the header instead of on the flex element itself:
+
+```html
+<div class="grid-stack-item-content">
+  <div class="gs-print-avoid-break-after">
+    <div class="my-section-header" style="display:flex">Section Title <span>...icons...</span></div>
+  </div>
+  <div class="grid-stack">...nested sub-grid widgets...</div>
+</div>
+```
 
 ## Utility Classes
 
@@ -69,3 +107,7 @@ printing - useful for anything interactive that doesn't make sense on paper, and
 
 This works anywhere in the document, not just on grid items - for example on buttons/links inside a widget's
 own content.
+
+`gs-print-avoid-break-after` is another such class - put it on a plain block-level element to stop a page
+break from landing right after it. See [Keeping a header with the content that follows it](#keeping-a-header-with-the-content-that-follows-it-sections--nested-sub-grids)
+above.

--- a/src/gridstack.scss
+++ b/src/gridstack.scss
@@ -248,6 +248,14 @@
   .gs-print-show {
     display: block;
   }
+  /* opt-in for any element (not just grid items) that must not have a page break land right after
+     it - ex: a section/table header that has to stay with the content that follows. Put this on a
+     plain block-level wrapper rather than directly on a `display:flex`/`grid` element: Chrome's print
+     engine ignores break-after/page-break-after set on flex/grid containers themselves. */
+  .gs-print-avoid-break-after {
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
   /* needs to out-specificity the base item rule above (display: block !important)
      so a hidden widget actually collapses instead of still reserving its slot */
   .grid-stack > .grid-stack-item.gs-print-hide {
@@ -276,6 +284,20 @@
     page: gs-portrait;
     /* vmin ensures we get the short edge of the paper */
     min-width: calc(100vmin * var(--gs-w) / var(--gs-columns, 12)) !important;
+  }
+
+  /* breakInside opts a widget (tall table/datagrid, or a section wrapping a nested sub-grid) out of
+     the base rule's break-inside: avoid, so it can fragment across pages instead of being pushed
+     whole to the next page whenever it doesn't fit in the space remaining on the current one - which
+     otherwise leaves the current page mostly blank. Pulled out of the float flow and widened to the
+     full print width, same reasoning as pageBreak/orientation above: Chrome can mis-paginate a
+     floated box that's allowed to break across pages, overlapping the next floated sibling. */
+  .grid-stack > .grid-stack-item[gs-break-inside="true"] {
+    float: none !important;
+    clear: both !important;
+    width: 100% !important;
+    break-inside: auto !important;
+    page-break-inside: auto !important;
   }
 
   /* Hide interactive elements during print */

--- a/src/gridstack.ts
+++ b/src/gridstack.ts
@@ -2031,14 +2031,17 @@ export class GridStack {
         el.removeAttribute(attrsRec[key]);
       }
     }
-    if (node.print) {
-      if (node.print.pageBreak) el.setAttribute('gs-page-break', String(node.print.pageBreak)); else el.removeAttribute('gs-page-break');
-      if (node.print.hide) el.classList.add('gs-print-hide'); else el.classList.remove('gs-print-hide');
-      if (node.print.orientation) el.setAttribute('gs-print-orientation', String(node.print.orientation)); else el.removeAttribute('gs-print-orientation');
+    const print = node.print;
+    if (print) {
+      if (print.pageBreak) el.setAttribute('gs-page-break', String(print.pageBreak)); else el.removeAttribute('gs-page-break');
+      if (print.hide) el.classList.add('gs-print-hide'); else el.classList.remove('gs-print-hide');
+      if (print.orientation) el.setAttribute('gs-print-orientation', String(print.orientation)); else el.removeAttribute('gs-print-orientation');
+      if (print.breakInside) el.setAttribute('gs-break-inside', String(print.breakInside)); else el.removeAttribute('gs-break-inside');
     } else {
       el.removeAttribute('gs-page-break');
       el.classList.remove('gs-print-hide');
       el.removeAttribute('gs-print-orientation');
+      el.removeAttribute('gs-break-inside');
     }
 
     return this;
@@ -2059,11 +2062,13 @@ export class GridStack {
     let pageBreak = el.getAttribute('gs-page-break');
     let hide = el.classList.contains('gs-print-hide');
     let orientation = el.getAttribute('gs-print-orientation') as 'portrait' | 'landscape';
-    if (pageBreak || hide || orientation) {
+    let breakInside = el.getAttribute('gs-break-inside');
+    if (pageBreak || hide || orientation || breakInside) {
       n.print = {};
       if (pageBreak) n.print.pageBreak = Utils.toBool(pageBreak);
       if (hide) n.print.hide = true;
       if (orientation) n.print.orientation = orientation;
+      if (breakInside) n.print.breakInside = Utils.toBool(breakInside);
     }
 
     const attr = el.getAttribute('gs-size-to-content');

--- a/src/types.ts
+++ b/src/types.ts
@@ -431,6 +431,12 @@ export interface PrintOptions {
   pageBreak?: boolean;
   /** set the orientation of the printed page (default?: 'portrait'). See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
   orientation?: 'portrait' | 'landscape';
+  /** allow this widget (ex: a tall table/datagrid, or a section with a nested sub-grid) to fragment
+   * across multiple printed pages instead of being kept together as one unbreakable block - which
+   * otherwise pushes the whole widget to the next page (leaving a blank gap) whenever it doesn't fit
+   * in the space remaining on the current page (default?: undefined = kept on one page).
+   * See [print_README.md](https://github.com/gridstack/gridstack.js/tree/master/print_README.md) */
+  breakInside?: boolean;
   /** application specific print options for a given widget */
   mode?: string;
 }


### PR DESCRIPTION
### Description
* allows tables and sections (nested grid with header) to have their content start right away when tall rather than separate with mostly empty page

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`yarn test`)
- [ ] Extended the README / documentation, if necessary
